### PR TITLE
fix(macOS): 修复macOS 在 CLI 管理页面读取不到工具 version 并提示 INTERNAL_ERROR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,6 @@ coverage/
 .serena/
 src/templates/
 .codex/
-src-tauri/target*/
+
+# Rust build artifacts
+src-tauri/target*

--- a/src-tauri/src/infra/cli_manager.rs
+++ b/src-tauri/src/infra/cli_manager.rs
@@ -290,6 +290,23 @@ fn find_exe_in_dir(dir: &Path, names: &[String]) -> Option<PathBuf> {
     None
 }
 
+/// Platform-specific system directories that GUI-launched processes may lack in PATH.
+///
+/// On macOS / Linux, apps launched from Dock / .desktop inherit a minimal PATH
+/// (typically `/usr/bin:/bin`). This list ensures we also search Homebrew, system,
+/// and common package-manager locations.
+#[cfg(not(windows))]
+fn platform_extra_path_dirs() -> &'static [&'static str] {
+    #[cfg(target_os = "macos")]
+    {
+        &["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"]
+    }
+    #[cfg(target_os = "linux")]
+    {
+        &["/usr/local/bin", "/usr/bin", "/bin"]
+    }
+}
+
 fn find_exe_in_path(names: &[String]) -> Option<PathBuf> {
     let path = std::env::var_os("PATH")?;
     let raw = path.to_string_lossy().to_string();
@@ -324,18 +341,9 @@ fn scan_executable(
         home.join(".cargo").join("bin"),
     ];
 
-    #[cfg(target_os = "macos")]
-    {
-        candidates.push(PathBuf::from("/opt/homebrew/bin"));
-        candidates.push(PathBuf::from("/usr/local/bin"));
-        candidates.push(PathBuf::from("/usr/bin"));
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        candidates.push(PathBuf::from("/usr/local/bin"));
-        candidates.push(PathBuf::from("/usr/bin"));
-        candidates.push(PathBuf::from("/bin"));
+    #[cfg(not(windows))]
+    for dir in platform_extra_path_dirs() {
+        candidates.push(PathBuf::from(dir));
     }
 
     #[cfg(windows)]
@@ -459,14 +467,15 @@ fn run_version(exe: &Path) -> crate::shared::error::AppResult<String> {
     let mut cmd = Command::new(exe);
     cmd.arg("--version");
 
-    #[cfg(target_os = "macos")]
+    // GUI-launched processes on macOS/Linux inherit a minimal PATH that often
+    // lacks Homebrew / nvm / system dirs. Prepend the standard locations so that
+    // shebang-based CLIs (#!/usr/bin/env node) can resolve their runtime.
+    #[cfg(not(windows))]
     {
+        let extra = platform_extra_path_dirs().join(":");
         cmd.env(
             "PATH",
-            format!(
-                "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:{}",
-                std::env::var("PATH").unwrap_or_default()
-            ),
+            format!("{}:{}", extra, std::env::var("PATH").unwrap_or_default()),
         );
     }
 


### PR DESCRIPTION
**解决问题**
- macOS在CLI管理页面读取不到工具的verison并提示检测失败：INTERNAL_ERROR: env: node: No such file or directory的问题

**验证效果**
修复前：
<img width="2456" height="6242" alt="image" src="https://github.com/user-attachments/assets/9517cd8a-2552-4cbd-9c02-48b57206bb80" />
修复后：
<img width="2452" height="6110" alt="image" src="https://github.com/user-attachments/assets/93ab0296-3725-42ef-8d32-9b2ad8e82300" />
 
