### PR TITLE
fix(update): restore changelog and local preview flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,6 +410,26 @@ jobs:
           merge-multiple: true
           path: stable-assets
 
+      - name: Fetch release body
+        id: release_body
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          script: |
+            const releaseId = Number('${{ needs.release-please.outputs.release_id }}');
+            if (!Number.isFinite(releaseId) || releaseId <= 0) {
+              core.setFailed(`Invalid release_id: ${releaseId}`);
+              return;
+            }
+
+            const { data: release } = await github.rest.repos.getRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: releaseId,
+            });
+
+            core.setOutput('body', release.body || '');
+
       - name: Generate latest.json
         shell: bash
         run: |
@@ -427,7 +447,6 @@ jobs:
           fi
 
           pub_date="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          notes="See release: https://github.com/${repo}/releases/tag/${tag}"
 
           win_asset="aio-coding-hub-win64.msi"
           win_sig_file="stable-assets/aio-coding-hub-win64.msi.sig"
@@ -456,33 +475,64 @@ jobs:
           mac_arm_url="https://github.com/${repo}/releases/download/${tag}/${mac_arm_asset}"
           linux_url="https://github.com/${repo}/releases/download/${tag}/${linux_asset}"
 
-          cat > latest.json <<EOF
-          {
-            "version": "${version}",
-            "notes": "${notes}",
-            "pub_date": "${pub_date}",
-            "platforms": {
-              "windows-x86_64": {
-                "signature": "${win_sig}",
-                "url": "${win_url}"
-              },
-              "darwin-x86_64": {
-                "signature": "${mac_intel_sig}",
-                "url": "${mac_intel_url}"
-              },
-              "darwin-aarch64": {
-                "signature": "${mac_arm_sig}",
-                "url": "${mac_arm_url}"
-              },
-              "linux-x86_64": {
-                "signature": "${linux_sig}",
-                "url": "${linux_url}"
-              }
-            }
-          }
-          EOF
+          export VERSION="$version"
+          export PUB_DATE="$pub_date"
+          export WIN_SIG="$win_sig"
+          export WIN_URL="$win_url"
+          export MAC_INTEL_SIG="$mac_intel_sig"
+          export MAC_INTEL_URL="$mac_intel_url"
+          export MAC_ARM_SIG="$mac_arm_sig"
+          export MAC_ARM_URL="$mac_arm_url"
+          export LINUX_SIG="$linux_sig"
+          export LINUX_URL="$linux_url"
 
-          node -e "JSON.parse(require('fs').readFileSync('latest.json','utf8')); console.log('latest.json OK');"
+          node <<'NODE'
+          const fs = require('fs');
+
+          const version = process.env.VERSION;
+          const pubDate = process.env.PUB_DATE;
+          const releaseBody = process.env.RELEASE_BODY;
+          const fallbackNotes = process.env.FALLBACK_NOTES;
+          const winSig = process.env.WIN_SIG;
+          const winUrl = process.env.WIN_URL;
+          const macIntelSig = process.env.MAC_INTEL_SIG;
+          const macIntelUrl = process.env.MAC_INTEL_URL;
+          const macArmSig = process.env.MAC_ARM_SIG;
+          const macArmUrl = process.env.MAC_ARM_URL;
+          const linuxSig = process.env.LINUX_SIG;
+          const linuxUrl = process.env.LINUX_URL;
+
+          const latestJson = {
+            version,
+            notes: releaseBody || fallbackNotes,
+            pub_date: pubDate,
+            platforms: {
+              'windows-x86_64': {
+                signature: winSig,
+                url: winUrl,
+              },
+              'darwin-x86_64': {
+                signature: macIntelSig,
+                url: macIntelUrl,
+              },
+              'darwin-aarch64': {
+                signature: macArmSig,
+                url: macArmUrl,
+              },
+              'linux-x86_64': {
+                signature: linuxSig,
+                url: linuxUrl,
+              },
+            },
+          };
+
+          fs.writeFileSync('latest.json', JSON.stringify(latestJson, null, 2));
+          JSON.parse(fs.readFileSync('latest.json', 'utf8'));
+          console.log('latest.json OK');
+          NODE
+        env:
+          RELEASE_BODY: ${{ steps.release_body.outputs.body }}
+          FALLBACK_NOTES: "See release: https://github.com/${{ github.repository }}/releases/tag/${{ needs.release-please.outputs.tag_name }}"
 
       - name: Delete existing latest.json (best-effort)
         uses: actions/github-script@v7

