### PR TITLE
feat: add Claude OAuth support with multi-account switching

### DIFF
--- a/src-tauri/src/commands/providers.rs
+++ b/src-tauri/src/commands/providers.rs
@@ -725,6 +725,7 @@ pub(crate) async fn provider_oauth_start_flow(
             code,
             redirect_uri,
             code_verifier: pkce.code_verifier,
+            state: Some(oauth_state),
         },
     )
     .await

--- a/src-tauri/src/gateway/oauth/adapters/claude.rs
+++ b/src-tauri/src/gateway/oauth/adapters/claude.rs
@@ -11,13 +11,25 @@ pub(crate) struct ClaudeOAuthProvider {
 
 impl ClaudeOAuthProvider {
     pub(crate) fn new() -> Self {
+        // Support custom OAuth client via env vars
+        let client_id = std::env::var("AIO_CLAUDE_OAUTH_CLIENT_ID")
+            .unwrap_or_else(|_| "9d1c250a-e61b-44d9-88ed-5944d1962f5e".to_string());
+        let client_secret = std::env::var("AIO_CLAUDE_OAUTH_CLIENT_SECRET").ok();
+
         Self {
             endpoints: OAuthEndpoints {
-                auth_url: "https://claude.ai/oauth/authorize",
-                token_url: "https://api.anthropic.com/v1/oauth/token",
-                client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e".to_string(),
-                client_secret: None,
-                scopes: vec!["org:create_api_key", "user:profile", "user:inference"],
+                auth_url: "https://platform.claude.com/oauth/authorize",
+                token_url: "https://platform.claude.com/v1/oauth/token",
+                client_id,
+                client_secret,
+                scopes: vec![
+                    "org:create_api_key",
+                    "user:profile",
+                    "user:inference",
+                    "user:sessions:claude_code",
+                    "user:mcp_servers",
+                    "user:file_upload",
+                ],
                 redirect_host: "localhost",
                 callback_path: "/callback",
                 default_callback_port: 54545,
@@ -52,23 +64,65 @@ impl OAuthProvider for ClaudeOAuthProvider {
         headers: &mut HeaderMap,
         access_token: &str,
     ) -> Result<(), String> {
+        // OAuth uses Bearer auth only — do NOT set x-api-key (that's for API key auth)
         insert_bearer_auth(headers, access_token, "claude oauth")?;
 
-        let key_val = HeaderValue::from_str(access_token)
-            .map_err(|e| format!("claude oauth: invalid access_token for x-api-key header: {e}"))?;
-        headers.insert("x-api-key", key_val);
+        headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
 
-        if !headers.contains_key("anthropic-version") {
-            headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
+        // Ensure oauth-2025-04-20 is always present in anthropic-beta.
+        // Merge with any existing beta flags from the client request.
+        let existing_beta = headers
+            .get("anthropic-beta")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+
+        let required_flags = [
+            "claude-code-20250219",
+            "oauth-2025-04-20",
+            "interleaved-thinking-2025-05-14",
+            "context-management-2025-06-27",
+            "prompt-caching-scope-2026-01-05",
+        ];
+
+        let mut flags: Vec<&str> = if existing_beta.is_empty() {
+            Vec::new()
+        } else {
+            existing_beta.split(',').map(|s| s.trim()).collect()
+        };
+
+        for flag in &required_flags {
+            if !flags.iter().any(|f| f == flag) {
+                flags.push(flag);
+            }
         }
-        if !headers.contains_key("anthropic-beta") {
-            headers.insert(
-                "anthropic-beta",
-                HeaderValue::from_static(
-                    "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05",
-                ),
-            );
-        }
+
+        let merged = flags.join(",");
+        headers.insert(
+            "anthropic-beta",
+            HeaderValue::from_str(&merged)
+                .unwrap_or_else(|_| HeaderValue::from_static("oauth-2025-04-20")),
+        );
+
+        // Mimic Claude Code CLI User-Agent and stainless headers
+        headers.insert("user-agent", HeaderValue::from_static("claude-code/2.1.45"));
+
+        // Use actual OS instead of hardcoded Windows
+        let os = if cfg!(target_os = "windows") {
+            "Windows"
+        } else if cfg!(target_os = "macos") {
+            "macOS"
+        } else {
+            "Linux"
+        };
+        headers.insert("x-stainless-os", HeaderValue::from_static(os));
+        headers.insert("x-stainless-runtime", HeaderValue::from_static("node"));
+        headers.insert("x-stainless-arch", HeaderValue::from_static("x64"));
+        headers.insert("x-stainless-lang", HeaderValue::from_static("js"));
+        headers.insert(
+            "x-stainless-package-version",
+            HeaderValue::from_static("0.52.0"),
+        );
         Ok(())
     }
 

--- a/src-tauri/src/gateway/oauth/token_exchange.rs
+++ b/src-tauri/src/gateway/oauth/token_exchange.rs
@@ -12,6 +12,7 @@ pub(crate) struct TokenExchangeRequest {
     pub code: String,
     pub redirect_uri: String,
     pub code_verifier: String,
+    pub state: Option<String>,
 }
 
 #[derive(Debug)]
@@ -26,66 +27,151 @@ pub(crate) async fn exchange_authorization_code(
     client: &reqwest::Client,
     req: &TokenExchangeRequest,
 ) -> Result<OAuthTokenSet, String> {
-    let mut form = vec![
-        ("grant_type", "authorization_code"),
-        ("code", &req.code),
-        ("redirect_uri", &req.redirect_uri),
-        ("client_id", &req.client_id),
-        ("code_verifier", &req.code_verifier),
-    ];
-
-    let secret_ref;
-    if let Some(ref secret) = req.client_secret {
-        secret_ref = secret.clone();
-        form.push(("client_secret", &secret_ref));
-    }
-
     tracing::info!(
         token_uri = %req.token_uri,
         client_id = %req.client_id,
+        redirect_uri = %req.redirect_uri,
+        code_len = req.code.len(),
+        code_verifier_len = req.code_verifier.len(),
         "exchanging authorization code for tokens"
     );
 
-    let resp = client
-        .post(&req.token_uri)
-        .form(&form)
-        .send()
-        .await
-        .map_err(|e| format!("token exchange request failed: {e}"))?;
+    // Anthropic requires JSON body, others use form-encoded
+    let is_anthropic = is_anthropic_oauth_token_uri(&req.token_uri);
+
+    let resp = if is_anthropic {
+        let missing_state = req
+            .state
+            .as_ref()
+            .map(|state| state.trim().is_empty())
+            .unwrap_or(true);
+        if missing_state {
+            return Err(
+                "SEC_INVALID_INPUT: Anthropic token exchange requires non-empty OAuth state"
+                    .to_string(),
+            );
+        }
+
+        let body = build_anthropic_exchange_json(req);
+
+        client
+            .post(&req.token_uri)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("token exchange request failed: {e}"))?
+    } else {
+        let mut form = vec![
+            ("grant_type", "authorization_code"),
+            ("code", &req.code),
+            ("redirect_uri", &req.redirect_uri),
+            ("client_id", &req.client_id),
+            ("code_verifier", &req.code_verifier),
+        ];
+
+        let secret_ref;
+        if let Some(ref secret) = req.client_secret {
+            secret_ref = secret.clone();
+            form.push(("client_secret", &secret_ref));
+        }
+
+        client
+            .post(&req.token_uri)
+            .form(&form)
+            .send()
+            .await
+            .map_err(|e| format!("token exchange request failed: {e}"))?
+    };
 
     parse_token_response(resp).await
+}
+
+fn build_anthropic_exchange_json(req: &TokenExchangeRequest) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "grant_type": "authorization_code",
+        "code": req.code,
+        "redirect_uri": req.redirect_uri,
+        "client_id": req.client_id,
+        "code_verifier": req.code_verifier,
+    });
+
+    if let Some(ref state) = req.state {
+        body["state"] = serde_json::json!(state);
+    }
+
+    if let Some(ref secret) = req.client_secret {
+        body["client_secret"] = serde_json::json!(secret);
+    }
+
+    body
 }
 
 pub(crate) async fn refresh_access_token(
     client: &reqwest::Client,
     req: &TokenRefreshRequest,
 ) -> Result<OAuthTokenSet, String> {
-    let mut form = vec![
-        ("grant_type", "refresh_token"),
-        ("refresh_token", &req.refresh_token),
-        ("client_id", &req.client_id),
-    ];
-
-    let secret_ref;
-    if let Some(ref secret) = req.client_secret {
-        secret_ref = secret.clone();
-        form.push(("client_secret", &secret_ref));
-    }
-
     tracing::debug!(
         token_uri = %req.token_uri,
         refresh_token = %mask_token(&req.refresh_token),
         "refreshing access token"
     );
 
-    let resp = client
-        .post(&req.token_uri)
-        .form(&form)
-        .send()
-        .await
-        .map_err(|e| format!("token refresh request failed: {e}"))?;
+    // Anthropic requires JSON body, others use form-encoded
+    let is_anthropic = is_anthropic_oauth_token_uri(&req.token_uri);
+
+    let resp = if is_anthropic {
+        let body = build_anthropic_refresh_json(req);
+
+        client
+            .post(&req.token_uri)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("token refresh request failed: {e}"))?
+    } else {
+        let mut form = vec![
+            ("grant_type", "refresh_token"),
+            ("refresh_token", &req.refresh_token),
+            ("client_id", &req.client_id),
+        ];
+
+        let secret_ref;
+        if let Some(ref secret) = req.client_secret {
+            secret_ref = secret.clone();
+            form.push(("client_secret", &secret_ref));
+        }
+
+        client
+            .post(&req.token_uri)
+            .form(&form)
+            .send()
+            .await
+            .map_err(|e| format!("token refresh request failed: {e}"))?
+    };
 
     parse_token_response(resp).await
+}
+
+fn build_anthropic_refresh_json(req: &TokenRefreshRequest) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "grant_type": "refresh_token",
+        "refresh_token": req.refresh_token,
+        "client_id": req.client_id,
+    });
+
+    if let Some(ref secret) = req.client_secret {
+        body["client_secret"] = serde_json::json!(secret);
+    }
+
+    body
+}
+
+fn is_anthropic_oauth_token_uri(token_uri: &str) -> bool {
+    let uri = token_uri.trim().to_ascii_lowercase();
+    uri.contains("api.anthropic.com/v1/oauth/token")
+        || uri.contains("platform.claude.com/v1/oauth/token")
+        || (uri.contains("/v1/oauth/token")
+            && (uri.contains("anthropic.com") || uri.contains("claude.com")))
 }
 
 async fn parse_token_response(resp: reqwest::Response) -> Result<OAuthTokenSet, String> {
@@ -98,14 +184,31 @@ async fn parse_token_response(resp: reqwest::Response) -> Result<OAuthTokenSet, 
     if !status.is_success() {
         // Try to parse error details
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
-            let error = json
-                .get("error")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
-            let desc = json
-                .get("error_description")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+            // Anthropic uses nested error structure: {"type":"error","error":{"type":"...","message":"..."}}
+            let (error, desc) =
+                if let Some(error_obj) = json.get("error").and_then(|v| v.as_object()) {
+                    // Nested structure (Anthropic format)
+                    let error_type = error_obj
+                        .get("type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let error_msg = error_obj
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    (error_type, error_msg)
+                } else {
+                    // Flat structure (standard OAuth format)
+                    let error = json
+                        .get("error")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let desc = json
+                        .get("error_description")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    (error, desc)
+                };
 
             if error == "invalid_grant" && desc.contains("refresh_token") {
                 return Err(

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/mod.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/mod.rs
@@ -1082,14 +1082,39 @@ pub(super) async fn run(mut input: RequestContext) -> Response {
                 headers.remove(header::CONTENT_ENCODING);
             }
 
-            let send_result = send::send_upstream(
-                ctx,
-                method.clone(),
-                url,
-                headers,
-                upstream_body_bytes.clone(),
-            )
-            .await;
+            // Fix empty text blocks for Claude OAuth
+            let cleaned_body = if input.cli_key == "claude" && provider.auth_mode == "oauth" {
+                if let Ok(mut json) =
+                    serde_json::from_slice::<serde_json::Value>(&upstream_body_bytes)
+                {
+                    if let Some(messages) = json.get_mut("messages").and_then(|v| v.as_array_mut())
+                    {
+                        for msg in messages {
+                            if let Some(content) =
+                                msg.get_mut("content").and_then(|v| v.as_array_mut())
+                            {
+                                content.retain(|block| {
+                                    if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                                        !text.trim().is_empty()
+                                    } else {
+                                        true
+                                    }
+                                });
+                            }
+                        }
+                    }
+                    serde_json::to_vec(&json)
+                        .unwrap_or_else(|_| upstream_body_bytes.to_vec())
+                        .into()
+                } else {
+                    upstream_body_bytes.clone()
+                }
+            } else {
+                upstream_body_bytes.clone()
+            };
+
+            let send_result =
+                send::send_upstream(ctx, method.clone(), url, headers, cleaned_body).await;
 
             match send_result {
                 send::SendResult::Ok(resp) => {


### PR DESCRIPTION
为满足 Anthropic 合规要求，在 OAuth 令牌交换中添加 state 字段
支持 Anthropic 令牌端点使用 JSON 请求体格式
解析 Anthropic 的嵌套错误响应
为 OAuth 移除 x-api-key 请求头，仅使用 Bearer 认证
将 oauth-2025-04-20 合并到 anthropic-beta 标志中
添加 Claude Code CLI 指纹请求头（User-Agent、X-Stainless-*）
动态检测操作系统，用于设置 x-stainless-os 请求头
过滤 Claude OAuth 请求中的空文本块
支持通过环境变量 AIO_CLAUDE_OAUTH_CLIENT_ID / AIO_CLAUDE_OAUTH_CLIENT_SECRET 自定义 OAuth 客户端