### PR TITLE
fix(heartbeat_watchdog): reload 返回 Ok 但实际异步失败时升级到窗口重建

### DIFF
--- a/src-tauri/src/app/heartbeat_watchdog.rs
+++ b/src-tauri/src/app/heartbeat_watchdog.rs
@@ -33,7 +33,6 @@ const RECOVERY_BACKOFF_BASE: Duration = Duration::from_secs(30);
 const RECOVERY_BACKOFF_MAX: Duration = Duration::from_secs(5 * 60);
 
 const RECOVERY_CIRCUIT_THRESHOLD: u32 = 5;
-const RECOVERY_CIRCUIT_DURATION: Duration = Duration::from_secs(10 * 60);
 
 /// Maximum number of window rebuild attempts within `REBUILD_COOLDOWN` before
 /// escalating to a full app restart.
@@ -215,17 +214,6 @@ impl HeartbeatWatchdogState {
         delay
     }
 
-    fn trip_circuit(&self, now_unix_ms: u64) {
-        let until = now_unix_ms.saturating_add(RECOVERY_CIRCUIT_DURATION.as_millis() as u64);
-        let mut inner = self
-            .inner
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        inner.circuit_open_until_unix_ms = until;
-        inner.recovery_streak = 0;
-        inner.next_recovery_allowed_unix_ms = until;
-    }
-
     fn bump_recovery_streak(&self) -> u32 {
         let mut inner = self
             .inner
@@ -363,12 +351,18 @@ async fn check_and_recover_if_needed(app: &tauri::AppHandle) {
     let streak = state.bump_recovery_streak();
 
     if should_trip_circuit(streak) {
-        state.trip_circuit(now);
+        // Page-level reload has been attempted RECOVERY_CIRCUIT_THRESHOLD times
+        // without receiving a pong. This strongly suggests the WebView is in an
+        // unrecoverable state (e.g. reload() returns Ok but the operation fails
+        // asynchronously in the wry event loop with HRESULT 0x8007139F).
+        // Escalate to window rebuild instead of waiting passively.
         tracing::warn!(
             streak,
-            open_for_s = RECOVERY_CIRCUIT_DURATION.as_secs(),
-            "blank screen recovery circuit tripped, pausing auto-recovery"
+            "page reload exhausted without pong, escalating to window rebuild"
         );
+        state.mark_webview_broken();
+        state.set_webview_alive(false);
+        attempt_escalated_recovery(app).await;
         return;
     }
 


### PR DESCRIPTION
## Summary

- `window.reload()` 在 WebView2 invalid state 下返回 `Ok`（fire-and-forget），但实际 reload 在 wry 事件循环中异步失败（`HRESULT 0x8007139F`）
- 原逻辑在 `attempt_reload` Ok 路径不会触发错误分类，熔断器只是被动等待 10 分钟
- 改为：当 5 次 reload 都没收到 pong 触发熔断时，直接标记 `webview_broken` 并升级到窗口重建
- 移除不再使用的 `trip_circuit` / `RECOVERY_CIRCUIT_DURATION`

## Context

这是 #156 的追加修复。#156 合并后在实际运行中观察到：WebView2 的 `0x8007139F` 错误导致 `reload()` 返回 Ok 但异步失败，错误分类逻辑永远不会被触发。

## Test plan

- [x] 8 个 heartbeat_watchdog 单元测试全部通过
- [x] `cargo clippy` 0 error
- [x] 实际复现场景中确认：连续 reload 无 pong 后升级到窗口重建路径