### PR TITLE
fix(release): keep Cargo.lock synced for release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,20 @@ jobs:
         working-directory: src-tauri
         run: cargo update --workspace
 
+      - name: Verify Cargo.lock is committed
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- src-tauri/Cargo.lock; then
+            exit 0
+          fi
+
+          echo "src-tauri/Cargo.lock is out of date." >&2
+          echo "Run 'cd src-tauri && cargo update --workspace' and commit the result." >&2
+          git diff -- src-tauri/Cargo.lock
+          exit 1
+
       - name: Rust clippy
         working-directory: src-tauri
         run: cargo clippy --all-targets --locked -- -D warnings

--- a/.github/workflows/release-pr-sync-cargo-lock.yml
+++ b/.github/workflows/release-pr-sync-cargo-lock.yml
@@ -1,0 +1,49 @@
+name: sync-release-pr-cargo-lock
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-pr-cargo-lock-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-cargo-lock:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Install Rust 1.90.0
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.90.0
+
+      - name: Sync Cargo.lock
+        working-directory: src-tauri
+        run: cargo update --workspace
+
+      - name: Commit updated Cargo.lock
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- src-tauri/Cargo.lock; then
+            echo "Cargo.lock already in sync."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src-tauri/Cargo.lock
+          git commit -m "chore(release): sync Cargo.lock"
+          git push origin "HEAD:${GITHUB_HEAD_REF}"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aio-coding-hub"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "axum",
  "base64 0.22.1",


### PR DESCRIPTION
## Summary
- sync the current Tauri lockfile with the 0.33.1 release version bump
- fail CI when Cargo.lock changes are generated but not committed
- auto-commit Cargo.lock updates back to release-please PR branches

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test:unit:coverage
- pnpm check:generated-bindings
- pnpm tauri:test
- pnpm tauri:clippy
- cargo check --locked