--- a/src/hooks/__tests__/useUpdateMeta.test.tsx
+++ b/src/hooks/__tests__/useUpdateMeta.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { tauriInvoke } from "../../test/mocks/tauri";
 import { clearTauriRuntime, setTauriRuntime } from "../../test/utils/tauriRuntime";
@@ -13,6 +13,46 @@ vi.mock("sonner", () => ({
 vi.mock("../../services/consoleLog", () => ({ logToConsole: vi.fn() }));
 
 describe("hooks/useUpdateMeta", () => {
+  beforeEach(() => {
+    localStorage.removeItem("devPreview.enabled");
+  });
+
+  it("uses the shared dev preview toggle to return a mock update and block install", async () => {
+    vi.resetModules();
+    clearTauriRuntime();
+    localStorage.setItem("devPreview.enabled", "1");
+
+    const { queryClient } = await import("../../query/queryClient");
+    queryClient.clear();
+
+    const mod = await import("../useUpdateMeta");
+    const { updateCheckNow, updateDownloadAndInstall, updateDialogSetOpen, useUpdateMeta } = mod;
+
+    const update = await updateCheckNow({ silent: true, openDialogIfUpdate: true });
+    expect(update?.rid).toBe(9_999_001);
+    expect(update?.body).toContain("Dev 预览更新日志");
+
+    const wrapper = ({ children }: any) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useUpdateMeta(), { wrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.dialogOpen).toBe(true);
+    expect(result.current.updateCandidate?.rid).toBe(9_999_001);
+    expect(result.current.updateCandidate?.body).toContain("不会参与真实安装");
+
+    queryClient.setQueryData(updaterKeys.check(), update);
+    updateDialogSetOpen(true);
+    await expect(updateDownloadAndInstall()).resolves.toBe(false);
+    expect(toast).toHaveBeenCalledWith("Dev 预览更新仅用于展示，不能安装");
+
+    localStorage.removeItem("devPreview.enabled");
+  });
+
   it("covers update check, dialog state, and download/install flows", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-01T00:00:00Z"));

--- a/src/hooks/useDevPreviewData.ts
+++ b/src/hooks/useDevPreviewData.ts
@@ -1,0 +1,66 @@
+import { useMemo, useSyncExternalStore } from "react";
+
+const STORAGE_KEY_DEV_PREVIEW_ENABLED = "devPreview.enabled";
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+function canUseDevPreview() {
+  return import.meta.env.DEV;
+}
+
+function readDevPreviewEnabled() {
+  if (!canUseDevPreview()) return false;
+
+  try {
+    return localStorage.getItem(STORAGE_KEY_DEV_PREVIEW_ENABLED) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeDevPreviewEnabled(enabled: boolean) {
+  if (!canUseDevPreview()) return;
+
+  try {
+    localStorage.setItem(STORAGE_KEY_DEV_PREVIEW_ENABLED, enabled ? "1" : "0");
+  } catch {}
+}
+
+export function getDevPreviewEnabled() {
+  return readDevPreviewEnabled();
+}
+
+export function setDevPreviewEnabled(enabled: boolean) {
+  writeDevPreviewEnabled(enabled);
+  emit();
+}
+
+export function toggleDevPreviewEnabled() {
+  setDevPreviewEnabled(!readDevPreviewEnabled());
+}
+
+export function useDevPreviewData() {
+  const enabled = useSyncExternalStore(
+    (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    readDevPreviewEnabled,
+    () => false
+  );
+
+  return useMemo(
+    () => ({
+      enabled,
+      setEnabled: setDevPreviewEnabled,
+      toggle: toggleDevPreviewEnabled,
+    }),
+    [enabled]
+  );
+}

--- a/src/hooks/useUpdateMeta.ts
+++ b/src/hooks/useUpdateMeta.ts
@@ -4,6 +4,7 @@ import { queryClient } from "../query/queryClient";
 import { updaterKeys } from "../query/keys";
 import { useAppAboutQuery } from "../query/appAbout";
 import { useUpdaterCheckQuery } from "../query/updater";
+import { getDevPreviewEnabled, useDevPreviewData } from "./useDevPreviewData";
 import { logToConsole } from "../services/consoleLog";
 import {
   updaterCheck,
@@ -14,6 +15,7 @@ import {
 import type { AppAboutInfo } from "../services/appAbout";
 
 const STORAGE_KEY_LAST_CHECKED_AT_MS = "updater.lastCheckedAtMs";
+const DEV_PREVIEW_UPDATE_RID = 9_999_001;
 
 export type UpdateMeta = {
   about: AppAboutInfo | null;
@@ -53,6 +55,26 @@ let starting: Promise<void> | null = null;
 let checkingPromise: Promise<UpdaterCheckUpdate | null> | null = null;
 let installingPromise: Promise<boolean | null> | null = null;
 
+function buildDevPreviewUpdateCandidate(currentVersion?: string): UpdaterCheckUpdate {
+  return {
+    rid: DEV_PREVIEW_UPDATE_RID,
+    version: "0.37.1-dev-preview",
+    currentVersion,
+    date: "2026-04-05T11:12:44Z",
+    body: [
+      "## Dev 预览更新日志",
+      "",
+      "- 更新弹窗现在会展示 release 正文，而不只是 GitHub 链接。",
+      "- 更新日志内容支持多行文本和长内容滚动。",
+      "- 这是一条仅开发环境可见的预览数据，不会参与真实安装。",
+    ].join("\n"),
+  };
+}
+
+function isDevPreviewUpdateCandidate(value: UpdaterCheckUpdate | null) {
+  return value?.rid === DEV_PREVIEW_UPDATE_RID;
+}
+
 function emit() {
   for (const listener of listeners) listener();
 }
@@ -90,11 +112,17 @@ export async function updateCheckNow(options: {
 
   checkingPromise = (async () => {
     try {
-      const update = await queryClient.fetchQuery({
-        queryKey: updaterKeys.check(),
-        queryFn: () => updaterCheck(),
-        staleTime: 0,
-      });
+      const update = getDevPreviewEnabled()
+        ? buildDevPreviewUpdateCandidate()
+        : await queryClient.fetchQuery({
+            queryKey: updaterKeys.check(),
+            queryFn: () => updaterCheck(),
+            staleTime: 0,
+          });
+
+      if (isDevPreviewUpdateCandidate(update)) {
+        queryClient.setQueryData(updaterKeys.check(), update);
+      }
 
       writeLastCheckedAtMs(Date.now());
 
@@ -147,6 +175,10 @@ export async function updateDownloadAndInstall(): Promise<boolean | null> {
   const updateCandidate =
     queryClient.getQueryData<UpdaterCheckUpdate | null>(updaterKeys.check()) ?? null;
   if (!updateCandidate) return null;
+  if (isDevPreviewUpdateCandidate(updateCandidate)) {
+    toast("Dev 预览更新仅用于展示，不能安装");
+    return false;
+  }
 
   if (uiSnapshot.installingUpdate) return installingPromise ?? true;
 
@@ -196,6 +228,7 @@ export function updateDialogSetOpen(open: boolean) {
 export function useUpdateMeta(): UpdateMeta {
   const aboutQuery = useAppAboutQuery();
   const updaterCheckQuery = useUpdaterCheckQuery();
+  const devPreview = useDevPreviewData();
 
   const ui = useSyncExternalStore(
     (listener) => {
@@ -207,10 +240,17 @@ export function useUpdateMeta(): UpdateMeta {
     () => uiSnapshot
   );
 
-  return useMemo(
-    () => ({
+  return useMemo(() => {
+    const cachedCandidate = updaterCheckQuery.data ?? null;
+    const updateCandidate = devPreview.enabled
+      ? buildDevPreviewUpdateCandidate(aboutQuery.data?.app_version)
+      : isDevPreviewUpdateCandidate(cachedCandidate)
+        ? null
+        : cachedCandidate;
+
+    return {
       about: aboutQuery.data ?? null,
-      updateCandidate: updaterCheckQuery.data ?? null,
+      updateCandidate,
       checkingUpdate: updaterCheckQuery.isFetching,
       dialogOpen: ui.dialogOpen,
 
@@ -218,16 +258,16 @@ export function useUpdateMeta(): UpdateMeta {
       installError: ui.installError,
       installTotalBytes: ui.installTotalBytes,
       installDownloadedBytes: ui.installDownloadedBytes,
-    }),
-    [
-      aboutQuery.data,
-      ui.dialogOpen,
-      ui.installDownloadedBytes,
-      ui.installError,
-      ui.installTotalBytes,
-      ui.installingUpdate,
-      updaterCheckQuery.data,
-      updaterCheckQuery.isFetching,
-    ]
-  );
+    };
+  }, [
+    aboutQuery.data,
+    devPreview.enabled,
+    ui.dialogOpen,
+    ui.installDownloadedBytes,
+    ui.installError,
+    ui.installTotalBytes,
+    ui.installingUpdate,
+    updaterCheckQuery.data,
+    updaterCheckQuery.isFetching,
+  ]);
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import { toast } from "sonner";
 import { CLIS } from "../constants/clis";
 import { HomeOverviewPanel } from "../components/home/HomeOverviewPanel";
+import { useDevPreviewData } from "../hooks/useDevPreviewData";
 import { useDocumentVisibility } from "../hooks/useDocumentVisibility";
 import { useWindowForeground } from "../hooks/useWindowForeground";
 import { useGatewaySessionsListQuery } from "../query/gateway";
@@ -58,11 +59,11 @@ export function HomePage() {
   const homeUsagePeriod = settingsQuery.data?.home_usage_period ?? DEFAULT_HOME_USAGE_PERIOD;
   const homeUsageWindowDays = resolveHomeUsageWindowDays(homeUsagePeriod);
   const isDevMode = import.meta.env.DEV;
+  const devPreview = useDevPreviewData();
 
   const [tab, setTab] = useState<HomeTabKey>("overview");
   const tabRef = useRef(tab);
   const [selectedLogId, setSelectedLogId] = useState<number | null>(null);
-  const [devPreviewEnabled, setDevPreviewEnabled] = useState(false);
 
   // --- Delegated state hooks ---
   const circuit = useHomeCircuitState();
@@ -178,11 +179,11 @@ export function HomePage() {
             <>
               {isDevMode ? (
                 <Button
-                  variant={devPreviewEnabled ? "primary" : "secondary"}
+                  variant={devPreview.enabled ? "primary" : "secondary"}
                   size="md"
-                  onClick={() => setDevPreviewEnabled((prev) => !prev)}
+                  onClick={() => devPreview.toggle()}
                 >
-                  {devPreviewEnabled ? "Dev关闭预览数据" : "Dev开启预览数据"}
+                  {devPreview.enabled ? "Dev关闭预览数据" : "Dev开启预览数据"}
                 </Button>
               ) : null}
               <TabList ariaLabel="首页视图切换" items={HOME_TABS} value={tab} onChange={setTab} />
@@ -195,7 +196,7 @@ export function HomePage() {
         {tab === "overview" ? (
           <HomeOverviewPanel
             showCustomTooltip={showCustomTooltip}
-            devPreviewEnabled={devPreviewEnabled}
+            devPreviewEnabled={devPreview.enabled}
             showHomeHeatmap={showHomeHeatmap}
             showHomeUsage={showHomeUsage}
             cliPriorityOrder={settingsQuery.data?.cli_priority_order}

--- a/src/pages/__tests__/HomePage.test.tsx
+++ b/src/pages/__tests__/HomePage.test.tsx
@@ -270,6 +270,7 @@ function mockHomePageBaseQueries() {
 
 describe("pages/HomePage", () => {
   beforeEach(() => {
+    localStorage.removeItem("devPreview.enabled");
     resetMswState();
     vi.mocked(useProviderLimitUsageV1Query).mockReturnValue({
       data: null,

--- a/src/pages/settings/SettingsSidebar.tsx
+++ b/src/pages/settings/SettingsSidebar.tsx
@@ -6,6 +6,7 @@ import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { toast } from "sonner";
 import type { UpdateMeta } from "../../hooks/useUpdateMeta";
 import { AIO_RELEASES_URL } from "../../constants/urls";
+import { useDevPreviewData } from "../../hooks/useDevPreviewData";
 import { runBackgroundTask } from "../../services/backgroundTasks";
 import { logToConsole } from "../../services/consoleLog";
 import {
@@ -76,6 +77,7 @@ function isConfigBundleShape(value: unknown): value is ConfigBundle {
 
 export function SettingsSidebar({ updateMeta }: SettingsSidebarProps) {
   const about = updateMeta.about;
+  const devPreview = useDevPreviewData();
 
   const queryClient = useQueryClient();
 
@@ -145,7 +147,7 @@ export function SettingsSidebar({ updateMeta }: SettingsSidebarProps) {
         return;
       }
 
-      if (about.run_mode === "portable") {
+      if (about.run_mode === "portable" && !devPreview.enabled) {
         toast("portable 模式请手动下载");
         await openUpdateLog();
         return;

--- a/src/pages/settings/__tests__/SettingsSidebar.test.tsx
+++ b/src/pages/settings/__tests__/SettingsSidebar.test.tsx
@@ -24,8 +24,15 @@ import {
 import { notifyModelPricesUpdated } from "../../../services/modelPrices";
 import { modelPricesKeys } from "../../../query/keys";
 
+const devPreviewRef = vi.hoisted(() => ({
+  current: { enabled: false, setEnabled: vi.fn(), toggle: vi.fn() } as any,
+}));
+
 vi.mock("sonner", () => ({ toast: vi.fn() }));
 vi.mock("../../../services/consoleLog", () => ({ logToConsole: vi.fn() }));
+vi.mock("../../../hooks/useDevPreviewData", () => ({
+  useDevPreviewData: () => devPreviewRef.current,
+}));
 vi.mock("../../../services/backgroundTasks", async () => {
   const actual = await vi.importActual<typeof import("../../../services/backgroundTasks")>(
     "../../../services/backgroundTasks"
@@ -221,6 +228,7 @@ function mockSidebarQueries() {
 describe("pages/settings/SettingsSidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    devPreviewRef.current = { enabled: false, setEnabled: vi.fn(), toggle: vi.fn() };
   });
 
   it("handles update checks (no about, portable, normal)", async () => {
@@ -267,6 +275,22 @@ describe("pages/settings/SettingsSidebar", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "check-update" }));
     expect(runBackgroundTask).toHaveBeenCalledWith("app-update-check", { trigger: "manual" });
+  });
+
+  it("runs local update preview even when about.run_mode is portable", async () => {
+    mockSidebarQueries();
+    devPreviewRef.current = { enabled: true, setEnabled: vi.fn(), toggle: vi.fn() };
+
+    renderWithProviders(
+      <SettingsSidebar updateMeta={createUpdateMeta({ about: { run_mode: "portable" } })} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "check-update" }));
+
+    await waitFor(() => {
+      expect(runBackgroundTask).toHaveBeenCalledWith("app-update-check", { trigger: "manual" });
+    });
+    expect(toast).not.toHaveBeenCalledWith("portable 模式请手动下载");
   });
 
   it("handles data management, model price sync, and subscription invalidation", async () => {

--- a/src/ui/MobileNav.tsx
+++ b/src/ui/MobileNav.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { NavLink } from "react-router-dom";
 import { AIO_REPO_URL } from "../constants/urls";
+import { useDevPreviewData } from "../hooks/useDevPreviewData";
 import { useGatewayStatus, openReleasesUrl } from "../hooks/useGatewayStatus";
 import { updateDialogSetOpen } from "../hooks/useUpdateMeta";
 import { cn } from "../utils/cn";
@@ -20,6 +21,7 @@ export type MobileNavProps = {
  */
 export function MobileNav({ isOpen, onClose }: MobileNavProps) {
   const { statusText, statusTone, portTone, portText, hasUpdate, isPortable } = useGatewayStatus();
+  const devPreview = useDevPreviewData();
 
   // Close on escape key
   useEffect(() => {
@@ -81,9 +83,13 @@ export function MobileNav({ isOpen, onClose }: MobileNavProps) {
                     "flex items-center gap-1 rounded-lg px-2 py-1 transition",
                     "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200 hover:bg-emerald-100 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-700 dark:hover:bg-emerald-900/50"
                   )}
-                  title={isPortable ? "发现新版本（打开下载页）" : "发现新版本（点击更新）"}
+                  title={
+                    isPortable && !devPreview.enabled
+                      ? "发现新版本（打开下载页）"
+                      : "发现新版本（点击更新）"
+                  }
                   onClick={() => {
-                    if (isPortable) {
+                    if (isPortable && !devPreview.enabled) {
                       openReleasesUrl().catch(() => {});
                       return;
                     }

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { AIO_REPO_URL } from "../constants/urls";
+import { useDevPreviewData } from "../hooks/useDevPreviewData";
 import { useGatewayStatus, openReleasesUrl } from "../hooks/useGatewayStatus";
 import { updateDialogSetOpen } from "../hooks/useUpdateMeta";
 import { cn } from "../utils/cn";
@@ -51,6 +52,7 @@ export type SidebarProps = {
 
 export function Sidebar({ isOpen = true, onNavClick, className }: SidebarProps) {
   const { statusText, statusTone, portTone, portText, hasUpdate, isPortable } = useGatewayStatus();
+  const devPreview = useDevPreviewData();
 
   function handleNavClick() {
     onNavClick?.();
@@ -99,9 +101,13 @@ export function Sidebar({ isOpen = true, onNavClick, className }: SidebarProps) 
                   "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200 hover:bg-emerald-100",
                   "dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-700 dark:hover:bg-emerald-900/50"
                 )}
-                title={isPortable ? "发现新版本（portable：打开下载页）" : "发现新版本（点击更新）"}
+                title={
+                  isPortable && !devPreview.enabled
+                    ? "发现新版本（portable：打开下载页）"
+                    : "发现新版本（点击更新）"
+                }
                 onClick={() => {
-                  if (isPortable) {
+                  if (isPortable && !devPreview.enabled) {
                     openReleasesUrl().catch(() => {});
                     return;
                   }

--- a/src/ui/__tests__/MobileNav.test.tsx
+++ b/src/ui/__tests__/MobileNav.test.tsx
@@ -22,6 +22,9 @@ const updateMetaRef = vi.hoisted(() => ({
 }));
 
 const updateDialogSetOpenMock = vi.hoisted(() => vi.fn());
+const devPreviewRef = vi.hoisted(() => ({
+  current: { enabled: false, setEnabled: vi.fn(), toggle: vi.fn() } as any,
+}));
 
 vi.mock("../../hooks/useGatewayMeta", () => ({
   useGatewayMeta: () => gatewayMetaRef.current,
@@ -31,6 +34,9 @@ vi.mock("../../hooks/useUpdateMeta", () => ({
   useUpdateMeta: () => updateMetaRef.current,
   updateDialogSetOpen: updateDialogSetOpenMock,
 }));
+vi.mock("../../hooks/useDevPreviewData", () => ({
+  useDevPreviewData: () => devPreviewRef.current,
+}));
 
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: vi.fn(),
@@ -39,6 +45,7 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 describe("ui/MobileNav", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    devPreviewRef.current = { enabled: false, setEnabled: vi.fn(), toggle: vi.fn() };
     gatewayMetaRef.current = { gatewayAvailable: "checking", gateway: null, preferredPort: 37123 };
     updateMetaRef.current = {
       about: null,
@@ -195,6 +202,31 @@ describe("ui/MobileNav", () => {
     // portable path does NOT call updateDialogSetOpen
     expect(updateDialogSetOpenMock).not.toHaveBeenCalled();
     windowOpen.mockRestore();
+  });
+
+  it("shows NEW button and opens dialog when portable dev preview is enabled", () => {
+    gatewayMetaRef.current = {
+      gatewayAvailable: "available",
+      gateway: { running: true, port: 37123 },
+      preferredPort: 37123,
+    };
+    updateMetaRef.current = {
+      ...updateMetaRef.current,
+      about: { run_mode: "portable" },
+      updateCandidate: { version: "0.0.0" },
+    };
+    devPreviewRef.current = { enabled: true, setEnabled: vi.fn(), toggle: vi.fn() };
+
+    const onClose = vi.fn();
+    render(
+      <MemoryRouter>
+        <MobileNav isOpen={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "NEW" }));
+    expect(updateDialogSetOpenMock).toHaveBeenCalledWith(true);
+    expect(onClose).toHaveBeenCalledOnce();
   });
 
   it("does not show NEW button when hasUpdate is false", () => {

--- a/src/ui/__tests__/Sidebar.test.tsx
+++ b/src/ui/__tests__/Sidebar.test.tsx
@@ -22,6 +22,9 @@ const updateMetaRef = vi.hoisted(() => ({
 }));
 
 const updateDialogSetOpenMock = vi.hoisted(() => vi.fn());
+const devPreviewRef = vi.hoisted(() => ({
+  current: { enabled: false, setEnabled: vi.fn(), toggle: vi.fn() } as any,
+}));
 
 vi.mock("../../hooks/useGatewayMeta", () => ({
   useGatewayMeta: () => gatewayMetaRef.current,
@@ -31,6 +34,9 @@ vi.mock("../../hooks/useUpdateMeta", () => ({
   useUpdateMeta: () => updateMetaRef.current,
   updateDialogSetOpen: updateDialogSetOpenMock,
 }));
+vi.mock("../../hooks/useDevPreviewData", () => ({
+  useDevPreviewData: () => devPreviewRef.current,
+}));
 
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: vi.fn(),
@@ -39,6 +45,7 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 describe("ui/Sidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    devPreviewRef.current = { enabled: false, setEnabled: vi.fn(), toggle: vi.fn() };
     gatewayMetaRef.current = { gatewayAvailable: "checking", gateway: null, preferredPort: 37123 };
     updateMetaRef.current = {
       about: null,
@@ -134,6 +141,29 @@ describe("ui/Sidebar", () => {
       expect(windowOpen).toHaveBeenCalledWith(AIO_RELEASES_URL, "_blank", "noopener,noreferrer");
     });
     windowOpen.mockRestore();
+  });
+
+  it("opens update dialog when portable app has dev preview enabled", () => {
+    gatewayMetaRef.current = {
+      gatewayAvailable: "available",
+      gateway: { running: true, port: 37123 },
+      preferredPort: 37123,
+    };
+    updateMetaRef.current = {
+      ...updateMetaRef.current,
+      about: { run_mode: "portable" },
+      updateCandidate: { version: "0.0.0" },
+    };
+    devPreviewRef.current = { enabled: true, setEnabled: vi.fn(), toggle: vi.fn() };
+
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "NEW" }));
+    expect(updateDialogSetOpenMock).toHaveBeenCalledWith(true);
   });
 
   it("calls onNavClick when a nav item is clicked", () => {


### PR DESCRIPTION
## Summary
- restore updater changelog generation so `latest.json.notes` uses the GitHub release body instead of a fixed release link
- add a shared dev preview toggle and mock update payload so update-dialog changelog rendering can be previewed locally
- allow local `tauri:dev` portable-mode flows to open the update dialog when dev preview is enabled

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/ui/__tests__/Sidebar.test.tsx src/ui/__tests__/MobileNav.test.tsx src/pages/settings/__tests__/SettingsSidebar.test.tsx src/hooks/__tests__/useUpdateMeta.test.tsx`
- [x] local manual preview: `pnpm dev` + `pnpm tauri:dev`, then Home -> `Dev开启预览数据` -> click `NEW` / `检查更新`
- [ ] GitHub release validation after merge: verify release asset `latest.json` contains release body in `notes`