### PR TITLE
feat: 支持 CX2CC 使用当前 AIO 服务 Codex 网关作为来源

### DIFF
--- a/src-tauri/src/commands/providers.rs
+++ b/src-tauri/src/commands/providers.rs
@@ -83,7 +83,8 @@ fn provider_runtime_reset_decision(
         || previous.base_url_mode != next.base_url_mode
         || previous.auth_mode != next.auth_mode
         || submitted_api_key_changed(previous_api_key, submitted_api_key)
-        || previous.source_provider_id != next.source_provider_id;
+        || previous.source_provider_id != next.source_provider_id
+        || previous.bridge_type != next.bridge_type;
 
     ProviderRuntimeResetDecision {
         clear_session_bindings: sensitive_config_changed,

--- a/src-tauri/src/domain/cost_stats.rs
+++ b/src-tauri/src/domain/cost_stats.rs
@@ -883,6 +883,18 @@ LIMIT ?6
                 1.0
             };
 
+            if multiplier == 0.0 {
+                let changed = stmt_update
+                    .execute(params![0_i64, id])
+                    .map_err(|e| db_err!("failed to update zero cost_usd_femto: {e}"))?;
+                if changed > 0 {
+                    report.updated = report.updated.saturating_add(1);
+                } else {
+                    report.skipped_other = report.skipped_other.saturating_add(1);
+                }
+                continue;
+            }
+
             let cost_usd_femto = cost::calculate_cost_usd_femto(
                 &usage,
                 &price_json,

--- a/src-tauri/src/domain/providers/queries.rs
+++ b/src-tauri/src/domain/providers/queries.rs
@@ -146,6 +146,7 @@ pub(crate) fn claude_terminal_launch_context(
         String,
         Option<String>,
         Option<i64>,
+        Option<String>,
     );
 
     if provider_id <= 0 {
@@ -163,7 +164,8 @@ SELECT
   api_key_plaintext,
   auth_mode,
   oauth_access_token,
-  source_provider_id
+  source_provider_id,
+  bridge_type
 FROM providers
 WHERE id = ?1
 "#,
@@ -177,6 +179,7 @@ WHERE id = ?1
                     row.get(4)?,
                     row.get(5)?,
                     row.get(6)?,
+                    row.get(7)?,
                 ))
             },
         )
@@ -191,6 +194,7 @@ WHERE id = ?1
         auth_mode,
         oauth_access_token,
         source_provider_id,
+        bridge_type,
     )) = row
     else {
         return Err("DB_NOT_FOUND: provider not found".to_string().into());
@@ -200,10 +204,12 @@ WHERE id = ?1
         return Err(format!("SEC_INVALID_INPUT: provider_id={provider_id} is not claude").into());
     }
 
-    // For OAuth mode or cx2cc providers (with source_provider_id), base_url may
-    // legitimately be empty (the gateway handles routing via source provider).
-    // For api_key mode without source_provider_id, base_url is still required.
-    if auth_mode != "oauth" && source_provider_id.is_none() {
+    let is_cx2cc = is_cx2cc_bridge(source_provider_id, bridge_type.as_deref());
+
+    // For OAuth mode or cx2cc providers, base_url may legitimately be empty
+    // (the gateway handles routing via source provider or local Codex gateway).
+    // For api_key mode without cx2cc, base_url is still required.
+    if auth_mode != "oauth" && !is_cx2cc {
         let base_url = base_urls_from_row(&base_url_fallback, &base_urls_json)
             .into_iter()
             .find(|v| !v.trim().is_empty())
@@ -227,7 +233,7 @@ WHERE id = ?1
                     .to_string()
             })?;
         token.to_string()
