### PR TITLE
feat(theme): 支持 Windows 系统主题跟随

### DIFF
--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -6,10 +6,17 @@ vi.mock("../../services/desktop/window", () => ({
   setDesktopWindowTheme: vi.fn().mockResolvedValue(true),
 }));
 
+const mockTauriListen = vi.fn();
+vi.mock("../../services/desktop/themeEvent", () => ({
+  listenThemeChanged: mockTauriListen,
+}));
+
 describe("hooks/useTheme", () => {
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.classList.remove("dark");
+    mockTauriListen.mockReset();
+    mockTauriListen.mockImplementation(() => Promise.resolve(() => {}));
   });
 
   afterEach(() => {
@@ -53,6 +60,23 @@ describe("hooks/useTheme", () => {
       },
       restore() {
         Object.defineProperty(window, "matchMedia", { writable: true, value: original });
+      },
+    };
+  }
+
+  function mockTauriThemeListener() {
+    let tauriHandler: ((theme: "light" | "dark") => void) | null = null;
+    mockTauriListen.mockImplementation((handler: (theme: "light" | "dark") => void) => {
+      tauriHandler = handler;
+      return Promise.resolve(() => {});
+    });
+
+    return {
+      fireTauriThemeChange(theme: "light" | "dark") {
+        tauriHandler?.(theme);
+      },
+      get handler() {
+        return tauriHandler;
       },
     };
   }
@@ -280,5 +304,63 @@ describe("hooks/useTheme", () => {
     expect(result.current.theme).toBe("dark");
     expect(result.current.resolvedTheme).toBe("dark");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("reacts to Tauri theme change events while in system mode", async () => {
+    const media = mockMatchMediaWithChangeListener(false);
+    const tauri = mockTauriThemeListener();
+    const { useTheme } = await importFreshUseTheme();
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe("system");
+    expect(result.current.resolvedTheme).toBe("light");
+
+    // Check that the listener was registered
+    expect(mockTauriListen).toHaveBeenCalled();
+
+    // Fire Tauri theme change event
+    act(() => {
+      tauri.handler?.("dark");
+    });
+
+    expect(result.current.theme).toBe("system");
+    expect(result.current.resolvedTheme).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    media.restore();
+  });
+
+  it("ignores Tauri theme change events after switching to an explicit theme", async () => {
+    mockTauriListen.mockClear();
+    const media = mockMatchMediaWithChangeListener(false);
+    const tauri = mockTauriThemeListener();
+    const { useTheme } = await importFreshUseTheme();
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setTheme("dark");
+    });
+
+    expect(result.current.theme).toBe("dark");
+    expect(result.current.resolvedTheme).toBe("dark");
+
+    act(() => {
+      tauri.fireTauriThemeChange("light");
+    });
+
+    expect(result.current.theme).toBe("dark");
+    expect(result.current.resolvedTheme).toBe("dark");
+
+    media.restore();
+  });
+
+  it("handles Tauri listen failure gracefully", async () => {
+    mockTauriListen.mockRejectedValueOnce(new Error("Tauri not available"));
+
+    const { useTheme } = await importFreshUseTheme();
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe("system");
+    expect(result.current.resolvedTheme).toBe("light");
   });
 });

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -317,6 +317,7 @@ describe("hooks/useTheme", () => {
 
     // Check that the listener was registered
     expect(mockTauriListen).toHaveBeenCalled();
+    vi.mocked(setDesktopWindowTheme).mockClear();
 
     // Fire Tauri theme change event
     act(() => {
@@ -326,6 +327,8 @@ describe("hooks/useTheme", () => {
     expect(result.current.theme).toBe("system");
     expect(result.current.resolvedTheme).toBe("dark");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(setDesktopWindowTheme).toHaveBeenCalledTimes(1);
+    expect(setDesktopWindowTheme).toHaveBeenLastCalledWith("system");
 
     media.restore();
   });

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,5 +1,6 @@
 import { useCallback, useSyncExternalStore } from "react";
 import { setDesktopWindowTheme } from "../services/desktop/window";
+import { listenThemeChanged } from "../services/desktop/themeEvent";
 
 type Theme = "light" | "dark" | "system";
 
@@ -112,29 +113,53 @@ function setThemeInternal(next: Theme) {
 // System theme media query listener (singleton, always active)
 // ---------------------------------------------------------------------------
 
+function handleSystemThemeChange() {
+  if (currentSnapshot.theme !== "system") return;
+  applyTheme("system");
+  const newResolved = getSystemTheme();
+  if (currentSnapshot.resolvedTheme !== newResolved) {
+    currentSnapshot = { ...currentSnapshot, resolvedTheme: newResolved };
+    emitChange();
+  }
+}
+
 if (canUseWindow() && typeof window.matchMedia === "function") {
   try {
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const handleThemeChange = () => {
-      // Only react when the user preference is "system"
-      if (currentSnapshot.theme !== "system") return;
-      applyTheme("system");
-      const newResolved = getSystemTheme();
-      if (currentSnapshot.resolvedTheme !== newResolved) {
-        currentSnapshot = { ...currentSnapshot, resolvedTheme: newResolved };
-        emitChange();
-      }
-    };
-
     if (typeof mq.addEventListener === "function") {
-      mq.addEventListener("change", handleThemeChange);
+      mq.addEventListener("change", handleSystemThemeChange);
     } else if (typeof mq.addListener === "function") {
-      mq.addListener(handleThemeChange);
+      mq.addListener(handleSystemThemeChange);
     }
   } catch {}
 }
 
+// ---------------------------------------------------------------------------
+// Tauri native theme change listener (Windows WebView2 fix)
+// ---------------------------------------------------------------------------
+
+/**
+ * Listen for Tauri native theme change events.
+ * This is more reliable than matchMedia on Windows (WebView2).
+ */
+function setupTauriThemeListener() {
+  listenThemeChanged((theme) => {
+    if (currentSnapshot.theme !== "system") return;
+    if (currentSnapshot.resolvedTheme !== theme) {
+      currentSnapshot = { ...currentSnapshot, resolvedTheme: theme };
+      emitChange();
+      // Sync DOM class for the new resolved theme
+      if (typeof document !== "undefined") {
+        document.documentElement.classList.toggle("dark", theme === "dark");
+      }
+    }
+  }).catch(() => {
+    // Tauri event listener is best-effort; ignore failures
+  });
+}
+
 if (canUseWindow()) {
+  setupTauriThemeListener();
   // Apply theme on module load to ensure DOM is in sync
   applyTheme(currentSnapshot.theme);
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -148,6 +148,7 @@ function setupTauriThemeListener() {
     if (currentSnapshot.resolvedTheme !== theme) {
       currentSnapshot = { ...currentSnapshot, resolvedTheme: theme };
       emitChange();
+      syncNativeTheme("system");
       // Sync DOM class for the new resolved theme
       if (typeof document !== "undefined") {
         document.documentElement.classList.toggle("dark", theme === "dark");

--- a/src/services/__tests__/desktopBridge.contract.test.ts
+++ b/src/services/__tests__/desktopBridge.contract.test.ts
@@ -7,12 +7,10 @@ const allowedRawTauriImportFiles = new Set([
   "services/desktop/event.ts",
   "services/desktop/updater.ts",
   "services/tauriInvoke.ts",
+  "services/desktop/themeEvent.ts",
 ]);
 
-const allowedRawInvokeFiles = new Set([
-  "services/tauriInvoke.ts",
-  "services/desktop/updater.ts",
-]);
+const allowedRawInvokeFiles = new Set(["services/tauriInvoke.ts", "services/desktop/updater.ts"]);
 
 const rawTauriImportPattern =
   /from\s+["']@tauri-apps\/(?:api|plugin)[^"']*["']|import\s*\(\s*["']@tauri-apps\/(?:api|plugin)[^"']*["']\s*\)/;

--- a/src/services/desktop/themeEvent.ts
+++ b/src/services/desktop/themeEvent.ts
@@ -1,0 +1,16 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export type TauriTheme = "light" | "dark";
+
+/**
+ * Listen for Tauri native theme change events.
+ * The payload is the theme string directly ("light" | "dark"), per Tauri 2's
+ * `onThemeChanged` contract — not wrapped in an object.
+ */
+export async function listenThemeChanged(
+  handler: (theme: TauriTheme) => void | Promise<void>
+): Promise<() => void> {
+  return await getCurrentWindow().onThemeChanged(({ payload }) => {
+    handler(payload as TauriTheme);
+  });
+}


### PR DESCRIPTION
## Summary
- WebView2 上 `prefers-color-scheme` 媒体查询不会随 Windows 系统主题实时更新，导致用户切换系统主题时 AIO 界面不跟随
- 新增 Tauri `getCurrentWindow().onThemeChanged` 作为补充监听源；与现有 `matchMedia` 形成双保险
- 仅在用户主题偏好为 `system` 时响应，显式 light/dark 选择不受影响

## Changes
- 新增 `src/services/desktop/themeEvent.ts`：封装 Tauri 主题变化事件，payload 为 `"light" | "dark"` 字符串（符合 Tauri 2 `onThemeChanged` 契约）
- `src/hooks/useTheme.ts`：注册模块级 Tauri 主题监听；handler 直接收 theme 字符串
- `src/services/__tests__/desktopBridge.contract.test.ts`：将 `themeEvent.ts` 加入允许直接使用 `@tauri-apps/*` 的白名单
- `src/hooks/__tests__/useTheme.test.ts`：新增 3 个 Tauri 事件相关用例

## Test plan
- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（0 errors，涉及文件无新增 warnings）
- [x] `vitest run` 涉及的测试文件 20/20 通过
- [ ] 手动验收：Windows 下切换系统深浅色，AIO 跟随变化