-    } else if source_provider_id.is_some() {
+    } else if is_cx2cc {
         let key = api_key_plaintext.trim().to_string();
         if key.is_empty() {
             format!("cx2cc-{provider_id}")
@@ -679,8 +685,12 @@ pub fn upsert(
 
     let requested_auth_mode = auth_mode.unwrap_or(ProviderAuthMode::ApiKey);
     let is_oauth = requested_auth_mode == ProviderAuthMode::Oauth;
-
-    let is_cx2cc = source_provider_id.is_some();
+    let is_cx2cc = is_cx2cc_bridge(source_provider_id, bridge_type.as_deref());
+    let bridge_type = if is_cx2cc {
+        Some(CX2CC_BRIDGE_TYPE.to_string())
+    } else {
+        None
+    };
 
     // Validate source_provider_id constraints for CX2CC bridging.
     if let Some(source_id) = source_provider_id {
@@ -733,6 +743,14 @@ pub fn upsert(
                 }
             }
         }
+    }
+
+    if is_cx2cc && cli_key != "claude" {
+        return Err(
+            "SEC_INVALID_INPUT: cx2cc bridge is only supported for claude"
+                .to_string()
+                .into(),
+        );
     }
 
     let base_urls = if is_oauth || is_cx2cc {

--- a/src-tauri/src/domain/providers/queries.rs
+++ b/src-tauri/src/domain/providers/queries.rs
@@ -688,10 +688,7 @@ pub fn upsert(
 
     if let Some(ref bt) = bridge_type {
         if bt != CX2CC_BRIDGE_TYPE {
-            return Err(
-                format!("SEC_INVALID_INPUT: unsupported bridge_type: {bt}")
-                    .into(),
-            );
+            return Err(format!("SEC_INVALID_INPUT: unsupported bridge_type: {bt}").into());
         }
     }
 

--- a/src-tauri/src/domain/providers/queries.rs
+++ b/src-tauri/src/domain/providers/queries.rs
@@ -685,6 +685,16 @@ pub fn upsert(
 
     let requested_auth_mode = auth_mode.unwrap_or(ProviderAuthMode::ApiKey);
     let is_oauth = requested_auth_mode == ProviderAuthMode::Oauth;
+
+    if let Some(ref bt) = bridge_type {
+        if bt != CX2CC_BRIDGE_TYPE {
+            return Err(
+                format!("SEC_INVALID_INPUT: unsupported bridge_type: {bt}")
+                    .into(),
+            );
+        }
+    }
+
     let is_cx2cc = is_cx2cc_bridge(source_provider_id, bridge_type.as_deref());
     let bridge_type = if is_cx2cc {
         Some(CX2CC_BRIDGE_TYPE.to_string())

--- a/src-tauri/src/domain/providers/types.rs
+++ b/src-tauri/src/domain/providers/types.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 
 pub(super) const DEFAULT_PRIORITY: i64 = 100;
 pub(super) const MAX_MODEL_NAME_LEN: usize = 200;
+pub(crate) const CX2CC_BRIDGE_TYPE: &str = "cx2cc";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, specta::Type, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -44,6 +45,10 @@ impl ProviderAuthMode {
             Self::Oauth => "oauth",
         }
     }
+}
+
+pub(crate) fn is_cx2cc_bridge(source_provider_id: Option<i64>, bridge_type: Option<&str>) -> bool {
+    source_provider_id.is_some() || bridge_type == Some(CX2CC_BRIDGE_TYPE)
 }
 
 #[derive(Debug, Clone)]
@@ -253,6 +258,10 @@ pub(crate) struct ClaudeTerminalLaunchContext {
 }
 
 impl ProviderForGateway {
+    pub(crate) fn is_cx2cc_bridge(&self) -> bool {
+        is_cx2cc_bridge(self.source_provider_id, self.bridge_type.as_deref())
+    }
+
     pub(crate) fn get_effective_claude_model(
         &self,
         requested_model: &str,

--- a/src-tauri/src/domain/usage_stats/tests.rs
+++ b/src-tauri/src/domain/usage_stats/tests.rs
@@ -11,7 +11,8 @@ fn setup_conn() -> Connection {
 	CREATE TABLE providers (
 	  id INTEGER PRIMARY KEY,
 	  name TEXT NOT NULL,
-	  source_provider_id INTEGER
+	  source_provider_id INTEGER,
+	  bridge_type TEXT
 	);
 
 	CREATE TABLE request_logs (

--- a/src-tauri/src/domain/usage_stats/tokens.rs
+++ b/src-tauri/src/domain/usage_stats/tokens.rs
@@ -5,11 +5,11 @@ pub(super) fn token_total(total: Option<i64>, input: Option<i64>, output: Option
     input.unwrap_or(0).saturating_add(output.unwrap_or(0))
 }
 
-pub(super) const SQL_EFFECTIVE_INPUT_TOKENS_EXPR: &str = "CASE WHEN cli_key IN ('codex','gemini') OR EXISTS (SELECT 1 FROM providers p WHERE p.id = final_provider_id AND p.source_provider_id IS NOT NULL) THEN MAX(COALESCE(input_tokens, 0) - COALESCE(cache_read_input_tokens, 0), 0) ELSE COALESCE(input_tokens, 0) END";
+pub(super) const SQL_EFFECTIVE_INPUT_TOKENS_EXPR: &str = "CASE WHEN cli_key IN ('codex','gemini') OR EXISTS (SELECT 1 FROM providers p WHERE p.id = final_provider_id AND (p.source_provider_id IS NOT NULL OR p.bridge_type = 'cx2cc')) THEN MAX(COALESCE(input_tokens, 0) - COALESCE(cache_read_input_tokens, 0), 0) ELSE COALESCE(input_tokens, 0) END";
 
 pub(super) fn sql_effective_input_tokens_expr_with_alias(alias: &str) -> String {
     format!(
-        "CASE WHEN {alias}.cli_key IN ('codex','gemini') OR EXISTS (SELECT 1 FROM providers p WHERE p.id = {alias}.final_provider_id AND p.source_provider_id IS NOT NULL) THEN MAX(COALESCE({alias}.input_tokens, 0) - COALESCE({alias}.cache_read_input_tokens, 0), 0) ELSE COALESCE({alias}.input_tokens, 0) END"
+        "CASE WHEN {alias}.cli_key IN ('codex','gemini') OR EXISTS (SELECT 1 FROM providers p WHERE p.id = {alias}.final_provider_id AND (p.source_provider_id IS NOT NULL OR p.bridge_type = 'cx2cc')) THEN MAX(COALESCE({alias}.input_tokens, 0) - COALESCE({alias}.cache_read_input_tokens, 0), 0) ELSE COALESCE({alias}.input_tokens, 0) END"
     )
 }
 

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/cx2cc_preparation.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/cx2cc_preparation.rs
@@ -6,7 +6,10 @@
 
 use super::provider_iterator::SkipReason;
 use super::*;
+use crate::app::app_state::GatewayState;
 use crate::gateway::proxy::protocol_bridge::{self, BridgeContext};
+use crate::shared::mutex_ext::MutexExt;
+use tauri::Manager;
 
 /// All CX2CC-related state produced by preparation.
 pub(super) struct Cx2ccResult {
@@ -28,7 +31,7 @@ pub(super) struct Cx2ccPreparationInput<'a> {
     pub(super) input: &'a RequestContext,
     pub(super) provider_id: i64,
     pub(super) provider_name_base: &'a str,
-    pub(super) source_id: i64,
+    pub(super) source_id: Option<i64>,
     pub(super) anthropic_stream_requested: bool,
     pub(super) upstream_body_bytes: Bytes,
     pub(super) use_codex_chatgpt_backend: bool,
@@ -42,44 +45,57 @@ pub(super) enum Cx2ccOutcome {
 
 /// Prepare CX2CC translation for a source-provider-backed bridge provider.
 pub(super) async fn prepare(args: Cx2ccPreparationInput<'_>) -> Cx2ccOutcome {
-    let source_result =
-        crate::providers::get_source_provider_for_gateway(&args.input.state.db, args.source_id);
+    let (
+        source,
+        source_cli_key,
+        source_provider_name,
+        source_cred,
+        source_provider_base_url,
+        mut use_codex_chatgpt_backend,
+        mut codex_chatgpt_account_id,
+    ) = if let Some(source_id) = args.source_id {
+        let source_result =
+            crate::providers::get_source_provider_for_gateway(&args.input.state.db, source_id);
 
-    let (source, source_cli_key) = match source_result {
-        Ok(pair) => pair,
-        Err(err) => {
-            let msg = format!(
-                "[CX2CC] source provider not found: {err} (provider={}, source_id={})",
-                args.provider_name_base, args.source_id
-            );
-            tracing::warn!(
-                trace_id = %args.input.trace_id,
-                provider_id = args.provider_id,
-                source_provider_id = args.source_id,
-                "cx2cc: source provider not found: {err}"
-            );
-            emit_gateway_log(&args.input.state.app, "warn", "CX2CC_SOURCE_NOT_FOUND", msg);
-            return Cx2ccOutcome::Skipped(SkipReason {
-                error_category: "config",
-                error_code: GatewayErrorCode::InternalError.as_str(),
-                reason: format!("cx2cc source provider not found: {err}"),
-            });
-        }
-    };
-
-    // Resolve source provider credential.
-    let source_cred =
-        match resolve_effective_credential(&args.input.state, &source_cli_key, &source).await {
-            Ok(cred) => cred,
+        let (source, source_cli_key) = match source_result {
+            Ok(pair) => pair,
             Err(err) => {
                 let msg = format!(
-                "[CX2CC] source credential resolution failed: {err} (provider={}, source_id={})",
-                args.provider_name_base, args.source_id
-            );
+                    "[CX2CC] source provider not found: {err} (provider={}, source_id={})",
+                    args.provider_name_base, source_id
+                );
                 tracing::warn!(
                     trace_id = %args.input.trace_id,
                     provider_id = args.provider_id,
-                    source_provider_id = args.source_id,
+                    source_provider_id = source_id,
+                    "cx2cc: source provider not found: {err}"
+                );
+                emit_gateway_log(&args.input.state.app, "warn", "CX2CC_SOURCE_NOT_FOUND", msg);
+                return Cx2ccOutcome::Skipped(SkipReason {
+                    error_category: "config",
+                    error_code: GatewayErrorCode::InternalError.as_str(),
+                    reason: format!("cx2cc source provider not found: {err}"),
+                });
+            }
+        };
+
+        let source_cred = match resolve_effective_credential(
+            &args.input.state,
+            &source_cli_key,
+            &source,
+        )
+        .await
+        {
+            Ok(cred) => cred,
+            Err(err) => {
+                let msg = format!(
+                        "[CX2CC] source credential resolution failed: {err} (provider={}, source_id={})",
+                        args.provider_name_base, source_id
+                    );
+                tracing::warn!(
+                    trace_id = %args.input.trace_id,
+                    provider_id = args.provider_id,
+                    source_provider_id = source_id,
                     "cx2cc: source provider credential resolution failed: {err}"
                 );
                 emit_gateway_log(
@@ -95,6 +111,75 @@ pub(super) async fn prepare(args: Cx2ccPreparationInput<'_>) -> Cx2ccOutcome {
                 });
             }
         };
+
+        let provider_base_url_base = match select_provider_base_url_for_request(
+            &args.input.state,
+            &source,
+            &source_cli_key,
+            args.input.provider_base_url_ping_cache_ttl_seconds,
+        )
+        .await
+        {
+            Ok(url) => url,
+            Err(err) => {
+                let msg = format!(
+                    "[CX2CC] source base_url resolution failed: {err} (provider={}, source_id={})",
+                    args.provider_name_base, source_id
+                );
+                tracing::warn!(
+                    trace_id = %args.input.trace_id,
+                    provider_id = args.provider_id,
+                    source_provider_id = source_id,
+                    "cx2cc: source provider base_url resolution failed: {err}"
+                );
+                emit_gateway_log(&args.input.state.app, "warn", "CX2CC_BASE_URL_FAILED", msg);
+                return Cx2ccOutcome::Skipped(SkipReason {
+                    error_category: "translation",
+                    error_code: GatewayErrorCode::InternalError.as_str(),
+                    reason: format!("cx2cc source base_url failed: {err}"),
+                });
+            }
+        };
+
+        let source_provider_name = if source.name.trim().is_empty() {
+            format!("Provider #{}", source.id)
+        } else {
+            source.name.clone()
+        };
+
+        (
+            Some(source),
+            source_cli_key,
+            source_provider_name,
+            source_cred,
+            provider_base_url_base,
+            args.use_codex_chatgpt_backend,
+            args.codex_chatgpt_account_id.clone(),
+        )
+    } else {
+        let state = args.input.state.app.state::<GatewayState>();
+        let manager = state.0.lock_or_recover();
+        let gateway_base_url = manager.status().base_url;
+        drop(manager);
+
+        let Some(gateway_base_url) = gateway_base_url else {
+            return Cx2ccOutcome::Skipped(SkipReason {
+                error_category: "config",
+                error_code: GatewayErrorCode::InternalError.as_str(),
+                reason: "cx2cc local codex gateway base_url missing".to_string(),
+            });
+        };
+
+        (
+            None,
+            "codex".to_string(),
+            "Codex".to_string(),
+            crate::infra::cli_proxy::PLACEHOLDER_KEY.to_string(),
+            format!("{}/v1", gateway_base_url.trim_end_matches('/')),
+            false,
+            None,
+        )
+    };
 
     // Translate request via protocol bridge (IR path).
     let body_val: serde_json::Value =
@@ -156,35 +241,7 @@ pub(super) async fn prepare(args: Cx2ccPreparationInput<'_>) -> Cx2ccOutcome {
     let upstream_query = None;
     let mut strip_request_content_encoding = true;
 
-    // Override base URL with source provider.
-    let provider_base_url_base = match select_provider_base_url_for_request(
-        &args.input.state,
-        &source,
-        &source_cli_key,
-        args.input.provider_base_url_ping_cache_ttl_seconds,
-    )
-    .await
-    {
-        Ok(url) => url,
-        Err(err) => {
-            let msg = format!(
-                "[CX2CC] source base_url resolution failed: {err} (provider={}, source_id={})",
-                args.provider_name_base, args.source_id
-            );
-            tracing::warn!(
-                trace_id = %args.input.trace_id,
-                provider_id = args.provider_id,
-                source_provider_id = args.source_id,
-                "cx2cc: source provider base_url resolution failed: {err}"
-            );
-            emit_gateway_log(&args.input.state.app, "warn", "CX2CC_BASE_URL_FAILED", msg);
-            return Cx2ccOutcome::Skipped(SkipReason {
-                error_category: "translation",
-                error_code: GatewayErrorCode::InternalError.as_str(),
-                reason: format!("cx2cc source base_url failed: {err}"),
-            });
-        }
-    };
+    let provider_base_url_base = source_provider_base_url;
 
     let cx2cc_codex_session_id = codex_session_id_completion::apply_if_needed(
         codex_session_id_completion::ApplyCodexSessionIdCompletionInput {
@@ -199,29 +256,22 @@ pub(super) async fn prepare(args: Cx2ccPreparationInput<'_>) -> Cx2ccOutcome {
     );
 
     // Re-detect Codex ChatGPT backend using source provider.
-    let mut use_codex_chatgpt_backend = args.use_codex_chatgpt_backend;
-    let mut codex_chatgpt_account_id = args.codex_chatgpt_account_id;
-    let cx2cc_is_chatgpt =
-        is_codex_chatgpt_backend(&source_cli_key, &source, &provider_base_url_base);
-    if cx2cc_is_chatgpt {
-        let details = crate::providers::get_oauth_details(&args.input.state.db, source.id).ok();
-        codex_chatgpt_account_id = details.and_then(|d| {
-            parse_codex_chatgpt_account_id(d.oauth_id_token.as_deref())
-                .or_else(|| parse_codex_chatgpt_account_id(Some(&d.oauth_access_token)))
-        });
-        use_codex_chatgpt_backend = true;
+    if let Some(source) = source.as_ref() {
+        let cx2cc_is_chatgpt =
+            is_codex_chatgpt_backend(&source_cli_key, source, &provider_base_url_base);
+        if cx2cc_is_chatgpt {
+            let details = crate::providers::get_oauth_details(&args.input.state.db, source.id).ok();
+            codex_chatgpt_account_id = details.and_then(|d| {
+                parse_codex_chatgpt_account_id(d.oauth_id_token.as_deref())
+                    .or_else(|| parse_codex_chatgpt_account_id(Some(&d.oauth_access_token)))
+            });
+            use_codex_chatgpt_backend = true;
+        }
     }
-
-    let source_provider_name = if source.name.trim().is_empty() {
-        format!("Provider #{}", source.id)
-    } else {
-        source.name.clone()
-    };
 
     tracing::info!(
         trace_id = %args.input.trace_id,
         provider_id = args.provider_id,
-        source_provider_id = args.source_id,
         openai_model = %openai_model,
         "cx2cc: request translated Anthropic -> OpenAI Responses API"
     );
@@ -275,7 +325,7 @@ pub(super) async fn prepare(args: Cx2ccPreparationInput<'_>) -> Cx2ccOutcome {
 
     Cx2ccOutcome::Ready(Box::new(Cx2ccResult {
         cx2cc_active: true,
-        cx2cc_source: Some((source.clone(), source_cli_key.clone())),
+        cx2cc_source: source.map(|provider| (provider, source_cli_key.clone())),
         cx2cc_codex_session_id,
         effective_credential: source_cred,
         provider_base_url_base,

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/provider_iterator.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/provider_iterator.rs
@@ -104,7 +104,9 @@ pub(super) async fn prepare_provider(
             None => return PreparationOutcome::Skipped,
         };
 
-    let mut effective_credential = if provider.source_provider_id.is_some() {
+    let is_cx2cc_bridge = provider.is_cx2cc_bridge();
+
+    let mut effective_credential = if is_cx2cc_bridge {
         String::new()
     } else {
         match resolve_effective_credential(&input.state, &input.cli_key, provider).await {
@@ -212,13 +214,13 @@ pub(super) async fn prepare_provider(
     let mut cx2cc_active = false;
     let mut cx2cc_source: Option<(crate::providers::ProviderForGateway, String)> = None;
     let mut cx2cc_codex_session_id: Option<String> = None;
-    if let Some(source_id) = provider.source_provider_id {
+    if is_cx2cc_bridge {
         let outcome = cx2cc_preparation::prepare(cx2cc_preparation::Cx2ccPreparationInput {
             ctx,
             input,
             provider_id,
             provider_name_base: &provider_name_base,
-            source_id,
+            source_id: provider.source_provider_id,
             anthropic_stream_requested,
             upstream_body_bytes,
             use_codex_chatgpt_backend,

--- a/src-tauri/src/infra/cli_proxy/mod.rs
+++ b/src-tauri/src/infra/cli_proxy/mod.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 const MANIFEST_SCHEMA_VERSION: u32 = 1;
 const MANAGED_BY: &str = "aio-coding-hub";
-const PLACEHOLDER_KEY: &str = "aio-coding-hub";
+pub(crate) const PLACEHOLDER_KEY: &str = "aio-coding-hub";
 
 static TRACE_COUNTER: AtomicU64 = AtomicU64::new(1);
 

--- a/src-tauri/src/infra/request_logs.rs
+++ b/src-tauri/src/infra/request_logs.rs
@@ -33,6 +33,12 @@ const INSERT_RETRY_MAX_DELAY_MS: u64 = 500;
 const COST_MULTIPLIER_CACHE_MAX_ENTRIES: usize = 256;
 const MODEL_PRICE_CACHE_MAX_ENTRIES: usize = 512;
 const CACHE_TTL_SECS: i64 = 5 * 60;
+const EFFECTIVE_COST_MULTIPLIER_SQL: &str = r#"
+SELECT COALESCE(source.cost_multiplier, bridge.cost_multiplier)
+FROM providers bridge
+LEFT JOIN providers source ON source.id = bridge.source_provider_id
+WHERE bridge.id = ?1
+"#;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DbWriteErrorKind {
@@ -336,11 +342,11 @@ fn insert_batch_once(
         .map_err(|e| DbWriteError::from_rusqlite("failed to start transaction", e))?;
 
     {
-        let mut stmt_multiplier = tx
-            .prepare_cached("SELECT cost_multiplier FROM providers WHERE id = ?1")
-            .map_err(|e| {
-                DbWriteError::from_rusqlite("failed to prepare cost_multiplier query", e)
-            })?;
+        let mut stmt_multiplier =
+            tx.prepare_cached(EFFECTIVE_COST_MULTIPLIER_SQL)
+                .map_err(|e| {
+                    DbWriteError::from_rusqlite("failed to prepare cost_multiplier query", e)
+                })?;
         let mut stmt_price_json = tx
             .prepare_cached("SELECT price_json FROM model_prices WHERE cli_key = ?1 AND model = ?2")
             .map_err(|e| DbWriteError::from_rusqlite("failed to prepare model_price query", e))?;
@@ -452,6 +458,8 @@ fn insert_batch_once(
                         let usage = usage_for_cost(item);
                         if !has_any_cost_usage(&usage) {
                             None
+                        } else if cost_multiplier == 0.0 {
+                            Some(0)
                         } else {
                             let mut priced_model = cost_basis.model.as_str();
                             let priced_cli_key = cost_basis.cli_key.as_str();
@@ -630,7 +638,8 @@ GROUP BY cli_key, session_id
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_cx2cc_cost_basis, InsertBatchCache};
+    use super::{parse_cx2cc_cost_basis, InsertBatchCache, EFFECTIVE_COST_MULTIPLIER_SQL};
+    use rusqlite::{params, Connection};
 
     #[test]
     fn parses_cx2cc_cost_basis_from_special_settings() {
@@ -675,5 +684,28 @@ mod tests {
 
         cache.put_model_price_json(key.clone(), value.clone(), now);
         assert_eq!(cache.get_model_price_json(&key, now), Some(value));
+    }
+
+    #[test]
+    fn effective_cost_multiplier_prefers_cx2cc_source_provider() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        conn.execute_batch(
+            r#"
+CREATE TABLE providers (
+  id INTEGER PRIMARY KEY,
+  cost_multiplier REAL NOT NULL DEFAULT 1.0,
+  source_provider_id INTEGER
+);
+INSERT INTO providers (id, cost_multiplier, source_provider_id) VALUES (7, 1.8, NULL);
+INSERT INTO providers (id, cost_multiplier, source_provider_id) VALUES (12, 1.2, 7);
+            "#,
+        )
+        .expect("seed providers");
+
+        let multiplier: f64 = conn
+            .query_row(EFFECTIVE_COST_MULTIPLIER_SQL, params![12], |row| row.get(0))
+            .expect("query multiplier");
+
+        assert_eq!(multiplier, 1.8);
     }
 }

--- a/src-tauri/src/infra/request_logs.rs
+++ b/src-tauri/src/infra/request_logs.rs
@@ -708,4 +708,48 @@ INSERT INTO providers (id, cost_multiplier, source_provider_id) VALUES (12, 1.2,
 
         assert_eq!(multiplier, 1.8);
     }
+
+    #[test]
+    fn effective_cost_multiplier_falls_back_when_source_deleted() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        conn.execute_batch(
+            r#"
+CREATE TABLE providers (
+  id INTEGER PRIMARY KEY,
+  cost_multiplier REAL NOT NULL DEFAULT 1.0,
+  source_provider_id INTEGER
+);
+INSERT INTO providers (id, cost_multiplier, source_provider_id) VALUES (12, 1.2, 999);
+            "#,
+        )
+        .expect("seed providers");
+
+        let multiplier: f64 = conn
+            .query_row(EFFECTIVE_COST_MULTIPLIER_SQL, params![12], |row| row.get(0))
+            .expect("query multiplier");
+
+        assert_eq!(multiplier, 1.2);
+    }
+
+    #[test]
+    fn effective_cost_multiplier_returns_own_when_no_source() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        conn.execute_batch(
+            r#"
+CREATE TABLE providers (
+  id INTEGER PRIMARY KEY,
+  cost_multiplier REAL NOT NULL DEFAULT 1.0,
+  source_provider_id INTEGER
+);
+INSERT INTO providers (id, cost_multiplier, source_provider_id) VALUES (5, 2.5, NULL);
+            "#,
+        )
+        .expect("seed providers");
+
+        let multiplier: f64 = conn
+            .query_row(EFFECTIVE_COST_MULTIPLIER_SQL, params![5], |row| row.get(0))
+            .expect("query multiplier");
+
+        assert_eq!(multiplier, 2.5);
+    }
 }

--- a/src/pages/providers/ProviderEditorDialog.tsx
+++ b/src/pages/providers/ProviderEditorDialog.tsx
@@ -375,7 +375,7 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
     const inheritedMultiplier = isCodexGatewaySource
       ? "0"
       : String(selectedCx2ccSourceProvider?.cost_multiplier ?? 1.0);
-    if (costMultiplierValue === inheritedMultiplier) return;
+    if (Number(costMultiplierValue) === Number(inheritedMultiplier)) return;
     setValue("cost_multiplier", inheritedMultiplier, {
       shouldDirty: true,
       shouldTouch: false,

--- a/src/pages/providers/ProviderEditorDialog.tsx
+++ b/src/pages/providers/ProviderEditorDialog.tsx
@@ -29,6 +29,8 @@ import {
   type CliKey,
   type ProviderSummary,
 } from "../../services/providers/providers";
+import { gatewayStatus } from "../../services/gateway/gateway";
+import { settingsGet } from "../../services/settings/settings";
 import {
   createProviderEditorDialogSchema,
   type ProviderEditorDialogFormInput,
@@ -38,6 +40,7 @@ import { Button } from "../../ui/Button";
 import { Dialog } from "../../ui/Dialog";
 import { FormField } from "../../ui/FormField";
 import { Input } from "../../ui/Input";
+import { Select } from "../../ui/Select";
 import { Switch } from "../../ui/Switch";
 import { TabList } from "../../ui/TabList";
 import { normalizeBaseUrlRows } from "./baseUrl";
@@ -169,9 +172,25 @@ function deriveAuthMode(
   provider: ProviderSummary | null | undefined
 ): "api_key" | "oauth" | "cx2cc" {
   if (!provider) return "api_key";
-  if (provider.source_provider_id) return "cx2cc";
+  if (provider.bridge_type === "cx2cc" || provider.source_provider_id != null) return "cx2cc";
   if (provider.auth_mode === "oauth") return "oauth";
   return "api_key";
+}
+
+const CX2CC_GLOBAL_SOURCE_VALUE = "__codex_gateway__";
+const CX2CC_PROXY_TOKEN = "aio-coding-hub";
+
+function deriveCx2ccSourceValue(
+  source:
+    | Pick<ProviderSummary, "source_provider_id" | "bridge_type">
+    | Pick<ProviderEditorInitialValues, "source_provider_id" | "bridge_type">
+    | null
+    | undefined
+) {
+  if (!source) return "";
+  if (source.source_provider_id != null) return String(source.source_provider_id);
+  if (source.bridge_type === "cx2cc") return CX2CC_GLOBAL_SOURCE_VALUE;
+  return "";
 }
 
 export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
@@ -209,8 +228,8 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
     deriveAuthMode(editProvider)
   );
 
-  const [sourceProviderId, setSourceProviderId] = useState<number | null>(
-    editProvider?.source_provider_id ?? null
+  const [cx2ccSourceValue, setCx2ccSourceValue] = useState<string>(
+    deriveCx2ccSourceValue(editProvider)
   );
 
   const [oauthStatus, setOauthStatus] = useState<{
@@ -221,6 +240,13 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
     has_refresh_token?: boolean;
   } | null>(null);
   const [oauthLoading, setOauthLoading] = useState(false);
+  const [cx2ccFallbackModels, setCx2ccFallbackModels] = useState<{
+    main: string;
+    haiku: string;
+    sonnet: string;
+    opus: string;
+  } | null>(null);
+  const [codexGatewayBaseOrigin, setCodexGatewayBaseOrigin] = useState<string | null>(null);
   const oauthStatusRequestSeqRef = useRef(0);
 
   const form = useForm<ProviderEditorDialogFormInput>({
@@ -239,6 +265,17 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
   const apiKeyValue = watch("api_key");
   const costMultiplierValue = watch("cost_multiplier");
   const apiKeyDirty = Boolean(formState.dirtyFields.api_key);
+  const isCodexGatewaySource = cx2ccSourceValue === CX2CC_GLOBAL_SOURCE_VALUE;
+  const sourceProviderId =
+    cx2ccSourceValue && cx2ccSourceValue !== CX2CC_GLOBAL_SOURCE_VALUE
+      ? Number(cx2ccSourceValue)
+      : null;
+  const selectedCx2ccSourceProvider = sourceProviderId
+    ? (codexProviders.find((provider) => provider.id === sourceProviderId) ?? null)
+    : null;
+  const codexGatewayBaseUrl = codexGatewayBaseOrigin
+    ? `${codexGatewayBaseOrigin.replace(/\/$/, "")}/v1`
+    : "当前网关 /v1";
 
   const title =
     mode === "create"
@@ -278,7 +315,6 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
     setSavedApiKey(null);
 
     if (mode === "create") {
-      const initialSourceProviderId = createInitialValues?.source_provider_id ?? null;
       setBaseUrlMode(createInitialValues?.base_url_mode ?? "order");
       setBaseUrlRows(buildBaseUrlRows(createInitialValues, newBaseUrlRow));
       setPingingAll(false);
@@ -286,9 +322,11 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
       setTags(createInitialValues?.tags ?? []);
       setTagInput("");
       setStreamIdleTimeoutSeconds(valueOrEmpty(createInitialValues?.stream_idle_timeout_seconds));
-      setSourceProviderId(initialSourceProviderId);
+      setCx2ccSourceValue(deriveCx2ccSourceValue(createInitialValues));
       setAuthMode(
-        initialSourceProviderId != null ? "cx2cc" : (createInitialValues?.auth_mode ?? "api_key")
+        deriveCx2ccSourceValue(createInitialValues)
+          ? "cx2cc"
+          : (createInitialValues?.auth_mode ?? "api_key")
       );
       setOauthStatus(null);
       reset(buildFormValues(createInitialValues));
@@ -300,7 +338,7 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
 
     const initialAuthMode = deriveAuthMode(snapshot);
     setAuthMode(initialAuthMode);
-    setSourceProviderId(snapshot.source_provider_id ?? null);
+    setCx2ccSourceValue(deriveCx2ccSourceValue(snapshot));
     setOauthStatus(null);
     setBaseUrlMode(snapshot.base_url_mode);
     setBaseUrlRows(snapshot.base_urls.map((url) => newBaseUrlRow(url)));
@@ -331,6 +369,52 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
       apiKeyFetchPromiseRef.current = null;
     };
   }, [cliKey, createInitialValues, editingProviderId, mode, open, reset]);
+
+  useEffect(() => {
+    if (authMode !== "cx2cc") return;
+    const inheritedMultiplier = isCodexGatewaySource
+      ? "0"
+      : String(selectedCx2ccSourceProvider?.cost_multiplier ?? 1.0);
+    if (costMultiplierValue === inheritedMultiplier) return;
+    setValue("cost_multiplier", inheritedMultiplier, {
+      shouldDirty: true,
+      shouldTouch: false,
+      shouldValidate: false,
+    });
+  }, [authMode, costMultiplierValue, isCodexGatewaySource, selectedCx2ccSourceProvider, setValue]);
+
+  useEffect(() => {
+    if (!open || cliKey !== "claude") return;
+    let cancelled = false;
+
+    void Promise.all([settingsGet(), gatewayStatus()])
+      .then(([settings, status]) => {
+        if (cancelled) return;
+        if (settings) {
+          setCx2ccFallbackModels({
+            main: settings.cx2cc_fallback_model_main.trim(),
+            haiku: settings.cx2cc_fallback_model_haiku.trim(),
+            sonnet: settings.cx2cc_fallback_model_sonnet.trim(),
+            opus: settings.cx2cc_fallback_model_opus.trim(),
+          });
+          setCodexGatewayBaseOrigin(
+            status?.base_url?.trim() || `http://127.0.0.1:${settings.preferred_port}`
+          );
+          return;
+        }
+        setCx2ccFallbackModels(null);
+        setCodexGatewayBaseOrigin(status?.base_url?.trim() || null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCx2ccFallbackModels(null);
+        setCodexGatewayBaseOrigin(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cliKey, open]);
 
   useEffect(() => {
     if (!open || mode !== "edit" || !editingProviderId || authMode !== "api_key") return;
@@ -561,8 +645,8 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
       finalBaseUrls = [];
       finalBaseUrlMode = "order";
 
-      if (!sourceProviderId) {
-        toast("请选择源 Codex 供应商");
+      if (!cx2ccSourceValue) {
+        toast("请选择源 Codex 来源");
         return;
       }
     } else {
@@ -586,6 +670,12 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
     try {
       const apiKeyToSave =
         authMode === "oauth" ? null : mode === "edit" && !apiKeyDirty ? "" : values.api_key;
+      const effectiveCostMultiplier =
+        isCx2cc && isCodexGatewaySource
+          ? 0
+          : isCx2cc && selectedCx2ccSourceProvider
+            ? selectedCx2ccSourceProvider.cost_multiplier
+            : values.cost_multiplier;
 
       const saved = await providerUpsert({
         ...(mode === "edit" ? { provider_id: props.provider.id } : {}),
@@ -596,7 +686,7 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
         auth_mode: isCx2cc ? "api_key" : authMode,
         api_key: authMode === "oauth" || isCx2cc ? null : apiKeyToSave,
         enabled: values.enabled,
-        cost_multiplier: values.cost_multiplier,
+        cost_multiplier: effectiveCostMultiplier,
         limit_5h_usd: values.limit_5h_usd,
         limit_daily_usd: values.limit_daily_usd,
         daily_reset_mode: values.daily_reset_mode,
@@ -608,7 +698,7 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
         note: values.note,
         stream_idle_timeout_seconds: parsedStreamIdleTimeoutSeconds,
         ...(cliKey === "claude" && authMode !== "oauth" ? { claude_models: claudeModels } : {}),
-        source_provider_id: isCx2cc ? sourceProviderId : null,
+        source_provider_id: isCx2cc && !isCodexGatewaySource ? sourceProviderId : null,
         bridge_type: isCx2cc ? "cx2cc" : null,
       });
 
@@ -679,51 +769,51 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
   const supportsOAuth = cliKey === "codex" || cliKey === "gemini";
   const supportsCx2cc = cliKey === "claude";
 
-  const tagsAndNoteSection = (
-    <div className="grid gap-3 sm:grid-cols-2">
-      <FormField label="标签" hint="按 Enter 添加标签">
-        <div className="flex min-h-10 flex-wrap items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 shadow-sm dark:border-slate-600 dark:bg-slate-800 dark:shadow-none">
-          {tags.map((tag) => (
-            <span key={tag} className={tagBadgeClassName(tag)}>
-              {tag}
-              <button
-                type="button"
-                onClick={() => setTags((prev) => prev.filter((t) => t !== tag))}
-                className={tagRemoveButtonClassName(tag)}
-                disabled={saving}
-                aria-label={`移除标签 ${tag}`}
-              >
-                <X className="h-2.5 w-2.5" />
-              </button>
-            </span>
-          ))}
-          <input
-            type="text"
-            value={tagInput}
-            onChange={(e) => setTagInput(e.currentTarget.value)}
-            onKeyDown={(e) => {
-              if (e.key !== "Enter") return;
-              e.preventDefault();
-              const trimmed = tagInput.trim();
-              if (!trimmed) return;
-              if (tags.includes(trimmed)) {
-                setTagInput("");
-                return;
-              }
-              setTags((prev) => [...prev, trimmed]);
+  const tagsField = (
+    <FormField label="标签" hint="按 Enter 添加标签">
+      <div className="flex min-h-10 flex-wrap items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 shadow-sm dark:border-slate-600 dark:bg-slate-800 dark:shadow-none">
+        {tags.map((tag) => (
+          <span key={tag} className={tagBadgeClassName(tag)}>
+            {tag}
+            <button
+              type="button"
+              onClick={() => setTags((prev) => prev.filter((t) => t !== tag))}
+              className={tagRemoveButtonClassName(tag)}
+              disabled={saving}
+              aria-label={`移除标签 ${tag}`}
+            >
+              <X className="h-2.5 w-2.5" />
+            </button>
+          </span>
+        ))}
+        <input
+          type="text"
+          value={tagInput}
+          onChange={(e) => setTagInput(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key !== "Enter") return;
+            e.preventDefault();
+            const trimmed = tagInput.trim();
+            if (!trimmed) return;
+            if (tags.includes(trimmed)) {
               setTagInput("");
-            }}
-            placeholder={tags.length === 0 ? "输入标签后按 Enter" : ""}
-            className="min-w-[80px] flex-1 border-none bg-transparent text-sm outline-none placeholder:text-slate-400"
-            disabled={saving}
-          />
-        </div>
-      </FormField>
+              return;
+            }
+            setTags((prev) => [...prev, trimmed]);
+            setTagInput("");
+          }}
+          placeholder={tags.length === 0 ? "输入标签后按 Enter" : ""}
+          className="min-w-[80px] flex-1 border-none bg-transparent text-sm outline-none placeholder:text-slate-400"
+          disabled={saving}
+        />
+      </div>
+    </FormField>
+  );
 
-      <FormField label="备注" hint="供应商列表中显示">
-        <Input placeholder="可选备注信息" disabled={saving} {...register("note")} />
-      </FormField>
-    </div>
+  const noteField = (
+    <FormField label="备注">
+      <Input placeholder="可选备注信息" disabled={saving} {...register("note")} />
+    </FormField>
   );
 
   async function handleOAuthLogin() {
@@ -1074,51 +1164,138 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
                 <Input placeholder="default" {...register("name")} />
               </FormField>
 
-              <FormField label="价格倍率">
-                <Input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  placeholder="1.0"
-                  {...register("cost_multiplier")}
-                />
-              </FormField>
+              {tagsField}
             </div>
 
-            <FormField label="源 Codex 供应商" hint="CX2CC 将复用此供应商的凭证和 Base URL">
-              <select
-                className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
-                value={sourceProviderId ?? ""}
+            {noteField}
+
+            <FormField label="源 Codex 来源">
+              <Select
+                value={cx2ccSourceValue}
                 onChange={(e) => {
-                  const val = e.target.value ? Number(e.target.value) : null;
-                  setSourceProviderId(val);
+                  setCx2ccSourceValue(e.target.value);
                 }}
                 disabled={saving}
+                className="w-full"
               >
-                <option value="">请选择 Codex 供应商…</option>
+                <option value="">请选择 Codex 来源…</option>
+                <option value={CX2CC_GLOBAL_SOURCE_VALUE}>
+                  当前 AIO 服务 Codex 网关（跟随当前分流）
+                </option>
                 {codexProviders
-                  .filter((p) => p.enabled && p.source_provider_id == null)
+                  .filter((p) => p.enabled && p.source_provider_id == null && p.bridge_type == null)
                   .map((p) => (
                     <option key={p.id} value={p.id}>
                       {p.name} ({p.auth_mode === "oauth" ? "OAuth" : "API Key"})
                     </option>
                   ))}
-              </select>
-              {(() => {
-                const selected = sourceProviderId
-                  ? (codexProviders.find((p) => p.id === sourceProviderId) ?? null)
-                  : null;
-                return selected ? (
-                  <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                    已选择：{selected.name} —{" "}
-                    {selected.auth_mode === "oauth" ? "OAuth 认证" : "API Key 认证"}
-                    {selected.base_urls.length > 0 ? ` — ${selected.base_urls[0]}` : ""}
+              </Select>
+              {isCodexGatewaySource ? (
+                <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2.5 text-xs text-slate-500 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400">
+                  <p>
+                    已选择
+                    <span className="mx-1 font-medium text-slate-700 dark:text-slate-200">
+                      当前 AIO 服务 Codex 网关
+                    </span>
                   </p>
-                ) : null;
-              })()}
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[11px] leading-5">
+                    <span>
+                      认证：
+                      <span className="ml-1 text-slate-700 dark:text-slate-200">App Token</span>
+                    </span>
+                    <span>
+                      价格倍率：
+                      <span className="ml-1 font-mono text-slate-700 dark:text-slate-200">
+                        免费
+                      </span>
+                    </span>
+                    <span className="min-w-0 max-w-full truncate" title={codexGatewayBaseUrl}>
+                      Base URL：
+                      <span className="ml-1 font-mono text-slate-700 dark:text-slate-200">
+                        {codexGatewayBaseUrl}
+                      </span>
+                    </span>
+                    <span>
+                      Token：
+                      <span className="ml-1 font-mono text-slate-700 dark:text-slate-200">
+                        {CX2CC_PROXY_TOKEN}
+                      </span>
+                    </span>
+                  </div>
+                  <p className="mt-1 text-[11px] leading-5">
+                    说明：转译后的请求会进入当前 AIO 服务 Codex 网关，再按当前 Codex 分流继续路由。
+                  </p>
+                  <p className="mt-1 text-[11px] leading-5">
+                    默认模型映射： 主模型
+                    <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
+                      {cx2ccFallbackModels?.main ?? "全局默认值"}
+                    </span>
+                    / Haiku
+                    <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
+                      {cx2ccFallbackModels?.haiku ?? "全局默认值"}
+                    </span>
+                    / Sonnet
+                    <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
+                      {cx2ccFallbackModels?.sonnet ?? "全局默认值"}
+                    </span>
+                    / Opus
+                    <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
+                      {cx2ccFallbackModels?.opus ?? "全局默认值"}
+                    </span>
+                  </p>
+                </div>
+              ) : selectedCx2ccSourceProvider ? (
+                <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2.5 text-xs text-slate-500 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400">
+                  <p>
+                    已选择
+                    <span className="mx-1 font-medium text-slate-700 dark:text-slate-200">
+                      {selectedCx2ccSourceProvider.name}
+                    </span>
+                  </p>
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[11px] leading-5">
+                    <span>
+                      认证：
+                      <span className="ml-1 text-slate-700 dark:text-slate-200">
+                        {selectedCx2ccSourceProvider.auth_mode === "oauth" ? "OAuth" : "API Key"}
+                      </span>
+                    </span>
+                    <span>
+                      价格倍率：
+                      <span className="ml-1 font-mono text-slate-700 dark:text-slate-200">
+                        x{selectedCx2ccSourceProvider.cost_multiplier.toFixed(2)}
+                      </span>
+                    </span>
+                    <span
+                      className="min-w-0 max-w-full truncate"
+                      title={selectedCx2ccSourceProvider.base_urls[0] ?? "跟随网关默认路由"}
+                    >
+                      Base URL：
+                      <span className="ml-1 font-mono text-slate-700 dark:text-slate-200">
+                        {selectedCx2ccSourceProvider.base_urls[0] ?? "跟随网关默认路由"}
+                      </span>
+                    </span>
+                  </div>
+                  <p className="mt-1 text-[11px] leading-5">
+                    默认模型映射： 主模型
+                    <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
+                      {cx2ccFallbackModels?.main ?? "全局默认值"}
+                    </span>
+                    / Haiku
+                    <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
+                      {cx2ccFallbackModels?.haiku ?? "全局默认值"}
+                    </span>
+                    / Sonnet
+                    <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
+                      {cx2ccFallbackModels?.sonnet ?? "全局默认值"}
+                    </span>
+                    / Opus
+                    <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
+                      {cx2ccFallbackModels?.opus ?? "全局默认值"}
+                    </span>
+                  </p>
+                </div>
+              ) : null}
             </FormField>
-
-            {tagsAndNoteSection}
           </>
         ) : (
           /* ── API Key mode: full form ── */
@@ -1128,49 +1305,10 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
                 <Input placeholder="default" {...register("name")} />
               </FormField>
 
-              <FormField label="标签" hint="按 Enter 添加标签">
-                <div className="flex min-h-10 flex-wrap items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 shadow-sm dark:border-slate-600 dark:bg-slate-800 dark:shadow-none">
-                  {tags.map((tag) => (
-                    <span key={tag} className={tagBadgeClassName(tag)}>
-                      {tag}
-                      <button
-                        type="button"
-                        onClick={() => setTags((prev) => prev.filter((t) => t !== tag))}
-                        className={tagRemoveButtonClassName(tag)}
-                        disabled={saving}
-                        aria-label={`移除标签 ${tag}`}
-                      >
-                        <X className="h-2.5 w-2.5" />
-                      </button>
-                    </span>
-                  ))}
-                  <input
-                    type="text"
-                    value={tagInput}
-                    onChange={(e) => setTagInput(e.currentTarget.value)}
-                    onKeyDown={(e) => {
-                      if (e.key !== "Enter") return;
-                      e.preventDefault();
-                      const trimmed = tagInput.trim();
-                      if (!trimmed) return;
-                      if (tags.includes(trimmed)) {
-                        setTagInput("");
-                        return;
-                      }
-                      setTags((prev) => [...prev, trimmed]);
-                      setTagInput("");
-                    }}
-                    placeholder={tags.length === 0 ? "输入标签后按 Enter" : ""}
-                    className="min-w-[80px] flex-1 border-none bg-transparent text-sm outline-none placeholder:text-slate-400"
-                    disabled={saving}
-                  />
-                </div>
-              </FormField>
+              {tagsField}
             </div>
 
-            <FormField label="备注">
-              <Input placeholder="可选备注信息" disabled={saving} {...register("note")} />
-            </FormField>
+            {noteField}
 
             <FormField label="Base URLs">
               <BaseUrlEditor

--- a/src/pages/providers/ProvidersView.tsx
+++ b/src/pages/providers/ProvidersView.tsx
@@ -73,6 +73,10 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
   );
   const codexProvidersQuery = useProvidersListQuery("codex", { enabled: activeCli === "claude" });
   const providersLoading = providersQuery.isFetching;
+  const sourceProvidersById = useMemo(
+    () => Object.fromEntries((codexProvidersQuery.data ?? []).map((p) => [p.id, p])),
+    [codexProvidersQuery.data]
+  );
   const sourceProviderNamesById = useMemo(
     () => Object.fromEntries((codexProvidersQuery.data ?? []).map((p) => [p.id, p.name])),
     [codexProvidersQuery.data]
@@ -598,7 +602,14 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
                       sourceProviderName={
                         provider.source_provider_id != null
                           ? (sourceProviderNamesById[provider.source_provider_id] ?? null)
-                          : undefined
+                          : provider.bridge_type === "cx2cc"
+                            ? "当前 AIO 服务 Codex 网关"
+                            : undefined
+                      }
+                      sourceProvider={
+                        provider.source_provider_id != null
+                          ? (sourceProvidersById[provider.source_provider_id] ?? null)
+                          : null
                       }
                       circuit={circuitByProviderId[provider.id] ?? null}
                       circuitResetting={Boolean(circuitResetting[provider.id]) || circuitLoading}

--- a/src/pages/providers/SortableProviderCard.tsx
+++ b/src/pages/providers/SortableProviderCard.tsx
@@ -103,6 +103,7 @@ function renderProviderNote(note: string) {
 export type SortableProviderCardProps = {
   provider: ProviderSummary;
   sourceProviderName?: string | null;
+  sourceProvider?: ProviderSummary | null;
   circuit: GatewayProviderCircuitStatus | null;
   circuitResetting: boolean;
   onToggleEnabled: (provider: ProviderSummary) => void;
@@ -119,6 +120,7 @@ export type SortableProviderCardProps = {
 export const SortableProviderCard = memo(function SortableProviderCard({
   provider,
   sourceProviderName = null,
+  sourceProvider = null,
   circuit,
   circuitResetting,
   onToggleEnabled,
@@ -162,6 +164,8 @@ export const SortableProviderCard = memo(function SortableProviderCard({
   const circuitState = useMemo(() => getGatewayCircuitDerivedState(circuit), [circuit]);
   const { isUnavailable, unavailableUntil } = circuitState;
   const isOAuth = provider.auth_mode === "oauth";
+  const isCx2cc = provider.source_provider_id != null || provider.bridge_type === "cx2cc";
+  const isCx2ccGateway = provider.bridge_type === "cx2cc" && provider.source_provider_id == null;
   const [apiKeyDetailsVisible, setApiKeyDetailsVisible] = useState(false);
   const [oauthLimits, setOauthLimits] = useState<OAuthLimitsResult | null>(
     () => oauthLimitsCache.get(provider.id) ?? null
@@ -178,6 +182,16 @@ export const SortableProviderCard = memo(function SortableProviderCard({
     unavailableUntil != null ? Math.max(0, unavailableUntil - nowUnix) : null;
   const unavailableCountdown =
     unavailableRemaining != null ? formatCountdownSeconds(unavailableRemaining) : null;
+  const cx2ccSourceName =
+    sourceProviderName ??
+    sourceProvider?.name ??
+    (provider.source_provider_id != null
+      ? `#${provider.source_provider_id}`
+      : "当前 AIO 服务 Codex 网关");
+  const cx2ccRouteLabel = isCx2ccGateway
+    ? "跟随当前 Codex 分流"
+    : (sourceProvider?.base_urls[0] ?? "跟随网关默认路由");
+  const visibleTags = provider.tags ?? [];
 
   // OAuth 限制重置倒计时
   const limitsResetCountdown = useMemo(() => {
@@ -319,7 +333,7 @@ export const SortableProviderCard = memo(function SortableProviderCard({
                   <RefreshCw className={cn("h-2.5 w-2.5", limitsLoading && "animate-spin")} />
                   OAuth
                 </button>
-              ) : provider.source_provider_id != null ? (
+              ) : isCx2cc ? (
                 <span
                   className="inline-flex w-16 shrink-0 items-center justify-center rounded-full px-2 py-0.5 font-mono text-[10px] bg-violet-50 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400"
                   title="CX2CC 转译模式"
@@ -344,6 +358,17 @@ export const SortableProviderCard = memo(function SortableProviderCard({
                   </span>
                 </>
               )}
+              {isCx2cc && provider.cost_multiplier !== 0 ? (
+                <span
+                  className={cn(
+                    "shrink-0 rounded-full px-2 py-0.5 font-mono text-[10px]",
+                    "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+                  )}
+                  title={`价格倍率: x${provider.cost_multiplier.toFixed(2)}`}
+                >
+                  x{provider.cost_multiplier.toFixed(2)}
+                </span>
+              ) : null}
               {provider.cli_key === "claude" && hasClaudeModels ? (
                 <span
                   className="shrink-0 rounded-full bg-sky-50 px-2 py-0.5 font-mono text-[10px] text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
@@ -363,7 +388,7 @@ export const SortableProviderCard = memo(function SortableProviderCard({
                   限额
                 </span>
               ) : null}
-              {(provider.tags ?? []).map((tag) => (
+              {visibleTags.map((tag) => (
                 <span key={tag} className={providerTagClassName(tag)} title={`标签: ${tag}`}>
                   {tag}
                 </span>
@@ -413,13 +438,21 @@ export const SortableProviderCard = memo(function SortableProviderCard({
                     </span>
                   ) : null}
                 </>
-              ) : provider.source_provider_id != null ? (
-                <span
-                  className="truncate font-mono text-xs text-violet-500 dark:text-violet-400 cursor-default"
-                  title={`源 Codex 供应商: ${sourceProviderName ?? `#${provider.source_provider_id}`}`}
-                >
-                  源: {sourceProviderName ?? `#${provider.source_provider_id}`}
-                </span>
+              ) : isCx2cc ? (
+                <>
+                  <span
+                    className="truncate font-mono text-xs text-violet-500 dark:text-violet-400 cursor-default"
+                    title={`来源: ${cx2ccSourceName}`}
+                  >
+                    来源: {cx2ccSourceName}
+                  </span>
+                  <span
+                    className="truncate font-mono text-xs text-slate-500 dark:text-slate-400 cursor-default"
+                    title={cx2ccRouteLabel}
+                  >
+                    {cx2ccRouteLabel}
+                  </span>
+                </>
               ) : apiKeyDetailsVisible ? (
                 <span
                   className="truncate font-mono text-xs text-slate-500 dark:text-slate-400 cursor-default"

--- a/src/pages/providers/__tests__/ProviderEditorDialog.test.tsx
+++ b/src/pages/providers/__tests__/ProviderEditorDialog.test.tsx
@@ -532,6 +532,31 @@ describe("pages/providers/ProviderEditorDialog", () => {
     expect((dialog.getByPlaceholderText("1.0") as HTMLInputElement).value).toBe("1");
   });
 
+  it("shows toast when saving cx2cc without selecting source", async () => {
+    render(
+      <ProviderEditorDialog
+        mode="create"
+        open={true}
+        cliKey="claude"
+        onSaved={vi.fn()}
+        onOpenChange={vi.fn()}
+      />
+    );
+
+    const dialog = within(screen.getByRole("dialog"));
+    fireEvent.click(dialog.getByRole("tab", { name: "CX2CC 转译" }));
+    fireEvent.change(dialog.getByPlaceholderText("default"), {
+      target: { value: "Empty Source" },
+    });
+
+    fireEvent.click(dialog.getByRole("button", { name: "保存" }));
+
+    await waitFor(() =>
+      expect(vi.mocked(toast)).toHaveBeenCalledWith("请选择源 Codex 来源")
+    );
+    expect(vi.mocked(providerUpsert)).not.toHaveBeenCalled();
+  });
+
   it("syncs haiku sonnet opus with main model by default", () => {
     render(
       <ProviderEditorDialog

--- a/src/pages/providers/__tests__/ProviderEditorDialog.test.tsx
+++ b/src/pages/providers/__tests__/ProviderEditorDialog.test.tsx
@@ -377,6 +377,161 @@ describe("pages/providers/ProviderEditorDialog", () => {
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
   });
 
+  it("inherits cost multiplier from selected codex source for cx2cc", async () => {
+    vi.mocked(providerUpsert).mockResolvedValue({
+      id: 12,
+      cli_key: "claude",
+      name: "Bridge Provider",
+      base_urls: [],
+      base_url_mode: "order",
+      enabled: true,
+      cost_multiplier: 1.8,
+      claude_models: {},
+      source_provider_id: 7,
+      bridge_type: "cx2cc",
+    } as any);
+
+    render(
+      <ProviderEditorDialog
+        mode="create"
+        open={true}
+        cliKey="claude"
+        onSaved={vi.fn()}
+        onOpenChange={vi.fn()}
+        codexProviders={[
+          makeProvider({
+            id: 7,
+            cli_key: "codex",
+            name: "Codex Source",
+            auth_mode: "api_key",
+            cost_multiplier: 1.8,
+            base_urls: ["https://codex.example.com/v1"],
+          }),
+        ]}
+      />
+    );
+
+    const dialog = within(screen.getByRole("dialog"));
+    fireEvent.click(dialog.getByRole("tab", { name: "CX2CC 转译" }));
+    fireEvent.change(dialog.getByPlaceholderText("default"), {
+      target: { value: "Bridge Provider" },
+    });
+    fireEvent.change(dialog.getByRole("combobox"), { target: { value: "7" } });
+
+    await waitFor(() => {
+      expect(dialog.getByText("Codex Source")).toBeInTheDocument();
+      expect(dialog.getByText("API Key")).toBeInTheDocument();
+      expect(dialog.getByText("x1.80")).toBeInTheDocument();
+      expect(dialog.getByText("https://codex.example.com/v1")).toBeInTheDocument();
+      expect(dialog.getByText(/默认模型映射：/)).toBeInTheDocument();
+      expect(dialog.getAllByText("gpt-5.4").length).toBeGreaterThanOrEqual(1);
+    });
+
+    fireEvent.click(dialog.getByRole("button", { name: "保存" }));
+
+    await waitFor(() =>
+      expect(vi.mocked(providerUpsert)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Bridge Provider",
+          cost_multiplier: 1.8,
+          source_provider_id: 7,
+          bridge_type: "cx2cc",
+        })
+      )
+    );
+  });
+
+  it("supports using the whole codex gateway as cx2cc source", async () => {
+    vi.mocked(providerUpsert).mockResolvedValue({
+      id: 13,
+      cli_key: "claude",
+      name: "Bridge Gateway Provider",
+      base_urls: [],
+      base_url_mode: "order",
+      enabled: true,
+      cost_multiplier: 0,
+      claude_models: {},
+      source_provider_id: null,
+      bridge_type: "cx2cc",
+    } as any);
+
+    render(
+      <ProviderEditorDialog
+        mode="create"
+        open={true}
+        cliKey="claude"
+        onSaved={vi.fn()}
+        onOpenChange={vi.fn()}
+      />
+    );
+
+    const dialog = within(screen.getByRole("dialog"));
+    fireEvent.click(dialog.getByRole("tab", { name: "CX2CC 转译" }));
+    fireEvent.change(dialog.getByPlaceholderText("default"), {
+      target: { value: "Bridge Gateway Provider" },
+    });
+    fireEvent.change(dialog.getByRole("combobox"), {
+      target: { value: "__codex_gateway__" },
+    });
+
+    await waitFor(() => {
+      expect(dialog.getByText("当前 AIO 服务 Codex 网关")).toBeInTheDocument();
+      expect(dialog.getByText("App Token")).toBeInTheDocument();
+      expect(dialog.getAllByText("免费").length).toBeGreaterThanOrEqual(1);
+      expect(dialog.getByText("http://127.0.0.1:37123/v1")).toBeInTheDocument();
+      expect(dialog.getByText("aio-coding-hub")).toBeInTheDocument();
+      expect(dialog.getByText(/转译后的请求会进入当前 AIO 服务 Codex 网关/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(dialog.getByRole("button", { name: "保存" }));
+
+    await waitFor(() =>
+      expect(vi.mocked(providerUpsert)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Bridge Gateway Provider",
+          cost_multiplier: 0,
+          source_provider_id: null,
+          bridge_type: "cx2cc",
+        })
+      )
+    );
+  });
+
+  it("resets cost multiplier to default when cx2cc source is not selected", async () => {
+    render(
+      <ProviderEditorDialog
+        mode="create"
+        open={true}
+        cliKey="claude"
+        onSaved={vi.fn()}
+        onOpenChange={vi.fn()}
+        codexProviders={[
+          makeProvider({
+            id: 7,
+            cli_key: "codex",
+            name: "Codex Source",
+            auth_mode: "api_key",
+            cost_multiplier: 1.8,
+          }),
+        ]}
+      />
+    );
+
+    const dialog = within(screen.getByRole("dialog"));
+    fireEvent.change(dialog.getByPlaceholderText("1.0"), { target: { value: "2.5" } });
+    fireEvent.click(dialog.getByRole("tab", { name: "CX2CC 转译" }));
+
+    await waitFor(() => {
+      expect(
+        dialog.queryByText(/CX2CC 会复用该供应商的认证信息、Base URL 和价格倍率。/)
+      ).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(dialog.getByRole("tab", { name: "API 密钥" }));
+
+    expect((dialog.getByPlaceholderText("1.0") as HTMLInputElement).value).toBe("1");
+  });
+
   it("syncs haiku sonnet opus with main model by default", () => {
     render(
       <ProviderEditorDialog

--- a/src/pages/providers/__tests__/ProvidersView.test.tsx
+++ b/src/pages/providers/__tests__/ProvidersView.test.tsx
@@ -301,8 +301,9 @@ describe("pages/providers/ProvidersView", () => {
     renderWithQuery(<ProvidersView activeCli="claude" setActiveCli={vi.fn()} />);
 
     expect(
-      screen.getAllByText((_, el) => el?.textContent === "源: OpenAI Primary").length
+      screen.getAllByText((_, el) => el?.textContent === "来源: OpenAI Primary").length
     ).toBeGreaterThan(0);
+    expect(screen.getByText("x1.00")).toBeInTheDocument();
   });
 
   it("supports toggling, circuit reset, create/edit/delete, and drag reorder", async () => {

--- a/src/pages/providers/__tests__/SortableProviderCard.test.tsx
+++ b/src/pages/providers/__tests__/SortableProviderCard.test.tsx
@@ -276,21 +276,70 @@ describe("pages/providers/SortableProviderCard", () => {
     expect(freeTag.className).toContain("text-emerald-700");
   });
 
-  it("keeps cx2cc source label without the top translation badge", () => {
+  it("renders cx2cc source summary for a concrete codex provider", () => {
     renderCard(
       {
         source_provider_id: 7,
+        cost_multiplier: 1.8,
       },
       {
         sourceProviderName: "Lisa",
+        sourceProvider: makeProvider({
+          id: 7,
+          cli_key: "codex",
+          name: "Lisa",
+          auth_mode: "oauth",
+          base_urls: ["https://codex.example.com/v1"],
+        }),
       }
     );
 
-    expect(screen.getAllByText((_, el) => el?.textContent === "源: Lisa").length).toBeGreaterThan(
+    expect(screen.getByText("CX2CC")).toBeInTheDocument();
+    expect(screen.getByText("x1.80")).toBeInTheDocument();
+    expect(screen.getAllByText((_, el) => el?.textContent === "来源: Lisa").length).toBeGreaterThan(
       0
     );
+    expect(screen.getByText("https://codex.example.com/v1")).toBeInTheDocument();
     expect(screen.queryByText("CX2CC 转译")).not.toBeInTheDocument();
+  });
+
+  it("renders cx2cc summary for the current aio codex gateway", () => {
+    renderCard({
+      bridge_type: "cx2cc",
+      source_provider_id: null,
+      cost_multiplier: 0,
+      tags: ["免费"],
+    });
+
     expect(screen.getByText("CX2CC")).toBeInTheDocument();
+    expect(screen.getByText("免费")).toBeInTheDocument();
+    expect(
+      screen.getAllByText((_, el) => el?.textContent === "来源: 当前 AIO 服务 Codex 网关").length
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("跟随当前 Codex 分流")).toBeInTheDocument();
+  });
+
+  it("shows only one 免费 label for zero-cost cx2cc cards", () => {
+    renderCard({
+      bridge_type: "cx2cc",
+      source_provider_id: null,
+      cost_multiplier: 0,
+      tags: ["免费", "bridge"],
+    });
+
+    expect(screen.getAllByText("免费")).toHaveLength(1);
+    expect(screen.getByText("bridge")).toBeInTheDocument();
+  });
+
+  it("does not render a separate cx2cc free price badge", () => {
+    renderCard({
+      bridge_type: "cx2cc",
+      source_provider_id: null,
+      cost_multiplier: 0,
+      tags: [],
+    });
+
+    expect(screen.queryByText("免费")).not.toBeInTheDocument();
   });
 
   it("renders ping mode label", () => {

--- a/src/pages/providers/providerDuplicate.ts
+++ b/src/pages/providers/providerDuplicate.ts
@@ -57,7 +57,7 @@ export function buildDuplicatedProviderInitialValues(
   existingProviders: ProviderSummary[],
   apiKey: string | null
 ): ProviderEditorInitialValues {
-  const isBridge = provider.source_provider_id != null;
+  const isBridge = provider.source_provider_id != null || provider.bridge_type === "cx2cc";
   return {
     name: buildDuplicatedProviderName(provider.name, existingProviders),
     api_key: !isBridge && provider.auth_mode === "api_key" ? (apiKey ?? "") : "",


### PR DESCRIPTION
- 支持 CX2CC 在未指定具体 source_provider_id 时，直接使用当前 AIO 服务 Codex 网关
- 统一编辑页与列表页的来源文案和展示信息
- 调整 CX2CC 零倍率场景的免费展示逻辑，避免重复显示