### PR TITLE
feat(ui): 首页个性化布局新增今日供应商用量总览

### DIFF
--- a/src/components/home/HomeCliRouteStrategyControl.tsx
+++ b/src/components/home/HomeCliRouteStrategyControl.tsx
@@ -1,0 +1,75 @@
+import type { CliKey } from "../../services/providers/providers";
+import type { SortModeSummary } from "../../services/providers/sortModes";
+import { Select } from "../../ui/Select";
+import { cn } from "../../utils/cn";
+
+function measureLabelUnits(label: string) {
+  let units = 0;
+  for (const char of label) {
+    units += /[\u0000-\u00ff]/.test(char) ? 1 : 2;
+  }
+  return units;
+}
+
+export type HomeCliRouteStrategyControlProps = {
+  cliKey: CliKey;
+  cliLabel: string;
+  sortModes: SortModeSummary[];
+  sortModesLoading: boolean;
+  sortModesAvailable: boolean | null;
+  activeModeByCli: Record<CliKey, number | null>;
+  activeModeToggling: Record<CliKey, boolean>;
+  onSetCliActiveMode: (cliKey: CliKey, modeId: number | null) => void;
+  orientation?: "horizontal" | "vertical";
+  className?: string;
+  selectClassName?: string;
+};
+
+export function HomeCliRouteStrategyControl({
+  cliKey,
+  cliLabel,
+  sortModes,
+  sortModesLoading,
+  sortModesAvailable,
+  activeModeByCli,
+  activeModeToggling,
+  onSetCliActiveMode,
+  orientation = "horizontal",
+  className,
+  selectClassName,
+}: HomeCliRouteStrategyControlProps) {
+  const vertical = orientation === "vertical";
+  const selectedModeValue = String(activeModeByCli[cliKey] ?? "");
+  const sortModeSelectDisabled =
+    sortModesLoading || sortModesAvailable === false || activeModeToggling[cliKey];
+  const selectWidthCh =
+    Math.max(8, ...["Default", ...sortModes.map((mode) => mode.name)].map(measureLabelUnits)) + 4;
+
+  return (
+    <div className={cn("flex min-w-0 shrink-0 items-center", className)}>
+      <Select
+        value={selectedModeValue}
+        onChange={(event) => {
+          const nextValue = event.currentTarget.value;
+          onSetCliActiveMode(cliKey, nextValue === "" ? null : Number(nextValue));
+        }}
+        disabled={sortModeSelectDisabled}
+        className={cn(
+          vertical
+            ? "h-6 max-w-full border-slate-200 bg-white px-2 pr-5 text-[12px] dark:border-slate-600 dark:bg-slate-900"
+            : "h-7 max-w-full flex-none border-slate-200 bg-white px-2 pr-6 text-sm dark:border-slate-600 dark:bg-slate-900",
+          selectClassName
+        )}
+        style={{ width: `${selectWidthCh}ch`, maxWidth: "100%" }}
+        aria-label={`${cliLabel} 路由策略`}
+      >
+        <option value="">Default</option>
+        {sortModes.map((mode) => (
+          <option key={mode.id} value={String(mode.id)}>
+            {mode.name}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}

--- a/src/components/home/HomeOAuthQuotaPanel.tsx
+++ b/src/components/home/HomeOAuthQuotaPanel.tsx
@@ -177,6 +177,7 @@ export function HomeOAuthQuotaPanelContent({
             disabled={refreshing}
             className="rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-slate-700 dark:hover:text-indigo-400"
             title="刷新 OAuth 配额"
+            aria-label="刷新 OAuth 配额"
           >
             <RefreshCw className={cn("h-3.5 w-3.5", refreshing && "animate-spin")} />
           </button>

--- a/src/components/home/HomeOAuthQuotaPanel.tsx
+++ b/src/components/home/HomeOAuthQuotaPanel.tsx
@@ -1,0 +1,228 @@
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { cliBadgeTone, cliShortLabel } from "../../constants/clis";
+import { useNowUnix } from "../../hooks/useNowUnix";
+import { Card } from "../../ui/Card";
+import { EmptyState } from "../../ui/EmptyState";
+import { Spinner } from "../../ui/Spinner";
+import { cn } from "../../utils/cn";
+import { hasHomeOAuthQuotaText, type HomeOAuthQuotaRow } from "./homeOAuthQuotaTypes";
+
+export type HomeOAuthQuotaPanelContentProps = {
+  rows: HomeOAuthQuotaRow[];
+  hasProviders: boolean;
+  hasRefreshed: boolean;
+  refreshing: boolean;
+  onRefresh?: () => void;
+  onRefreshRow?: (providerId: number) => void;
+};
+
+type HomeOAuthQuotaPanelProps = HomeOAuthQuotaPanelContentProps & {
+  onRefresh: () => void;
+};
+
+function formatCompactResetText(resetAt: number | null, nowUnix: number): string | null {
+  if (resetAt == null) return null;
+  const remaining = resetAt - nowUnix;
+  if (remaining <= 0) return "已重置";
+  const totalMinutes = Math.floor(remaining / 60);
+  if (totalMinutes < 1) return "<1m";
+
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) {
+    const dayPart = `${days}d`;
+    const hourPart = hours > 0 ? `${hours}h` : "";
+    const minutePart = minutes > 0 ? `${minutes}m` : "";
+    return `${dayPart}${hourPart}${minutePart}`;
+  }
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h${minutes}m` : `${hours}h`;
+  }
+
+  return `${minutes}m`;
+}
+
+function buildQuotaSegment(
+  label: string,
+  quotaText: string | null,
+  resetText: string | null
+): string | null {
+  if (!quotaText) return null;
+  return resetText ? `${label}: ${quotaText}·${resetText}` : `${label}: ${quotaText}`;
+}
+
+function OAuthQuotaProviderCard({
+  row,
+  onRefreshRow,
+}: {
+  row: HomeOAuthQuotaRow;
+  onRefreshRow?: (providerId: number) => void;
+}) {
+  const shouldTrackNowUnix =
+    row.state === "success" &&
+    (row.limits?.limit_5h_reset_at != null || row.limits?.limit_weekly_reset_at != null);
+  const nowUnix = useNowUnix(shouldTrackNowUnix);
+  const shortLabel = row.limits?.limit_short_label || "短窗";
+  const reset5h = formatCompactResetText(row.limits?.limit_5h_reset_at ?? null, nowUnix);
+  const resetWeekly = formatCompactResetText(row.limits?.limit_weekly_reset_at ?? null, nowUnix);
+  const quotaSummary = [
+    buildQuotaSegment(shortLabel, row.limits?.limit_5h_text ?? null, reset5h),
+    buildQuotaSegment("7d", row.limits?.limit_weekly_text ?? null, resetWeekly),
+  ]
+    .filter((segment): segment is string => Boolean(segment))
+    .join(" / ");
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-3 py-2.5 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2 text-xs text-slate-700 dark:text-slate-300">
+            <span
+              className={cn(
+                "shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium",
+                cliBadgeTone(row.cliKey)
+              )}
+            >
+              {cliShortLabel(row.cliKey)}
+            </span>
+            <span className="truncate font-medium">{row.providerName}</span>
+          </div>
+
+          <div className="flex items-center gap-1">
+            {!row.enabled ? (
+              <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-500 dark:bg-slate-700 dark:text-slate-400">
+                已禁用
+              </span>
+            ) : null}
+            {row.state === "error" ? (
+              <span className="rounded-full bg-rose-50 px-1.5 py-0.5 text-[10px] text-rose-700 dark:bg-rose-900/30 dark:text-rose-400">
+                刷新失败
+              </span>
+            ) : null}
+            {onRefreshRow ? (
+              <button
+                type="button"
+                onClick={() => onRefreshRow(row.providerId)}
+                disabled={row.state === "loading"}
+                className="rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-slate-700 dark:hover:text-indigo-400"
+                title={`刷新 ${row.providerName} OAuth 配额`}
+                aria-label={`刷新 ${row.providerName} OAuth 配额`}
+              >
+                <RefreshCw
+                  className={cn("h-3.5 w-3.5", row.state === "loading" && "animate-spin")}
+                />
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        {row.state === "loading" ? (
+          <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+            <Spinner size="sm" />
+            刷新中...
+          </div>
+        ) : row.state === "error" ? (
+          <div className="flex items-start gap-2 text-xs text-rose-600 dark:text-rose-400">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>刷新失败，请重试</span>
+          </div>
+        ) : row.state === "idle" ? (
+          <div className="text-xs text-slate-500 dark:text-slate-400">
+            点击右上角刷新获取 OAuth 配额
+          </div>
+        ) : !hasHomeOAuthQuotaText(row.limits) ? (
+          <div className="text-xs text-slate-500 dark:text-slate-400">暂无 OAuth 配额信息</div>
+        ) : (
+          <div className="text-xs text-slate-600 dark:text-slate-400">
+            <span className="font-mono" title={quotaSummary}>
+              {quotaSummary}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function HomeOAuthQuotaPanelContent({
+  rows,
+  hasProviders,
+  hasRefreshed,
+  refreshing,
+  onRefresh,
+  onRefreshRow,
+}: HomeOAuthQuotaPanelContentProps) {
+  const showNoQuotaNotice =
+    hasRefreshed &&
+    rows.length > 0 &&
+    rows.every((row) => row.state === "success" && !hasHomeOAuthQuotaText(row.limits));
+
+  if (!hasProviders) {
+    return <EmptyState title="当前没有 OAuth 供应商" />;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-2">
+      <div className="flex items-center justify-between shrink-0">
+        <span className="text-xs text-slate-400 dark:text-slate-500">
+          {rows.length} 个 OAuth 供应商
+        </span>
+        {onRefresh ? (
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={refreshing}
+            className="rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-slate-700 dark:hover:text-indigo-400"
+            title="刷新 OAuth 配额"
+          >
+            <RefreshCw className={cn("h-3.5 w-3.5", refreshing && "animate-spin")} />
+          </button>
+        ) : null}
+      </div>
+
+      <>
+        {showNoQuotaNotice ? (
+          <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50/80 px-3 py-2 text-xs text-slate-500 dark:border-slate-700 dark:bg-slate-800/40 dark:text-slate-400">
+            当前暂无 OAuth 配额信息
+          </div>
+        ) : null}
+
+        <div className="min-h-0 flex-1 space-y-2 overflow-auto pr-1 scrollbar-overlay">
+          {rows.map((row) => (
+            <OAuthQuotaProviderCard
+              key={`${row.cliKey}:${row.providerId}`}
+              row={row}
+              onRefreshRow={onRefreshRow}
+            />
+          ))}
+        </div>
+      </>
+    </div>
+  );
+}
+
+export function HomeOAuthQuotaPanel({
+  rows,
+  hasProviders,
+  hasRefreshed,
+  refreshing,
+  onRefresh,
+  onRefreshRow,
+}: HomeOAuthQuotaPanelProps) {
+  return (
+    <Card padding="sm" className="flex h-full flex-col">
+      <div className="mb-3 text-sm font-semibold">OAuth 配额</div>
+      <HomeOAuthQuotaPanelContent
+        rows={rows}
+        hasProviders={hasProviders}
+        hasRefreshed={hasRefreshed}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        onRefreshRow={onRefreshRow}
+      />
+    </Card>
+  );
+}

--- a/src/components/home/HomeOverviewPanel.tsx
+++ b/src/components/home/HomeOverviewPanel.tsx
@@ -27,6 +27,7 @@ import { TabList } from "../../ui/TabList";
 import { formatCountdownSeconds } from "../../utils/formatters";
 import { CliBrandIcon } from "./CliBrandIcon";
 import { HomeCliRouteStrategyControl } from "./HomeCliRouteStrategyControl";
+import type { HomeOAuthQuotaRow } from "./homeOAuthQuotaTypes";
 import { HomeRequestLogsPanel } from "./HomeRequestLogsPanel";
 import { HomeTodayProviderUsageOverview } from "./HomeTodayProviderUsageOverview";
 import { HomeUsageSection } from "./HomeUsageSection";
@@ -41,6 +42,10 @@ const LazyHomeActiveSessionsCardContent = lazy(() =>
 
 const LazyHomeProviderLimitPanelContent = lazy(() =>
   import("./HomeProviderLimitPanel").then((m) => ({ default: m.HomeProviderLimitPanelContent }))
+);
+
+const LazyHomeOAuthQuotaPanelContent = lazy(() =>
+  import("./HomeOAuthQuotaPanel").then((m) => ({ default: m.HomeOAuthQuotaPanelContent }))
 );
 
 const LazyHomeWorkspaceConfigPanel = lazy(() =>
@@ -179,6 +184,66 @@ const PREVIEW_PROVIDER_LIMIT_ROWS: ProviderLimitUsageRow[] = [
   },
 ];
 
+const PREVIEW_OAUTH_QUOTA_ROWS: HomeOAuthQuotaRow[] = [
+  {
+    providerId: 301,
+    cliKey: "claude",
+    providerName: "Claude OAuth 主账号",
+    enabled: true,
+    state: "success",
+    limits: {
+      limit_short_label: "5h",
+      limit_5h_text: "29%",
+      limit_weekly_text: "83%",
+      limit_5h_reset_at: Math.floor(Date.now() / 1000) + 2 * 3600 + 34 * 60,
+      limit_weekly_reset_at: Math.floor(Date.now() / 1000) + 3 * 86400 + 2 * 3600 + 29 * 60,
+    },
+    error: null,
+  },
+  {
+    providerId: 302,
+    cliKey: "codex",
+    providerName: "Codex OAuth 空数据",
+    enabled: true,
+    state: "success",
+    limits: {
+      limit_short_label: "5h",
+      limit_5h_text: null,
+      limit_weekly_text: null,
+      limit_5h_reset_at: null,
+      limit_weekly_reset_at: null,
+    },
+    error: null,
+  },
+  {
+    providerId: 303,
+    cliKey: "gemini",
+    providerName: "Gemini OAuth 未刷新",
+    enabled: true,
+    state: "idle",
+    limits: null,
+    error: null,
+  },
+  {
+    providerId: 304,
+    cliKey: "codex",
+    providerName: "Codex OAuth 刷新失败",
+    enabled: true,
+    state: "error",
+    limits: null,
+    error: "preview error",
+  },
+  {
+    providerId: 305,
+    cliKey: "gemini",
+    providerName: "Gemini OAuth 已禁用",
+    enabled: false,
+    state: "loading",
+    limits: null,
+    error: null,
+  },
+];
+
 function didKeysChange(current: string[], previous: string[]) {
   return (
     current.length !== previous.length || current.some((key, index) => key !== previous[index])
@@ -232,6 +297,12 @@ export type HomeOverviewPanelProps = {
   providerLimitAvailable: boolean | null;
   providerLimitRefreshing: boolean;
   onRefreshProviderLimit: () => void;
+  oauthQuotaRows: HomeOAuthQuotaRow[];
+  oauthQuotaVisible: boolean;
+  oauthQuotaRefreshing: boolean;
+  oauthQuotaHasRefreshed: boolean;
+  onRefreshOAuthQuota: () => Promise<void>;
+  onRefreshOAuthQuotaRow: (providerId: number) => Promise<void>;
 
   openCircuits: OpenCircuitRow[];
   onResetCircuitProvider: (providerId: number) => void;
@@ -325,6 +396,12 @@ export function HomeOverviewPanel({
   providerLimitAvailable,
   providerLimitRefreshing,
   onRefreshProviderLimit,
+  oauthQuotaRows,
+  oauthQuotaVisible,
+  oauthQuotaRefreshing,
+  oauthQuotaHasRefreshed,
+  onRefreshOAuthQuota,
+  onRefreshOAuthQuotaRow,
   openCircuits,
   onResetCircuitProvider,
   resettingCircuitProviderIds,
@@ -357,6 +434,13 @@ export function HomeOverviewPanel({
     devPreviewEnabled && providerLimitRows.length === 0
       ? PREVIEW_PROVIDER_LIMIT_ROWS
       : providerLimitRows;
+  const oauthQuotaPreviewActive = devPreviewEnabled;
+  const displayedOAuthQuotaRows = oauthQuotaPreviewActive
+    ? PREVIEW_OAUTH_QUOTA_ROWS
+    : oauthQuotaRows;
+  const displayedOAuthQuotaVisible = oauthQuotaPreviewActive || oauthQuotaVisible;
+  const displayedOAuthQuotaHasRefreshed = oauthQuotaPreviewActive ? true : oauthQuotaHasRefreshed;
+  const displayedOAuthQuotaRefreshing = oauthQuotaPreviewActive ? false : oauthQuotaRefreshing;
   const displayedWorkspaceConfigs = useMemo(() => {
     let nextConfigs: HomeCliWorkspaceConfig[];
     if (workspaceConfigs.length === 0) {
@@ -401,19 +485,19 @@ export function HomeOverviewPanel({
     const labelByKey = new Map(HOME_OVERVIEW_TABS.map((item) => [item.key, item.label]));
     return sessionsTabsOrder.map((key) => ({ key, label: labelByKey.get(key) ?? key }));
   }, [sessionsTabsOrder]);
-  const showLogsPrimaryProviderLimitTab =
-    providerLimitLoading ||
-    providerLimitAvailable === false ||
-    displayedProviderLimitRows.length > 0;
+  const legacySessionsTabs = useMemo(
+    () => sessionsTabs.filter((item) => item.key !== "oauthQuota"),
+    [sessionsTabs]
+  );
   const logsPrimaryTabs = useMemo(
     () =>
       sessionsTabs.filter(
         (item) =>
           item.key === "workspaceConfig" ||
           item.key === "circuit" ||
-          (item.key === "providerLimit" && showLogsPrimaryProviderLimitTab)
+          (item.key === "oauthQuota" && displayedOAuthQuotaVisible)
       ),
-    [sessionsTabs, showLogsPrimaryProviderLimitTab]
+    [displayedOAuthQuotaVisible, sessionsTabs]
   );
 
   const openCircuitKeys = useMemo(
@@ -477,19 +561,10 @@ export function HomeOverviewPanel({
   }, [openCircuitKeys]);
 
   useEffect(() => {
-    if (!logsPrimaryLayout) return;
-    if (sessionsTab === "providerLimit" && !showLogsPrimaryProviderLimitTab) {
-      setSessionsTab("workspaceConfig");
-      return;
-    }
-    if (
-      sessionsTab === "workspaceConfig" ||
-      sessionsTab === "circuit" ||
-      (sessionsTab === "providerLimit" && showLogsPrimaryProviderLimitTab)
-    )
-      return;
+    const visibleTabs = logsPrimaryLayout ? logsPrimaryTabs : legacySessionsTabs;
+    if (visibleTabs.some((tab) => tab.key === sessionsTab)) return;
     setSessionsTab("workspaceConfig");
-  }, [logsPrimaryLayout, sessionsTab, showLogsPrimaryProviderLimitTab]);
+  }, [legacySessionsTabs, logsPrimaryLayout, logsPrimaryTabs, sessionsTab]);
 
   const requestLogsPanel = (
     <HomeRequestLogsPanel
@@ -516,8 +591,12 @@ export function HomeOverviewPanel({
       <div className="shrink-0">
         <TabList
           ariaLabel="概览状态切换"
-          items={sessionsTabs}
-          value={sessionsTab}
+          items={legacySessionsTabs}
+          value={
+            legacySessionsTabs.some((item) => item.key === sessionsTab)
+              ? sessionsTab
+              : "workspaceConfig"
+          }
           onChange={setSessionsTab}
           size="sm"
           className="w-full overflow-x-auto"
@@ -553,6 +632,8 @@ export function HomeOverviewPanel({
               refreshing={providerLimitRefreshing}
             />
           </Suspense>
+        ) : sessionsTab === "oauthQuota" ? (
+          <div />
         ) : displayedCircuits.length === 0 ? (
           <EmptyState title="当前没有熔断中的 Provider" />
         ) : (
@@ -632,8 +713,7 @@ export function HomeOverviewPanel({
           ariaLabel="新布局信息切换"
           items={logsPrimaryTabs}
           value={
-            sessionsTab === "circuit" ||
-            (sessionsTab === "providerLimit" && showLogsPrimaryProviderLimitTab)
+            logsPrimaryTabs.some((item) => item.key === sessionsTab)
               ? sessionsTab
               : "workspaceConfig"
           }
@@ -695,14 +775,21 @@ export function HomeOverviewPanel({
               </div>
             </div>
           )
-        ) : sessionsTab === "providerLimit" ? (
+        ) : sessionsTab === "oauthQuota" ? (
           <Suspense fallback={<OverviewPanelFallback />}>
-            <LazyHomeProviderLimitPanelContent
-              rows={displayedProviderLimitRows}
-              loading={providerLimitLoading}
-              available={providerLimitAvailable}
-              onRefresh={onRefreshProviderLimit}
-              refreshing={providerLimitRefreshing}
+            <LazyHomeOAuthQuotaPanelContent
+              rows={displayedOAuthQuotaRows}
+              hasProviders={displayedOAuthQuotaVisible}
+              hasRefreshed={displayedOAuthQuotaHasRefreshed}
+              refreshing={displayedOAuthQuotaRefreshing}
+              onRefresh={() => {
+                if (oauthQuotaPreviewActive) return;
+                void onRefreshOAuthQuota();
+              }}
+              onRefreshRow={(providerId) => {
+                if (oauthQuotaPreviewActive) return;
+                void onRefreshOAuthQuotaRow(providerId);
+              }}
             />
           </Suspense>
         ) : (

--- a/src/components/home/HomeOverviewPanel.tsx
+++ b/src/components/home/HomeOverviewPanel.tsx
@@ -747,6 +747,7 @@ export function HomeOverviewPanel({
                 <HomeTodayProviderUsageOverview
                   devPreviewEnabled={devPreviewEnabled}
                   activeSessions={displayedActiveSessions}
+                  traces={traces}
                 />
               ) : (
                 <HomeUsageSection

--- a/src/components/home/HomeOverviewPanel.tsx
+++ b/src/components/home/HomeOverviewPanel.tsx
@@ -632,9 +632,7 @@ export function HomeOverviewPanel({
               refreshing={providerLimitRefreshing}
             />
           </Suspense>
-        ) : sessionsTab === "oauthQuota" ? (
-          <div />
-        ) : displayedCircuits.length === 0 ? (
+        ) : sessionsTab === "oauthQuota" ? null : displayedCircuits.length === 0 ? (
           <EmptyState title="当前没有熔断中的 Provider" />
         ) : (
           <div className="h-full overflow-y-auto pr-1">

--- a/src/components/home/HomeOverviewPanel.tsx
+++ b/src/components/home/HomeOverviewPanel.tsx
@@ -26,6 +26,7 @@ import { Spinner } from "../../ui/Spinner";
 import { TabList } from "../../ui/TabList";
 import { formatCountdownSeconds } from "../../utils/formatters";
 import { CliBrandIcon } from "./CliBrandIcon";
+import { HomeCliRouteStrategyControl } from "./HomeCliRouteStrategyControl";
 import { HomeRequestLogsPanel } from "./HomeRequestLogsPanel";
 import { HomeTodayProviderUsageOverview } from "./HomeTodayProviderUsageOverview";
 import { HomeUsageSection } from "./HomeUsageSection";
@@ -400,9 +401,19 @@ export function HomeOverviewPanel({
     const labelByKey = new Map(HOME_OVERVIEW_TABS.map((item) => [item.key, item.label]));
     return sessionsTabsOrder.map((key) => ({ key, label: labelByKey.get(key) ?? key }));
   }, [sessionsTabsOrder]);
+  const showLogsPrimaryProviderLimitTab =
+    providerLimitLoading ||
+    providerLimitAvailable === false ||
+    displayedProviderLimitRows.length > 0;
   const logsPrimaryTabs = useMemo(
-    () => sessionsTabs.filter((item) => item.key === "workspaceConfig" || item.key === "circuit"),
-    [sessionsTabs]
+    () =>
+      sessionsTabs.filter(
+        (item) =>
+          item.key === "workspaceConfig" ||
+          item.key === "circuit" ||
+          (item.key === "providerLimit" && showLogsPrimaryProviderLimitTab)
+      ),
+    [sessionsTabs, showLogsPrimaryProviderLimitTab]
   );
 
   const openCircuitKeys = useMemo(
@@ -421,6 +432,28 @@ export function HomeOverviewPanel({
   }, [displayedWorkspaceConfigs, selectedWorkspaceConfigCliKey]);
   const effectiveSelectedWorkspaceConfigCliKey =
     selectedWorkspaceConfigCliKey ?? displayedWorkspaceConfigs[0]?.cliKey ?? null;
+  const effectiveSelectedWorkspaceConfig = useMemo(
+    () =>
+      displayedWorkspaceConfigs.find(
+        (config) => config.cliKey === effectiveSelectedWorkspaceConfigCliKey
+      ) ??
+      displayedWorkspaceConfigs[0] ??
+      null,
+    [displayedWorkspaceConfigs, effectiveSelectedWorkspaceConfigCliKey]
+  );
+  const legacyWorkspaceRouteStrategyControl = effectiveSelectedWorkspaceConfig ? (
+    <HomeCliRouteStrategyControl
+      cliKey={effectiveSelectedWorkspaceConfig.cliKey}
+      cliLabel={effectiveSelectedWorkspaceConfig.cliLabel}
+      sortModes={sortModes}
+      sortModesLoading={sortModesLoading}
+      sortModesAvailable={sortModesAvailable}
+      activeModeByCli={activeModeByCli}
+      activeModeToggling={activeModeToggling}
+      onSetCliActiveMode={onSetCliActiveMode}
+      orientation="horizontal"
+    />
+  ) : null;
 
   useEffect(() => {
     const previousOpenCircuitKeys = previousOpenCircuitKeysRef.current;
@@ -435,19 +468,28 @@ export function HomeOverviewPanel({
     previousOpenCircuitKeysRef.current = openCircuitKeys;
 
     if (openCircuitChanged) {
-      if (logsPrimaryLayout && openCircuitKeys.length === 0) {
+      if (openCircuitKeys.length === 0) {
         setSessionsTab("workspaceConfig");
       } else {
         setSessionsTab("circuit");
       }
     }
-  }, [logsPrimaryLayout, openCircuitKeys]);
+  }, [openCircuitKeys]);
 
   useEffect(() => {
     if (!logsPrimaryLayout) return;
-    if (sessionsTab === "workspaceConfig" || sessionsTab === "circuit") return;
+    if (sessionsTab === "providerLimit" && !showLogsPrimaryProviderLimitTab) {
+      setSessionsTab("workspaceConfig");
+      return;
+    }
+    if (
+      sessionsTab === "workspaceConfig" ||
+      sessionsTab === "circuit" ||
+      (sessionsTab === "providerLimit" && showLogsPrimaryProviderLimitTab)
+    )
+      return;
     setSessionsTab("workspaceConfig");
-  }, [logsPrimaryLayout, sessionsTab]);
+  }, [logsPrimaryLayout, sessionsTab, showLogsPrimaryProviderLimitTab]);
 
   const requestLogsPanel = (
     <HomeRequestLogsPanel
@@ -498,12 +540,7 @@ export function HomeOverviewPanel({
               configs={displayedWorkspaceConfigs}
               selectedCliKey={effectiveSelectedWorkspaceConfigCliKey}
               onSelectCliKey={setSelectedWorkspaceConfigCliKey}
-              sortModes={sortModes}
-              sortModesLoading={sortModesLoading}
-              sortModesAvailable={sortModesAvailable}
-              activeModeByCli={activeModeByCli}
-              activeModeToggling={activeModeToggling}
-              onSetCliActiveMode={onSetCliActiveMode}
+              headerAddon={legacyWorkspaceRouteStrategyControl}
             />
           </Suspense>
         ) : sessionsTab === "providerLimit" ? (
@@ -581,6 +618,12 @@ export function HomeOverviewPanel({
           cliProxyAppliedToCurrentGateway={cliProxyAppliedToCurrentGateway}
           cliProxyToggling={cliProxyToggling}
           onSetCliProxyEnabled={onSetCliProxyEnabled}
+          sortModes={sortModes}
+          sortModesLoading={sortModesLoading}
+          sortModesAvailable={sortModesAvailable}
+          activeModeByCli={activeModeByCli}
+          activeModeToggling={activeModeToggling}
+          onSetCliActiveMode={onSetCliActiveMode}
         />
       </div>
 
@@ -588,7 +631,12 @@ export function HomeOverviewPanel({
         <TabList
           ariaLabel="新布局信息切换"
           items={logsPrimaryTabs}
-          value={sessionsTab === "circuit" ? "circuit" : "workspaceConfig"}
+          value={
+            sessionsTab === "circuit" ||
+            (sessionsTab === "providerLimit" && showLogsPrimaryProviderLimitTab)
+              ? sessionsTab
+              : "workspaceConfig"
+          }
           onChange={(next) => setSessionsTab(next as HomeOverviewTabKey)}
           size="sm"
           className="w-full overflow-x-auto"
@@ -647,18 +695,22 @@ export function HomeOverviewPanel({
               </div>
             </div>
           )
+        ) : sessionsTab === "providerLimit" ? (
+          <Suspense fallback={<OverviewPanelFallback />}>
+            <LazyHomeProviderLimitPanelContent
+              rows={displayedProviderLimitRows}
+              loading={providerLimitLoading}
+              available={providerLimitAvailable}
+              onRefresh={onRefreshProviderLimit}
+              refreshing={providerLimitRefreshing}
+            />
+          </Suspense>
         ) : (
           <Suspense fallback={<OverviewPanelFallback />}>
             <LazyHomeWorkspaceConfigPanel
               configs={displayedWorkspaceConfigs}
               selectedCliKey={effectiveSelectedWorkspaceConfigCliKey}
               onSelectCliKey={setSelectedWorkspaceConfigCliKey}
-              sortModes={sortModes}
-              sortModesLoading={sortModesLoading}
-              sortModesAvailable={sortModesAvailable}
-              activeModeByCli={activeModeByCli}
-              activeModeToggling={activeModeToggling}
-              onSetCliActiveMode={onSetCliActiveMode}
             />
           </Suspense>
         )}

--- a/src/components/home/HomeOverviewPanel.tsx
+++ b/src/components/home/HomeOverviewPanel.tsx
@@ -27,9 +27,12 @@ import { TabList } from "../../ui/TabList";
 import { formatCountdownSeconds } from "../../utils/formatters";
 import { CliBrandIcon } from "./CliBrandIcon";
 import { HomeRequestLogsPanel } from "./HomeRequestLogsPanel";
+import { HomeTodayProviderUsageOverview } from "./HomeTodayProviderUsageOverview";
 import { HomeUsageSection } from "./HomeUsageSection";
 import { HomeWorkStatusCard } from "./HomeWorkStatusCard";
 import type { HomeCliWorkspaceConfig } from "./homeWorkspaceConfigTypes";
+
+export type HomeOverviewUsageView = "summary" | "usageChart";
 
 const LazyHomeActiveSessionsCardContent = lazy(() =>
   import("./HomeActiveSessionsCard").then((m) => ({ default: m.HomeActiveSessionsCardContent }))
@@ -243,6 +246,7 @@ export type HomeOverviewPanelProps = {
 
   selectedLogId: number | null;
   onSelectLogId: (id: number | null) => void;
+  personalizedUsageView: HomeOverviewUsageView;
 };
 
 const PREVIEW_WORKSPACE_CONFIGS: HomeCliWorkspaceConfig[] = [
@@ -331,6 +335,7 @@ export function HomeOverviewPanel({
   onRefreshRequestLogs,
   selectedLogId,
   onSelectLogId,
+  personalizedUsageView,
 }: HomeOverviewPanelProps) {
   const [sessionsTabsOrder] = useState<HomeOverviewTabKey[]>(() =>
     readHomeOverviewTabOrderFromStorage()
@@ -738,15 +743,22 @@ export function HomeOverviewPanel({
           <div className="flex min-h-0 lg:col-span-4">{logsPrimaryInfoPanel}</div>
           <div className="flex min-h-0 flex-col gap-4 lg:col-span-8">
             <div className="shrink-0">
-              <HomeUsageSection
-                devPreviewEnabled={devPreviewEnabled}
-                showHeatmap={false}
-                showUsageChart={true}
-                usageWindowDays={usageWindowDays}
-                usageHeatmapRows={usageHeatmapRows}
-                usageHeatmapLoading={usageHeatmapLoading}
-                onRefreshUsageHeatmap={onRefreshUsageHeatmap}
-              />
+              {personalizedUsageView === "summary" ? (
+                <HomeTodayProviderUsageOverview
+                  devPreviewEnabled={devPreviewEnabled}
+                  activeSessions={displayedActiveSessions}
+                />
+              ) : (
+                <HomeUsageSection
+                  devPreviewEnabled={devPreviewEnabled}
+                  showHeatmap={false}
+                  showUsageChart={true}
+                  usageWindowDays={usageWindowDays}
+                  usageHeatmapRows={usageHeatmapRows}
+                  usageHeatmapLoading={usageHeatmapLoading}
+                  onRefreshUsageHeatmap={onRefreshUsageHeatmap}
+                />
+              )}
             </div>
             <div className="min-h-0 flex-1">{requestLogsPanel}</div>
           </div>

--- a/src/components/home/HomeTodayProviderUsageOverview.tsx
+++ b/src/components/home/HomeTodayProviderUsageOverview.tsx
@@ -20,7 +20,6 @@ import {
 const SUMMARY_SKELETON_KEYS = [0, 1, 2, 3, 4];
 const PROVIDER_SKELETON_KEYS = [0, 1, 2];
 const MAX_PROVIDER_ROWS = 3;
-const PROVIDER_HEADER_LABEL = "供应商（前 3 个）";
 const LIVE_TRACE_MAX_AGE_MS = 15 * 60 * 1000;
 const STALE_TRACE_TIMEOUT_MS = 5 * 60 * 1000;
 const OVERVIEW_REFRESH_INTERVAL_MS = 60 * 1000;
@@ -29,6 +28,10 @@ const TABLE_TH_CLASS =
 const TABLE_TD_CLASS = "border-b border-slate-100 px-3 py-3 dark:border-slate-800";
 const TABLE_MONO_TD_CLASS =
   "border-b border-slate-100 px-3 py-3 font-mono text-xs tabular-nums text-slate-700 dark:border-slate-800 dark:text-slate-300";
+const TABLE_TH_MAIN_CLASS =
+  "text-[11px] font-medium tracking-normal text-slate-500 dark:text-slate-400";
+const TABLE_TH_NOTE_CLASS =
+  "text-[9px] font-normal tracking-normal text-slate-400 dark:text-slate-500";
 const TODAY_PROVIDER_QUERY_CONFIG = {
   period: "daily" as const,
   input: {
@@ -374,6 +377,21 @@ function rowTokenBreakdown(row: UsageLeaderboardRow) {
   ].join(" / ");
 }
 
+function rowBillableTokenBreakdown(row: UsageLeaderboardRow, summary: UsageSummary | null) {
+  return [formatTokenValue(row.io_total_tokens), formatPercent(tokenShare(row, summary))].join(
+    " / "
+  );
+}
+
+function TableHeaderLabel({ label, note }: { label: string; note?: string }) {
+  return (
+    <div className="inline-flex items-baseline gap-1 whitespace-nowrap normal-case">
+      <span className={TABLE_TH_MAIN_CLASS}>{label}</span>
+      {note ? <span className={TABLE_TH_NOTE_CLASS}>（{note}）</span> : null}
+    </div>
+  );
+}
+
 function SummaryMetricCard({
   title,
   value,
@@ -551,26 +569,19 @@ export function HomeTodayProviderUsageOverview({
               <thead>
                 <tr>
                   <th scope="col" className={TABLE_TH_CLASS}>
-                    {PROVIDER_HEADER_LABEL}
+                    <TableHeaderLabel label="供应商" note="前 3 个" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
-                    <div className="inline-flex items-center gap-1 whitespace-nowrap normal-case">
-                      <span className="text-[11px] font-medium tracking-normal text-slate-500 dark:text-slate-400">
-                        Token
-                      </span>
-                      <span className="text-[9px] font-normal tracking-normal text-slate-400 dark:text-slate-500">
-                        含缓存 / 缓存 / 命中率
-                      </span>
-                    </div>
+                    <TableHeaderLabel label="计费 Token" note="输入+输出" />
+                  </th>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    <TableHeaderLabel label="缓存情况" note="含缓存 / 缓存 / 命中率" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
                     总花费
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
                     成功率
-                  </th>
-                  <th scope="col" className={TABLE_TH_CLASS}>
-                    Token 占比
                   </th>
                 </tr>
               </thead>
@@ -592,26 +603,19 @@ export function HomeTodayProviderUsageOverview({
               <thead className="sticky top-0 z-10">
                 <tr>
                   <th scope="col" className={TABLE_TH_CLASS}>
-                    {PROVIDER_HEADER_LABEL}
+                    <TableHeaderLabel label="供应商" note="前 3 个" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
-                    <div className="inline-flex items-center gap-1 whitespace-nowrap normal-case">
-                      <span className="text-[11px] font-medium tracking-normal text-slate-500 dark:text-slate-400">
-                        Token
-                      </span>
-                      <span className="text-[9px] font-normal tracking-normal text-slate-400 dark:text-slate-500">
-                        含缓存 / 缓存 / 命中率
-                      </span>
-                    </div>
+                    <TableHeaderLabel label="计费 Token" note="输入+输出" />
+                  </th>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    <TableHeaderLabel label="缓存情况" note="含缓存 / 缓存 / 命中率" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
                     总花费
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
                     成功率
-                  </th>
-                  <th scope="col" className={TABLE_TH_CLASS}>
-                    Token 占比
                   </th>
                 </tr>
               </thead>
@@ -640,6 +644,9 @@ export function HomeTodayProviderUsageOverview({
                       </div>
                     </td>
                     <td className={TABLE_MONO_TD_CLASS}>
+                      {isSynthetic ? "— / —" : rowBillableTokenBreakdown(row, model.summary)}
+                    </td>
+                    <td className={TABLE_MONO_TD_CLASS}>
                       {isSynthetic ? "— / — / —" : rowTokenBreakdown(row)}
                     </td>
                     <td className={TABLE_MONO_TD_CLASS}>
@@ -647,9 +654,6 @@ export function HomeTodayProviderUsageOverview({
                     </td>
                     <td className={TABLE_MONO_TD_CLASS}>
                       {isSynthetic ? "—" : formatPercent(successRate(row))}
-                    </td>
-                    <td className={TABLE_MONO_TD_CLASS}>
-                      {isSynthetic ? "—" : formatPercent(tokenShare(row, model.summary))}
                     </td>
                   </tr>
                 ))}

--- a/src/components/home/HomeTodayProviderUsageOverview.tsx
+++ b/src/components/home/HomeTodayProviderUsageOverview.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import { Loader2 } from "lucide-react";
+import { useNowMs } from "../../hooks/useNowMs";
 import type { GatewayActiveSession } from "../../services/gateway/gateway";
+import type { TraceSession } from "../../services/gateway/traceStore";
 import type { UsageLeaderboardRow, UsageSummary } from "../../services/usage/usage";
 import { Card } from "../../ui/Card";
 import { computeCacheHitRate } from "../../utils/cacheRateMetrics";
@@ -14,6 +16,8 @@ const SUMMARY_SKELETON_KEYS = [0, 1, 2, 3, 4];
 const PROVIDER_SKELETON_KEYS = [0, 1, 2];
 const MAX_PROVIDER_ROWS = 3;
 const PROVIDER_HEADER_LABEL = "供应商（前 3 个）";
+const LIVE_TRACE_MAX_AGE_MS = 15 * 60 * 1000;
+const STALE_TRACE_TIMEOUT_MS = 5 * 60 * 1000;
 const TABLE_TH_CLASS =
   "border-b border-slate-200 bg-slate-50/70 px-3 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-400";
 const TABLE_TD_CLASS = "border-b border-slate-100 px-3 py-3 dark:border-slate-800";
@@ -55,6 +59,14 @@ type DisplayProviderRow = {
   isRunning: boolean;
   isSynthetic: boolean;
 };
+type ProviderIdentity = {
+  providerId: number | null;
+  cliKey: string | null;
+  normalizedName: string;
+};
+type ActiveProviderEntry = ProviderIdentity & {
+  displayName: string;
+};
 
 const SUMMARY_METRIC_ACCENT_CLASS: Record<SummaryMetricAccent, string> = {
   blue: "bg-blue-500",
@@ -74,8 +86,66 @@ function successRate(row: UsageLeaderboardRow) {
   return row.requests_success / row.requests_total;
 }
 
-function normalizeProviderName(name: string | null | undefined) {
-  return name?.trim().toLocaleLowerCase() ?? "";
+function normalizeCliKey(value: string | null | undefined) {
+  const normalized = value?.trim().toLocaleLowerCase() ?? "";
+  return normalized || null;
+}
+
+function normalizeProviderName(name: string | null | undefined, cliKey?: string | null) {
+  const normalized = name?.trim().toLocaleLowerCase() ?? "";
+  if (!normalized) return "";
+  const normalizedCliKey = normalizeCliKey(cliKey);
+  const prefix = normalizedCliKey ? `${normalizedCliKey}/` : null;
+  if (prefix && normalized.startsWith(prefix)) {
+    return normalized.slice(prefix.length).trim();
+  }
+  return normalized;
+}
+
+function parseProviderRowIdentity(row: UsageLeaderboardRow): ProviderIdentity {
+  const match = row.key.match(/^([^:]+):(\d+)$/);
+  const cliKey = normalizeCliKey(match?.[1] ?? null);
+  const providerId = match ? Number(match[2]) : NaN;
+
+  return {
+    providerId: Number.isSafeInteger(providerId) && providerId > 0 ? providerId : null,
+    cliKey,
+    normalizedName: normalizeProviderName(row.name, cliKey),
+  };
+}
+
+function activeProviderIdentity(session: GatewayActiveSession): ActiveProviderEntry {
+  const cliKey = normalizeCliKey(session.cli_key);
+  const providerId =
+    Number.isSafeInteger(session.provider_id) && session.provider_id > 0
+      ? session.provider_id
+      : null;
+
+  return {
+    providerId,
+    cliKey,
+    normalizedName: normalizeProviderName(session.provider_name, cliKey),
+    displayName: session.provider_name?.trim() || "未知",
+  };
+}
+
+function providerIdentityKey(identity: ProviderIdentity) {
+  if (identity.providerId != null) return `id:${identity.providerId}`;
+  if (identity.cliKey && identity.normalizedName) {
+    return `name:${identity.cliKey}:${identity.normalizedName}`;
+  }
+  return `name:${identity.normalizedName}`;
+}
+
+function formatSyntheticProviderName(
+  entry: ActiveProviderEntry,
+  options: { preferCliPrefix: boolean }
+) {
+  const rawName = entry.displayName.trim();
+  if (!rawName) return "未知";
+  if (!options.preferCliPrefix || !entry.cliKey) return rawName;
+  const prefix = `${entry.cliKey}/`;
+  return rawName.toLocaleLowerCase().startsWith(prefix) ? rawName : `${prefix}${rawName}`;
 }
 
 function sortProviderRows(rows: UsageLeaderboardRow[]) {
@@ -90,26 +160,80 @@ function sortProviderRows(rows: UsageLeaderboardRow[]) {
   });
 }
 
-function buildActiveProviderNames(activeSessions: GatewayActiveSession[]) {
+function buildActiveProviders(
+  activeSessions: GatewayActiveSession[],
+  options: { preferCliPrefix: boolean }
+) {
   const seen = new Set<string>();
-  const names: string[] = [];
+  const entries: ActiveProviderEntry[] = [];
 
   for (const session of activeSessions) {
-    const name = session.provider_name?.trim();
-    const normalized = normalizeProviderName(name);
-    if (!name || !normalized || seen.has(normalized)) continue;
-    seen.add(normalized);
-    names.push(name);
+    const identity = activeProviderIdentity(session);
+    const key = providerIdentityKey(identity);
+    if (!identity.normalizedName || seen.has(key)) continue;
+    seen.add(key);
+    entries.push({
+      ...identity,
+      displayName: formatSyntheticProviderName(identity, options),
+    });
   }
 
-  return names;
+  return entries;
 }
 
-function createSyntheticProviderRow(name: string): UsageLeaderboardRow {
-  const normalized = normalizeProviderName(name).replace(/\s+/g, "-");
+function buildRunningProvidersFromTraces(
+  traces: TraceSession[],
+  nowMs: number,
+  options: { preferCliPrefix: boolean }
+) {
+  const seen = new Set<string>();
+  const entries: ActiveProviderEntry[] = [];
+
+  for (const trace of traces) {
+    if (trace.summary) continue;
+    if (nowMs - trace.first_seen_ms >= LIVE_TRACE_MAX_AGE_MS) continue;
+    if (nowMs - trace.last_seen_ms >= STALE_TRACE_TIMEOUT_MS) continue;
+
+    const latestAttempt = (trace.attempts ?? [])
+      .slice()
+      .sort((left, right) => right.attempt_index - left.attempt_index)[0];
+    const providerName = latestAttempt?.provider_name?.trim();
+    if (!providerName || providerName === "Unknown") continue;
+
+    const cliKey = normalizeCliKey(trace.cli_key);
+    const providerId =
+      latestAttempt &&
+      Number.isSafeInteger(latestAttempt.provider_id) &&
+      latestAttempt.provider_id > 0
+        ? latestAttempt.provider_id
+        : null;
+    const entry: ActiveProviderEntry = {
+      providerId,
+      cliKey,
+      normalizedName: normalizeProviderName(providerName, cliKey),
+      displayName: providerName,
+    };
+    const key = providerIdentityKey(entry);
+    if (!entry.normalizedName || seen.has(key)) continue;
+
+    seen.add(key);
+    entries.push({
+      ...entry,
+      displayName: formatSyntheticProviderName(entry, options),
+    });
+  }
+
+  return entries;
+}
+
+function createSyntheticProviderRow(entry: ActiveProviderEntry): UsageLeaderboardRow {
+  const normalized = entry.normalizedName.replace(/\s+/g, "-");
   return {
-    key: `running:${normalized || "unknown"}`,
-    name,
+    key:
+      entry.providerId != null
+        ? `running:${entry.cliKey ?? "provider"}:${entry.providerId}`
+        : `running:${normalized || "unknown"}`,
+    name: entry.displayName,
     requests_total: 0,
     requests_success: 0,
     requests_failed: 0,
@@ -128,34 +252,69 @@ function createSyntheticProviderRow(name: string): UsageLeaderboardRow {
 
 function selectProviderRows(
   rows: UsageLeaderboardRow[],
-  activeSessions: GatewayActiveSession[]
+  activeProviders: ActiveProviderEntry[]
 ): DisplayProviderRow[] {
   const sortedRows = sortProviderRows(rows);
-  const activeProviderNames = buildActiveProviderNames(activeSessions);
-  const activeProviderSet = new Set(activeProviderNames.map((name) => normalizeProviderName(name)));
-  const rowByName = new Map(
-    sortedRows.map((row) => [normalizeProviderName(row.name), row] as const)
+  const rowIdentityByKey = new Map(
+    sortedRows.map((row) => [row.key, parseProviderRowIdentity(row)] as const)
   );
-  const rankByName = new Map(
-    sortedRows.map((row, index) => [normalizeProviderName(row.name), index] as const)
+  const activeProviderIdSet = new Set(
+    activeProviders
+      .map((entry) => entry.providerId)
+      .filter((providerId): providerId is number => providerId != null)
   );
+  const activeProviderNameSet = new Set(activeProviders.map((entry) => entry.normalizedName));
+  const activeProviderById = new Map(
+    activeProviders
+      .filter(
+        (entry): entry is ActiveProviderEntry & { providerId: number } => entry.providerId != null
+      )
+      .map((entry) => [entry.providerId, entry] as const)
+  );
+  const activeProviderByName = new Map(
+    activeProviders.map((entry) => [entry.normalizedName, entry] as const)
+  );
+  const rowById = new Map<number, UsageLeaderboardRow>();
+  const rowByName = new Map<string, UsageLeaderboardRow>();
+  const rankById = new Map<number, number>();
+  const rankByName = new Map<string, number>();
+
+  sortedRows.forEach((row, index) => {
+    const identity = rowIdentityByKey.get(row.key);
+    if (!identity) return;
+    if (identity.providerId != null && !rowById.has(identity.providerId)) {
+      rowById.set(identity.providerId, row);
+      rankById.set(identity.providerId, index);
+    }
+    if (identity.normalizedName && !rowByName.has(identity.normalizedName)) {
+      rowByName.set(identity.normalizedName, row);
+      rankByName.set(identity.normalizedName, index);
+    }
+  });
   const selected = new Map<string, DisplayProviderRow>();
 
   for (const row of sortedRows) {
-    const normalized = normalizeProviderName(row.name);
-    if (!activeProviderSet.has(normalized)) continue;
-    selected.set(normalized, { row, isRunning: true, isSynthetic: false });
+    const identity = rowIdentityByKey.get(row.key);
+    if (!identity) continue;
+    const matchedActive =
+      (identity.providerId != null ? activeProviderById.get(identity.providerId) : null) ??
+      activeProviderByName.get(identity.normalizedName);
+    if (!matchedActive) continue;
+    selected.set(providerIdentityKey(matchedActive), { row, isRunning: true, isSynthetic: false });
     if (selected.size >= MAX_PROVIDER_ROWS) break;
   }
 
   if (selected.size < MAX_PROVIDER_ROWS) {
-    for (const name of activeProviderNames) {
-      const normalized = normalizeProviderName(name);
-      if (!normalized || selected.has(normalized)) continue;
-      selected.set(normalized, {
-        row: rowByName.get(normalized) ?? createSyntheticProviderRow(name),
+    for (const entry of activeProviders) {
+      const key = providerIdentityKey(entry);
+      if (!entry.normalizedName || selected.has(key)) continue;
+      const matchedRow =
+        (entry.providerId != null ? rowById.get(entry.providerId) : null) ??
+        rowByName.get(entry.normalizedName);
+      selected.set(key, {
+        row: matchedRow ?? createSyntheticProviderRow(entry),
         isRunning: true,
-        isSynthetic: !rowByName.has(normalized),
+        isSynthetic: matchedRow == null,
       });
       if (selected.size >= MAX_PROVIDER_ROWS) break;
     }
@@ -163,18 +322,33 @@ function selectProviderRows(
 
   if (selected.size < MAX_PROVIDER_ROWS) {
     for (const row of sortedRows) {
-      const normalized = normalizeProviderName(row.name);
-      if (selected.has(normalized)) continue;
-      selected.set(normalized, { row, isRunning: false, isSynthetic: false });
+      const identity = rowIdentityByKey.get(row.key);
+      if (!identity) continue;
+      const key = providerIdentityKey(identity);
+      if (selected.has(key)) continue;
+      if (
+        (identity.providerId != null && activeProviderIdSet.has(identity.providerId)) ||
+        activeProviderNameSet.has(identity.normalizedName)
+      ) {
+        continue;
+      }
+      selected.set(key, { row, isRunning: false, isSynthetic: false });
       if (selected.size >= MAX_PROVIDER_ROWS) break;
     }
   }
 
   return Array.from(selected.values()).sort((left, right) => {
+    const leftIdentity = rowIdentityByKey.get(left.row.key) ?? parseProviderRowIdentity(left.row);
+    const rightIdentity =
+      rowIdentityByKey.get(right.row.key) ?? parseProviderRowIdentity(right.row);
     const leftRank =
-      rankByName.get(normalizeProviderName(left.row.name)) ?? Number.MAX_SAFE_INTEGER;
+      (leftIdentity.providerId != null ? rankById.get(leftIdentity.providerId) : undefined) ??
+      rankByName.get(leftIdentity.normalizedName) ??
+      Number.MAX_SAFE_INTEGER;
     const rightRank =
-      rankByName.get(normalizeProviderName(right.row.name)) ?? Number.MAX_SAFE_INTEGER;
+      (rightIdentity.providerId != null ? rankById.get(rightIdentity.providerId) : undefined) ??
+      rankByName.get(rightIdentity.normalizedName) ??
+      Number.MAX_SAFE_INTEGER;
     if (leftRank !== rightRank) return leftRank - rightRank;
     return left.row.name.localeCompare(right.row.name);
   });
@@ -294,19 +468,33 @@ function ProviderUsageSkeleton() {
 export function HomeTodayProviderUsageOverview({
   devPreviewEnabled = false,
   activeSessions = [],
+  traces,
 }: {
   devPreviewEnabled?: boolean;
   activeSessions?: GatewayActiveSession[];
+  traces?: TraceSession[];
 }) {
   const model = useHomeTokenCostDataModel({
     scope: "provider",
     queryConfig: TODAY_PROVIDER_QUERY_CONFIG,
     devPreviewEnabled,
   });
+  const nowMs = useNowMs(Boolean(traces && traces.length > 0), 250);
+  const activeProviders = useMemo(
+    () =>
+      traces != null
+        ? buildRunningProvidersFromTraces(traces, nowMs, {
+            preferCliPrefix: !model.previewActive,
+          })
+        : buildActiveProviders(activeSessions, {
+            preferCliPrefix: !model.previewActive,
+          }),
+    [activeSessions, model.previewActive, nowMs, traces]
+  );
 
   const topRows = useMemo(
-    () => selectProviderRows(model.rows, activeSessions),
-    [activeSessions, model.rows]
+    () => selectProviderRows(model.rows, activeProviders),
+    [activeProviders, model.rows]
   );
 
   return (

--- a/src/components/home/HomeTodayProviderUsageOverview.tsx
+++ b/src/components/home/HomeTodayProviderUsageOverview.tsx
@@ -1,0 +1,442 @@
+import { useMemo } from "react";
+import { Loader2 } from "lucide-react";
+import type { GatewayActiveSession } from "../../services/gateway/gateway";
+import type { UsageLeaderboardRow, UsageSummary } from "../../services/usage/usage";
+import { Card } from "../../ui/Card";
+import { computeCacheHitRate } from "../../utils/cacheRateMetrics";
+import { formatTokensMillions } from "../../utils/chartHelpers";
+import { formatInteger, formatPercent, formatUsdCompact } from "../../utils/formatters";
+import { computeStatusBadge } from "./HomeLogShared";
+import { QueryErrorCard } from "../shared/QueryErrorCard";
+import { useHomeTokenCostDataModel } from "./useHomeTokenCostDataModel";
+
+const SUMMARY_SKELETON_KEYS = [0, 1, 2, 3, 4];
+const PROVIDER_SKELETON_KEYS = [0, 1, 2];
+const MAX_PROVIDER_ROWS = 3;
+const PROVIDER_HEADER_LABEL = "供应商（前 3 个）";
+const TABLE_TH_CLASS =
+  "border-b border-slate-200 bg-slate-50/70 px-3 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-400";
+const TABLE_TD_CLASS = "border-b border-slate-100 px-3 py-3 dark:border-slate-800";
+const TABLE_MONO_TD_CLASS =
+  "border-b border-slate-100 px-3 py-3 font-mono text-xs tabular-nums text-slate-700 dark:border-slate-800 dark:text-slate-300";
+const TODAY_PROVIDER_QUERY_CONFIG = {
+  period: "daily" as const,
+  input: {
+    startTs: null,
+    endTs: null,
+    cliKey: null,
+    providerId: null,
+  },
+  previewFactor: 1,
+};
+const IN_PROGRESS_BADGE = computeStatusBadge({
+  status: null,
+  errorCode: null,
+  inProgress: true,
+});
+
+function formatTokenValue(value: number | null | undefined) {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return formatTokensMillions(value);
+}
+
+function summaryCacheHitRate(summary: UsageSummary | null) {
+  if (!summary) return NaN;
+  return computeCacheHitRate(
+    summary.input_tokens,
+    summary.cache_creation_input_tokens,
+    summary.cache_read_input_tokens
+  );
+}
+
+type SummaryMetricAccent = "blue" | "purple" | "green" | "orange" | "slate";
+type DisplayProviderRow = {
+  row: UsageLeaderboardRow;
+  isRunning: boolean;
+  isSynthetic: boolean;
+};
+
+const SUMMARY_METRIC_ACCENT_CLASS: Record<SummaryMetricAccent, string> = {
+  blue: "bg-blue-500",
+  purple: "bg-violet-500",
+  green: "bg-emerald-500",
+  orange: "bg-orange-500",
+  slate: "bg-slate-400 dark:bg-slate-500",
+};
+
+function tokenShare(row: UsageLeaderboardRow, summary: UsageSummary | null) {
+  if (!summary || summary.io_total_tokens <= 0) return 0;
+  return row.io_total_tokens / summary.io_total_tokens;
+}
+
+function successRate(row: UsageLeaderboardRow) {
+  if (row.requests_total <= 0) return NaN;
+  return row.requests_success / row.requests_total;
+}
+
+function normalizeProviderName(name: string | null | undefined) {
+  return name?.trim().toLocaleLowerCase() ?? "";
+}
+
+function sortProviderRows(rows: UsageLeaderboardRow[]) {
+  return rows.slice().sort((left, right) => {
+    if (right.io_total_tokens !== left.io_total_tokens) {
+      return right.io_total_tokens - left.io_total_tokens;
+    }
+    if (right.requests_total !== left.requests_total) {
+      return right.requests_total - left.requests_total;
+    }
+    return left.name.localeCompare(right.name);
+  });
+}
+
+function buildActiveProviderNames(activeSessions: GatewayActiveSession[]) {
+  const seen = new Set<string>();
+  const names: string[] = [];
+
+  for (const session of activeSessions) {
+    const name = session.provider_name?.trim();
+    const normalized = normalizeProviderName(name);
+    if (!name || !normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    names.push(name);
+  }
+
+  return names;
+}
+
+function createSyntheticProviderRow(name: string): UsageLeaderboardRow {
+  const normalized = normalizeProviderName(name).replace(/\s+/g, "-");
+  return {
+    key: `running:${normalized || "unknown"}`,
+    name,
+    requests_total: 0,
+    requests_success: 0,
+    requests_failed: 0,
+    total_tokens: 0,
+    io_total_tokens: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    avg_duration_ms: null,
+    avg_ttfb_ms: null,
+    avg_output_tokens_per_second: null,
+    cost_usd: null,
+  };
+}
+
+function selectProviderRows(
+  rows: UsageLeaderboardRow[],
+  activeSessions: GatewayActiveSession[]
+): DisplayProviderRow[] {
+  const sortedRows = sortProviderRows(rows);
+  const activeProviderNames = buildActiveProviderNames(activeSessions);
+  const activeProviderSet = new Set(activeProviderNames.map((name) => normalizeProviderName(name)));
+  const rowByName = new Map(
+    sortedRows.map((row) => [normalizeProviderName(row.name), row] as const)
+  );
+  const rankByName = new Map(
+    sortedRows.map((row, index) => [normalizeProviderName(row.name), index] as const)
+  );
+  const selected = new Map<string, DisplayProviderRow>();
+
+  for (const row of sortedRows) {
+    const normalized = normalizeProviderName(row.name);
+    if (!activeProviderSet.has(normalized)) continue;
+    selected.set(normalized, { row, isRunning: true, isSynthetic: false });
+    if (selected.size >= MAX_PROVIDER_ROWS) break;
+  }
+
+  if (selected.size < MAX_PROVIDER_ROWS) {
+    for (const name of activeProviderNames) {
+      const normalized = normalizeProviderName(name);
+      if (!normalized || selected.has(normalized)) continue;
+      selected.set(normalized, {
+        row: rowByName.get(normalized) ?? createSyntheticProviderRow(name),
+        isRunning: true,
+        isSynthetic: !rowByName.has(normalized),
+      });
+      if (selected.size >= MAX_PROVIDER_ROWS) break;
+    }
+  }
+
+  if (selected.size < MAX_PROVIDER_ROWS) {
+    for (const row of sortedRows) {
+      const normalized = normalizeProviderName(row.name);
+      if (selected.has(normalized)) continue;
+      selected.set(normalized, { row, isRunning: false, isSynthetic: false });
+      if (selected.size >= MAX_PROVIDER_ROWS) break;
+    }
+  }
+
+  return Array.from(selected.values()).sort((left, right) => {
+    const leftRank =
+      rankByName.get(normalizeProviderName(left.row.name)) ?? Number.MAX_SAFE_INTEGER;
+    const rightRank =
+      rankByName.get(normalizeProviderName(right.row.name)) ?? Number.MAX_SAFE_INTEGER;
+    if (leftRank !== rightRank) return leftRank - rightRank;
+    return left.row.name.localeCompare(right.row.name);
+  });
+}
+
+function rowTokenBreakdown(row: UsageLeaderboardRow) {
+  return [
+    formatTokenValue(row.total_tokens),
+    formatTokenValue(Math.max(0, row.total_tokens - row.io_total_tokens)),
+    formatPercent(
+      computeCacheHitRate(
+        row.input_tokens,
+        row.cache_creation_input_tokens,
+        row.cache_read_input_tokens
+      )
+    ),
+  ].join(" / ");
+}
+
+function SummaryMetricCard({
+  title,
+  value,
+  accent,
+}: {
+  title: string;
+  value: string;
+  accent: SummaryMetricAccent;
+}) {
+  return (
+    <Card padding="sm" className="relative h-full overflow-hidden">
+      <div className={`absolute inset-x-0 top-0 h-0.5 ${SUMMARY_METRIC_ACCENT_CLASS[accent]}`} />
+      <div className="text-[11px] font-medium text-slate-500 dark:text-slate-400">{title}</div>
+      <div className="mt-1 font-mono text-sm font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+        {value}
+      </div>
+    </Card>
+  );
+}
+
+function SummaryMetricCardSkeleton() {
+  return (
+    <Card padding="sm" className="h-full animate-pulse">
+      <div className="h-3 w-14 rounded bg-slate-200 dark:bg-slate-700" />
+      <div className="mt-2 h-5 w-16 rounded bg-slate-200 dark:bg-slate-700" />
+    </Card>
+  );
+}
+
+function SummaryCards({
+  summary,
+  totalCostUsd,
+  loading,
+}: {
+  summary: UsageSummary | null;
+  totalCostUsd: number | null;
+  loading: boolean;
+}) {
+  if (loading && !summary) {
+    return (
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {SUMMARY_SKELETON_KEYS.map((key) => (
+          <SummaryMetricCardSkeleton key={key} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-2 xl:grid-cols-5">
+      <SummaryMetricCard
+        title="含缓存总 Token"
+        value={formatTokenValue(summary?.total_tokens)}
+        accent="purple"
+      />
+      <SummaryMetricCard
+        title="总 Token"
+        value={formatTokenValue(summary?.io_total_tokens)}
+        accent="blue"
+      />
+      <SummaryMetricCard
+        title="缓存命中率"
+        value={formatPercent(summaryCacheHitRate(summary))}
+        accent="purple"
+      />
+      <SummaryMetricCard
+        title="今日请求数"
+        value={formatInteger(summary?.requests_total)}
+        accent="green"
+      />
+      <SummaryMetricCard title="今日花费" value={formatUsdCompact(totalCostUsd)} accent="orange" />
+    </div>
+  );
+}
+
+function ProviderUsageSkeleton() {
+  return (
+    <tr className="animate-pulse">
+      <td className={TABLE_TD_CLASS}>
+        <div className="h-4 w-28 rounded bg-slate-200 dark:bg-slate-700" />
+      </td>
+      <td className={TABLE_MONO_TD_CLASS}>
+        <div className="h-3 w-40 rounded bg-slate-100 dark:bg-slate-600" />
+      </td>
+      <td className={TABLE_MONO_TD_CLASS}>
+        <div className="h-3 w-14 rounded bg-slate-100 dark:bg-slate-600" />
+      </td>
+      <td className={TABLE_MONO_TD_CLASS}>
+        <div className="h-3 w-12 rounded bg-slate-100 dark:bg-slate-600" />
+      </td>
+      <td className={TABLE_MONO_TD_CLASS}>
+        <div className="h-3 w-12 rounded bg-slate-100 dark:bg-slate-600" />
+      </td>
+    </tr>
+  );
+}
+
+export function HomeTodayProviderUsageOverview({
+  devPreviewEnabled = false,
+  activeSessions = [],
+}: {
+  devPreviewEnabled?: boolean;
+  activeSessions?: GatewayActiveSession[];
+}) {
+  const model = useHomeTokenCostDataModel({
+    scope: "provider",
+    queryConfig: TODAY_PROVIDER_QUERY_CONFIG,
+    devPreviewEnabled,
+  });
+
+  const topRows = useMemo(
+    () => selectProviderRows(model.rows, activeSessions),
+    [activeSessions, model.rows]
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SummaryCards
+        summary={model.summary}
+        totalCostUsd={model.totalCostUsd}
+        loading={model.loading}
+      />
+
+      <QueryErrorCard
+        errorText={model.errorText}
+        loading={model.fetching}
+        onRetry={model.refresh}
+        message="读取今日供应商用量失败，请重试；必要时查看 Console 日志。"
+      />
+
+      <Card padding="none" className="overflow-hidden">
+        {model.loading && model.summary == null && topRows.length === 0 ? (
+          <div className="overflow-x-auto">
+            <table className="w-full border-separate border-spacing-0 text-left text-sm">
+              <caption className="sr-only">今日供应商用量</caption>
+              <thead>
+                <tr>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    {PROVIDER_HEADER_LABEL}
+                  </th>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    <div className="inline-flex items-center gap-1 whitespace-nowrap normal-case">
+                      <span className="text-[11px] font-medium tracking-normal text-slate-500 dark:text-slate-400">
+                        Token
+                      </span>
+                      <span className="text-[9px] font-normal tracking-normal text-slate-400 dark:text-slate-500">
+                        含缓存 / 缓存 / 命中率
+                      </span>
+                    </div>
+                  </th>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    总花费
+                  </th>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    成功率
+                  </th>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    Token 占比
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {PROVIDER_SKELETON_KEYS.map((key) => (
+                  <ProviderUsageSkeleton key={key} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : topRows.length === 0 ? (
+          <div className="px-4 py-10 text-center text-sm text-slate-600 dark:text-slate-400">
+            今日暂无供应商用量数据。
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full border-separate border-spacing-0 text-left text-sm">
+              <caption className="sr-only">今日供应商用量</caption>
+              <thead className="sticky top-0 z-10">
+                <tr>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    {PROVIDER_HEADER_LABEL}
+                  </th>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    <div className="inline-flex items-center gap-1 whitespace-nowrap normal-case">
+                      <span className="text-[11px] font-medium tracking-normal text-slate-500 dark:text-slate-400">
+                        Token
+                      </span>
+                      <span className="text-[9px] font-normal tracking-normal text-slate-400 dark:text-slate-500">
+                        含缓存 / 缓存 / 命中率
+                      </span>
+                    </div>
+                  </th>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    总花费
+                  </th>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    成功率
+                  </th>
+                  <th scope="col" className={TABLE_TH_CLASS}>
+                    Token 占比
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {topRows.map(({ row, isRunning, isSynthetic }) => (
+                  <tr
+                    key={row.key}
+                    className="align-top transition-colors hover:bg-slate-50/60 dark:hover:bg-slate-800/50"
+                  >
+                    <td className={TABLE_TD_CLASS}>
+                      <div className="flex items-center gap-2">
+                        {isRunning ? (
+                          <span
+                            aria-label={IN_PROGRESS_BADGE.text}
+                            title={IN_PROGRESS_BADGE.text}
+                            className={`inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-[11px] font-medium ${IN_PROGRESS_BADGE.tone}`}
+                          >
+                            <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+                          </span>
+                        ) : null}
+                        <div className="font-medium text-slate-900 dark:text-slate-100">
+                          {row.name}
+                        </div>
+                      </div>
+                    </td>
+                    <td className={TABLE_MONO_TD_CLASS}>
+                      {isSynthetic ? "— / — / —" : rowTokenBreakdown(row)}
+                    </td>
+                    <td className={TABLE_MONO_TD_CLASS}>
+                      {isSynthetic ? "—" : formatUsdCompact(row.cost_usd)}
+                    </td>
+                    <td className={TABLE_MONO_TD_CLASS}>
+                      {isSynthetic ? "—" : formatPercent(successRate(row))}
+                    </td>
+                    <td className={TABLE_MONO_TD_CLASS}>
+                      {isSynthetic ? "—" : formatPercent(tokenShare(row, model.summary))}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/components/home/HomeTodayProviderUsageOverview.tsx
+++ b/src/components/home/HomeTodayProviderUsageOverview.tsx
@@ -442,7 +442,7 @@ function rowTokenBreakdown(row: UsageLeaderboardRow) {
   ];
 }
 
-function rowBillableTokenBreakdown(row: UsageLeaderboardRow, summary: UsageSummary | null) {
+function rowInputOutputTokenBreakdown(row: UsageLeaderboardRow, summary: UsageSummary | null) {
   return [formatTokenValue(row.io_total_tokens), formatPercent(tokenShare(row, summary))];
 }
 
@@ -528,7 +528,7 @@ function SummaryCards({
         accent="purple"
       />
       <SummaryMetricCard
-        title="计费 Token"
+        title="输入+输出 Token"
         value={formatTokenValue(summary?.io_total_tokens)}
         accent="blue"
       />
@@ -652,7 +652,7 @@ export function HomeTodayProviderUsageOverview({
                     <TableHeaderLabel label="供应商" note="前 3 个" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
-                    <TableHeaderLabel label="计费 Token" note="输入+输出" />
+                    <TableHeaderLabel label="输入+输出 Token" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
                     <TableHeaderLabel label="缓存情况" note="含缓存/缓存/命中率" />
@@ -686,7 +686,7 @@ export function HomeTodayProviderUsageOverview({
                     <TableHeaderLabel label="供应商" note="前 3 个" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
-                    <TableHeaderLabel label="计费 Token" note="输入+输出" />
+                    <TableHeaderLabel label="输入+输出 Token" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
                     <TableHeaderLabel label="缓存情况" note="含缓存/缓存/命中率" />
@@ -726,7 +726,9 @@ export function HomeTodayProviderUsageOverview({
                     <td className={TABLE_MONO_TD_CLASS}>
                       <TokenBreakdown
                         parts={
-                          isSynthetic ? ["—", "—"] : rowBillableTokenBreakdown(row, model.summary)
+                          isSynthetic
+                            ? ["—", "—"]
+                            : rowInputOutputTokenBreakdown(row, model.summary)
                         }
                       />
                     </td>

--- a/src/components/home/HomeTodayProviderUsageOverview.tsx
+++ b/src/components/home/HomeTodayProviderUsageOverview.tsx
@@ -592,18 +592,20 @@ export function HomeTodayProviderUsageOverview({
                   >
                     <td className={TABLE_TD_CLASS}>
                       <div className="flex items-center gap-2">
-                        {isRunning ? (
-                          <span
-                            aria-label={IN_PROGRESS_BADGE.text}
-                            title={IN_PROGRESS_BADGE.text}
-                            className={`inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-[11px] font-medium ${IN_PROGRESS_BADGE.tone}`}
-                          >
-                            <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
-                          </span>
-                        ) : null}
-                        <div className="font-medium text-slate-900 dark:text-slate-100">
+                        <div className="min-w-0 font-medium text-slate-900 dark:text-slate-100">
                           {row.name}
                         </div>
+                        <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
+                          {isRunning ? (
+                            <span
+                              aria-label={IN_PROGRESS_BADGE.text}
+                              title={IN_PROGRESS_BADGE.text}
+                              className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[11px] font-medium ${IN_PROGRESS_BADGE.tone}`}
+                            >
+                              <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+                            </span>
+                          ) : null}
+                        </span>
                       </div>
                     </td>
                     <td className={TABLE_MONO_TD_CLASS}>

--- a/src/components/home/HomeTodayProviderUsageOverview.tsx
+++ b/src/components/home/HomeTodayProviderUsageOverview.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import { Loader2 } from "lucide-react";
+import { useDocumentVisibility } from "../../hooks/useDocumentVisibility";
 import { useNowMs } from "../../hooks/useNowMs";
+import { useWindowForeground } from "../../hooks/useWindowForeground";
 import type { GatewayActiveSession } from "../../services/gateway/gateway";
 import type { TraceSession } from "../../services/gateway/traceStore";
 import type { UsageLeaderboardRow, UsageSummary } from "../../services/usage/usage";
@@ -10,7 +12,10 @@ import { formatTokensMillions } from "../../utils/chartHelpers";
 import { formatInteger, formatPercent, formatUsdCompact } from "../../utils/formatters";
 import { computeStatusBadge } from "./HomeLogShared";
 import { QueryErrorCard } from "../shared/QueryErrorCard";
-import { useHomeTokenCostDataModel } from "./useHomeTokenCostDataModel";
+import {
+  useHomeTokenCostDataModel,
+  type HomeTokenCostDataModelQueryRefreshConfig,
+} from "./useHomeTokenCostDataModel";
 
 const SUMMARY_SKELETON_KEYS = [0, 1, 2, 3, 4];
 const PROVIDER_SKELETON_KEYS = [0, 1, 2];
@@ -18,6 +23,7 @@ const MAX_PROVIDER_ROWS = 3;
 const PROVIDER_HEADER_LABEL = "供应商（前 3 个）";
 const LIVE_TRACE_MAX_AGE_MS = 15 * 60 * 1000;
 const STALE_TRACE_TIMEOUT_MS = 5 * 60 * 1000;
+const OVERVIEW_REFRESH_INTERVAL_MS = 60 * 1000;
 const TABLE_TH_CLASS =
   "border-b border-slate-200 bg-slate-50/70 px-3 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-400";
 const TABLE_TD_CLASS = "border-b border-slate-100 px-3 py-3 dark:border-slate-800";
@@ -474,11 +480,36 @@ export function HomeTodayProviderUsageOverview({
   activeSessions?: GatewayActiveSession[];
   traces?: TraceSession[];
 }) {
+  const documentVisible = useDocumentVisibility();
+  const queryRefreshConfig = useMemo<HomeTokenCostDataModelQueryRefreshConfig>(() => {
+    const refetchIntervalMs: number | false = documentVisible
+      ? OVERVIEW_REFRESH_INTERVAL_MS
+      : false;
+
+    return {
+      summary: {
+        refetchIntervalMs,
+        refetchOnMount: "always" as const,
+      },
+      leaderboard: {
+        refetchIntervalMs,
+        refetchOnMount: "always" as const,
+      },
+    };
+  }, [documentVisible]);
   const model = useHomeTokenCostDataModel({
     scope: "provider",
     queryConfig: TODAY_PROVIDER_QUERY_CONFIG,
     devPreviewEnabled,
+    queryRefreshConfig,
   });
+
+  useWindowForeground({
+    enabled: true,
+    onForeground: model.refresh,
+    throttleMs: 1000,
+  });
+
   const nowMs = useNowMs(Boolean(traces && traces.length > 0), 250);
   const activeProviders = useMemo(
     () =>

--- a/src/components/home/HomeTodayProviderUsageOverview.tsx
+++ b/src/components/home/HomeTodayProviderUsageOverview.tsx
@@ -146,6 +146,23 @@ function providerIdentityKey(identity: ProviderIdentity) {
   return `name:${identity.normalizedName}`;
 }
 
+function providerScopedNameKey(identity: ProviderIdentity) {
+  if (!identity.cliKey || !identity.normalizedName) return null;
+  return `${identity.cliKey}:${identity.normalizedName}`;
+}
+
+function addUniqueValue<T>(map: Map<string, T | null>, key: string, value: T) {
+  if (map.has(key)) {
+    map.set(key, null);
+    return;
+  }
+  map.set(key, value);
+}
+
+function getUniqueValue<T>(map: Map<string, T | null>, key: string) {
+  return map.get(key) ?? null;
+}
+
 function formatSyntheticProviderName(
   entry: ActiveProviderEntry,
   options: { preferCliPrefix: boolean }
@@ -272,7 +289,6 @@ function selectProviderRows(
       .map((entry) => entry.providerId)
       .filter((providerId): providerId is number => providerId != null)
   );
-  const activeProviderNameSet = new Set(activeProviders.map((entry) => entry.normalizedName));
   const activeProviderById = new Map(
     activeProviders
       .filter(
@@ -280,13 +296,23 @@ function selectProviderRows(
       )
       .map((entry) => [entry.providerId, entry] as const)
   );
-  const activeProviderByName = new Map(
-    activeProviders.map((entry) => [entry.normalizedName, entry] as const)
-  );
+  const activeProviderByScopedName = new Map<string, ActiveProviderEntry>();
+  const uniqueActiveProviderByName = new Map<string, ActiveProviderEntry | null>();
+  activeProviders.forEach((entry) => {
+    const scopedNameKey = providerScopedNameKey(entry);
+    if (scopedNameKey && !activeProviderByScopedName.has(scopedNameKey)) {
+      activeProviderByScopedName.set(scopedNameKey, entry);
+    }
+    if (entry.normalizedName) {
+      addUniqueValue(uniqueActiveProviderByName, entry.normalizedName, entry);
+    }
+  });
   const rowById = new Map<number, UsageLeaderboardRow>();
-  const rowByName = new Map<string, UsageLeaderboardRow>();
+  const rowByScopedName = new Map<string, UsageLeaderboardRow>();
+  const uniqueRowByName = new Map<string, UsageLeaderboardRow | null>();
   const rankById = new Map<number, number>();
-  const rankByName = new Map<string, number>();
+  const rankByScopedName = new Map<string, number>();
+  const uniqueRankByName = new Map<string, number | null>();
 
   sortedRows.forEach((row, index) => {
     const identity = rowIdentityByKey.get(row.key);
@@ -295,19 +321,69 @@ function selectProviderRows(
       rowById.set(identity.providerId, row);
       rankById.set(identity.providerId, index);
     }
-    if (identity.normalizedName && !rowByName.has(identity.normalizedName)) {
-      rowByName.set(identity.normalizedName, row);
-      rankByName.set(identity.normalizedName, index);
+    const scopedNameKey = providerScopedNameKey(identity);
+    if (scopedNameKey && !rowByScopedName.has(scopedNameKey)) {
+      rowByScopedName.set(scopedNameKey, row);
+      rankByScopedName.set(scopedNameKey, index);
+    }
+    if (identity.normalizedName) {
+      addUniqueValue(uniqueRowByName, identity.normalizedName, row);
+      addUniqueValue(uniqueRankByName, identity.normalizedName, index);
     }
   });
   const selected = new Map<string, DisplayProviderRow>();
+  const findActiveProvider = (identity: ProviderIdentity) => {
+    const matchedById =
+      identity.providerId != null ? activeProviderById.get(identity.providerId) : null;
+    if (matchedById) return matchedById;
+
+    const scopedNameKey = providerScopedNameKey(identity);
+    const matchedByScopedName = scopedNameKey
+      ? activeProviderByScopedName.get(scopedNameKey)
+      : null;
+    if (matchedByScopedName) return matchedByScopedName;
+
+    if (!identity.normalizedName) return null;
+    const matchedByName = getUniqueValue(uniqueActiveProviderByName, identity.normalizedName);
+    if (!matchedByName) return null;
+    if (identity.cliKey && matchedByName.cliKey) return null;
+    return matchedByName;
+  };
+  const findRowForActiveProvider = (entry: ActiveProviderEntry) => {
+    const matchedById = entry.providerId != null ? rowById.get(entry.providerId) : null;
+    if (matchedById) return matchedById;
+
+    const scopedNameKey = providerScopedNameKey(entry);
+    const matchedByScopedName = scopedNameKey ? rowByScopedName.get(scopedNameKey) : null;
+    if (matchedByScopedName) return matchedByScopedName;
+
+    if (!entry.normalizedName) return null;
+    const matchedByName = getUniqueValue(uniqueRowByName, entry.normalizedName);
+    if (!matchedByName) return null;
+    const matchedIdentity =
+      rowIdentityByKey.get(matchedByName.key) ?? parseProviderRowIdentity(matchedByName);
+    if (entry.cliKey && matchedIdentity.cliKey) return null;
+    return matchedByName;
+  };
+  const hasActiveProviderMatch = (identity: ProviderIdentity) => {
+    if (identity.providerId != null && activeProviderIdSet.has(identity.providerId)) return true;
+    const scopedNameKey = providerScopedNameKey(identity);
+    if (scopedNameKey && activeProviderByScopedName.has(scopedNameKey)) return true;
+    return findActiveProvider(identity) != null;
+  };
+  const rankForIdentity = (identity: ProviderIdentity) => {
+    const idRank = identity.providerId != null ? rankById.get(identity.providerId) : undefined;
+    if (idRank != null) return idRank;
+    const scopedNameKey = providerScopedNameKey(identity);
+    const scopedRank = scopedNameKey ? rankByScopedName.get(scopedNameKey) : undefined;
+    if (scopedRank != null) return scopedRank;
+    return getUniqueValue(uniqueRankByName, identity.normalizedName) ?? Number.MAX_SAFE_INTEGER;
+  };
 
   for (const row of sortedRows) {
     const identity = rowIdentityByKey.get(row.key);
     if (!identity) continue;
-    const matchedActive =
-      (identity.providerId != null ? activeProviderById.get(identity.providerId) : null) ??
-      activeProviderByName.get(identity.normalizedName);
+    const matchedActive = findActiveProvider(identity);
     if (!matchedActive) continue;
     selected.set(providerIdentityKey(matchedActive), { row, isRunning: true, isSynthetic: false });
     if (selected.size >= MAX_PROVIDER_ROWS) break;
@@ -317,9 +393,7 @@ function selectProviderRows(
     for (const entry of activeProviders) {
       const key = providerIdentityKey(entry);
       if (!entry.normalizedName || selected.has(key)) continue;
-      const matchedRow =
-        (entry.providerId != null ? rowById.get(entry.providerId) : null) ??
-        rowByName.get(entry.normalizedName);
+      const matchedRow = findRowForActiveProvider(entry);
       selected.set(key, {
         row: matchedRow ?? createSyntheticProviderRow(entry),
         isRunning: true,
@@ -335,10 +409,7 @@ function selectProviderRows(
       if (!identity) continue;
       const key = providerIdentityKey(identity);
       if (selected.has(key)) continue;
-      if (
-        (identity.providerId != null && activeProviderIdSet.has(identity.providerId)) ||
-        activeProviderNameSet.has(identity.normalizedName)
-      ) {
+      if (hasActiveProviderMatch(identity)) {
         continue;
       }
       selected.set(key, { row, isRunning: false, isSynthetic: false });
@@ -350,14 +421,8 @@ function selectProviderRows(
     const leftIdentity = rowIdentityByKey.get(left.row.key) ?? parseProviderRowIdentity(left.row);
     const rightIdentity =
       rowIdentityByKey.get(right.row.key) ?? parseProviderRowIdentity(right.row);
-    const leftRank =
-      (leftIdentity.providerId != null ? rankById.get(leftIdentity.providerId) : undefined) ??
-      rankByName.get(leftIdentity.normalizedName) ??
-      Number.MAX_SAFE_INTEGER;
-    const rightRank =
-      (rightIdentity.providerId != null ? rankById.get(rightIdentity.providerId) : undefined) ??
-      rankByName.get(rightIdentity.normalizedName) ??
-      Number.MAX_SAFE_INTEGER;
+    const leftRank = rankForIdentity(leftIdentity);
+    const rightRank = rankForIdentity(rightIdentity);
     if (leftRank !== rightRank) return leftRank - rightRank;
     return left.row.name.localeCompare(right.row.name);
   });
@@ -374,13 +439,11 @@ function rowTokenBreakdown(row: UsageLeaderboardRow) {
         row.cache_read_input_tokens
       )
     ),
-  ].join(" / ");
+  ];
 }
 
 function rowBillableTokenBreakdown(row: UsageLeaderboardRow, summary: UsageSummary | null) {
-  return [formatTokenValue(row.io_total_tokens), formatPercent(tokenShare(row, summary))].join(
-    " / "
-  );
+  return [formatTokenValue(row.io_total_tokens), formatPercent(tokenShare(row, summary))];
 }
 
 function TableHeaderLabel({ label, note }: { label: string; note?: string }) {
@@ -389,6 +452,23 @@ function TableHeaderLabel({ label, note }: { label: string; note?: string }) {
       <span className={TABLE_TH_MAIN_CLASS}>{label}</span>
       {note ? <span className={TABLE_TH_NOTE_CLASS}>（{note}）</span> : null}
     </div>
+  );
+}
+
+function TokenBreakdown({ parts }: { parts: string[] }) {
+  return (
+    <span aria-label={parts.join("/")} className="inline-flex items-baseline gap-0.5 tabular-nums">
+      {parts.map((part, index) => (
+        <span key={`${part}-${index}`} className="inline-flex items-baseline gap-0.5">
+          {index > 0 ? (
+            <span className="text-slate-400 dark:text-slate-500" aria-hidden="true">
+              /
+            </span>
+          ) : null}
+          <span>{part}</span>
+        </span>
+      ))}
+    </span>
   );
 }
 
@@ -448,7 +528,7 @@ function SummaryCards({
         accent="purple"
       />
       <SummaryMetricCard
-        title="总 Token"
+        title="计费 Token"
         value={formatTokenValue(summary?.io_total_tokens)}
         accent="blue"
       />
@@ -528,7 +608,7 @@ export function HomeTodayProviderUsageOverview({
     throttleMs: 1000,
   });
 
-  const nowMs = useNowMs(Boolean(traces && traces.length > 0), 250);
+  const nowMs = useNowMs(Boolean(traces && traces.length > 0), 1000);
   const activeProviders = useMemo(
     () =>
       traces != null
@@ -575,7 +655,7 @@ export function HomeTodayProviderUsageOverview({
                     <TableHeaderLabel label="计费 Token" note="输入+输出" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
-                    <TableHeaderLabel label="缓存情况" note="含缓存 / 缓存 / 命中率" />
+                    <TableHeaderLabel label="缓存情况" note="含缓存/缓存/命中率" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
                     总花费
@@ -609,7 +689,7 @@ export function HomeTodayProviderUsageOverview({
                     <TableHeaderLabel label="计费 Token" note="输入+输出" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
-                    <TableHeaderLabel label="缓存情况" note="含缓存 / 缓存 / 命中率" />
+                    <TableHeaderLabel label="缓存情况" note="含缓存/缓存/命中率" />
                   </th>
                   <th scope="col" className={TABLE_TH_CLASS}>
                     总花费
@@ -644,10 +724,16 @@ export function HomeTodayProviderUsageOverview({
                       </div>
                     </td>
                     <td className={TABLE_MONO_TD_CLASS}>
-                      {isSynthetic ? "— / —" : rowBillableTokenBreakdown(row, model.summary)}
+                      <TokenBreakdown
+                        parts={
+                          isSynthetic ? ["—", "—"] : rowBillableTokenBreakdown(row, model.summary)
+                        }
+                      />
                     </td>
                     <td className={TABLE_MONO_TD_CLASS}>
-                      {isSynthetic ? "— / — / —" : rowTokenBreakdown(row)}
+                      <TokenBreakdown
+                        parts={isSynthetic ? ["—", "—", "—"] : rowTokenBreakdown(row)}
+                      />
                     </td>
                     <td className={TABLE_MONO_TD_CLASS}>
                       {isSynthetic ? "—" : formatUsdCompact(row.cost_usd)}

--- a/src/components/home/HomeTokenCostPanel.tsx
+++ b/src/components/home/HomeTokenCostPanel.tsx
@@ -17,7 +17,7 @@ import { QueryErrorCard } from "../shared/QueryErrorCard";
 import { useHomeTokenCostDataModel } from "./useHomeTokenCostDataModel";
 
 type TokenCostScope = "provider" | "model";
-type TokenCostRange = "today" | "last3" | "last7" | "last15" | "last30" | "month";
+type TokenCostRange = "today" | "yesterday" | "last3" | "last7" | "last15" | "last30" | "month";
 
 const TOKEN_COST_SCOPE_ITEMS = [
   { key: "provider", label: "供应商" },
@@ -26,6 +26,7 @@ const TOKEN_COST_SCOPE_ITEMS = [
 
 const TOKEN_COST_RANGE_ITEMS = [
   { key: "today", label: "今天" },
+  { key: "yesterday", label: "昨天" },
   { key: "last3", label: "最近3天" },
   { key: "last7", label: "最近7天" },
   { key: "last15", label: "最近15天" },
@@ -108,6 +109,17 @@ function buildTokenCostQueryConfig(range: TokenCostRange, now = new Date()): Tok
   const tomorrowStart = addLocalDays(todayStart, 1);
 
   switch (range) {
+    case "yesterday":
+      return {
+        label: rangeLabel(range),
+        period: "custom",
+        input: {
+          ...emptyTokenCostQueryInput(),
+          startTs: unixSecondsFromDate(addLocalDays(todayStart, -1)),
+          endTs: unixSecondsFromDate(todayStart),
+        },
+        previewFactor: 1,
+      };
     case "last3":
       return {
         label: rangeLabel(range),

--- a/src/components/home/HomeTokenCostPanel.tsx
+++ b/src/components/home/HomeTokenCostPanel.tsx
@@ -196,10 +196,46 @@ function summaryCostCoverage(summary: UsageSummary | null) {
   return covered / denom;
 }
 
-const CACHE_BREAKDOWN_SEPARATOR = " / ";
-
 function trimCompactZero(value: string) {
   return value.replace(/\.0([KM])$/, "$1").replace(/\.0%$/, "%");
+}
+
+function TableHeaderLabel({ label, note }: { label: string; note?: string }) {
+  return (
+    <div className="inline-flex items-baseline gap-1 whitespace-nowrap normal-case">
+      <span>{label}</span>
+      {note ? (
+        <span className="text-[10px] font-normal tracking-normal text-slate-400 dark:text-slate-500">
+          （{note}）
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function TokenBreakdownInline({ parts }: { parts: string[] }) {
+  return (
+    <span aria-label={parts.join("/")} className="inline-flex items-baseline gap-0.5 tabular-nums">
+      {parts.map((part, index) => (
+        <span key={`${part}-${index}`} className="inline-flex items-baseline gap-0.5">
+          {index > 0 ? (
+            <span className="text-slate-400 dark:text-slate-500" aria-hidden="true">
+              /
+            </span>
+          ) : null}
+          <span>{part}</span>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function BillableTokenValue({ row }: { row: UsageLeaderboardRow }) {
+  return (
+    <span className="whitespace-nowrap tabular-nums">
+      {trimCompactZero(formatTokensMillions(row.io_total_tokens))}
+    </span>
+  );
 }
 
 function CacheHitRateBreakdown({ row }: { row: UsageLeaderboardRow }) {
@@ -217,11 +253,7 @@ function CacheHitRateBreakdown({ row }: { row: UsageLeaderboardRow }) {
   const hitRateText =
     hasValidTotal && Number.isFinite(hitRate) ? trimCompactZero(formatPercent(hitRate)) : "—";
 
-  return (
-    <div className="whitespace-nowrap">
-      {[totalText, cacheText, hitRateText].join(CACHE_BREAKDOWN_SEPARATOR)}
-    </div>
-  );
+  return <TokenBreakdownInline parts={[totalText, cacheText, hitRateText]} />;
 }
 
 function TokenShareBar({ percent }: { percent: number }) {
@@ -280,7 +312,11 @@ function TokenSummaryCards({
         value={formatTokenValue(summary?.total_tokens)}
         accent="purple"
       />
-      <StatCard title="总 Token" value={formatTokenValue(summary?.io_total_tokens)} accent="blue" />
+      <StatCard
+        title="计费 Token"
+        value={formatTokenValue(summary?.io_total_tokens)}
+        accent="blue"
+      />
       <StatCard title="总花费" value={formatCostValue(totalCostUsd)} accent="orange" />
       <StatCard
         title="成本覆盖率"
@@ -343,10 +379,10 @@ function TokenLeaderboardTable({
               {scopeLabel(scope)}
             </th>
             <th scope="col" className={TABLE_TH_CLASS}>
-              <div>Token 明细</div>
-              <div className="mt-0.5 normal-case text-[10px] font-normal tracking-normal text-slate-400 dark:text-slate-500">
-                含缓存总量 / 缓存量 / 缓存命中率
-              </div>
+              <TableHeaderLabel label="计费 Token" note="输入+输出" />
+            </th>
+            <th scope="col" className={TABLE_TH_CLASS}>
+              <TableHeaderLabel label="缓存情况" note="含缓存/缓存/命中率" />
             </th>
             <th scope="col" className={TABLE_TH_CLASS}>
               总花费
@@ -378,6 +414,9 @@ function TokenLeaderboardTable({
               </td>
               <td className={TABLE_TD_CLASS}>
                 <div className="font-medium text-slate-900 dark:text-slate-100">{row.name}</div>
+              </td>
+              <td className={TABLE_MONO_TD_CLASS}>
+                <BillableTokenValue row={row} />
               </td>
               <td className={TABLE_MONO_TD_CLASS}>
                 <CacheHitRateBreakdown row={row} />

--- a/src/components/home/HomeTokenCostPanel.tsx
+++ b/src/components/home/HomeTokenCostPanel.tsx
@@ -230,7 +230,7 @@ function TokenBreakdownInline({ parts }: { parts: string[] }) {
   );
 }
 
-function BillableTokenValue({ row }: { row: UsageLeaderboardRow }) {
+function InputOutputTokenValue({ row }: { row: UsageLeaderboardRow }) {
   return (
     <span className="whitespace-nowrap tabular-nums">
       {trimCompactZero(formatTokensMillions(row.io_total_tokens))}
@@ -313,7 +313,7 @@ function TokenSummaryCards({
         accent="purple"
       />
       <StatCard
-        title="计费 Token"
+        title="输入+输出 Token"
         value={formatTokenValue(summary?.io_total_tokens)}
         accent="blue"
       />
@@ -379,7 +379,7 @@ function TokenLeaderboardTable({
               {scopeLabel(scope)}
             </th>
             <th scope="col" className={TABLE_TH_CLASS}>
-              <TableHeaderLabel label="计费 Token" note="输入+输出" />
+              <TableHeaderLabel label="输入+输出 Token" />
             </th>
             <th scope="col" className={TABLE_TH_CLASS}>
               <TableHeaderLabel label="缓存情况" note="含缓存/缓存/命中率" />
@@ -416,7 +416,7 @@ function TokenLeaderboardTable({
                 <div className="font-medium text-slate-900 dark:text-slate-100">{row.name}</div>
               </td>
               <td className={TABLE_MONO_TD_CLASS}>
-                <BillableTokenValue row={row} />
+                <InputOutputTokenValue row={row} />
               </td>
               <td className={TABLE_MONO_TD_CLASS}>
                 <CacheHitRateBreakdown row={row} />

--- a/src/components/home/HomeWorkStatusCard.tsx
+++ b/src/components/home/HomeWorkStatusCard.tsx
@@ -3,11 +3,13 @@
 
 import { CLIS } from "../../constants/clis";
 import type { CliKey } from "../../services/providers/providers";
+import type { SortModeSummary } from "../../services/providers/sortModes";
 import { Button } from "../../ui/Button";
 import { Card } from "../../ui/Card";
 import { Switch } from "../../ui/Switch";
 import { cn } from "../../utils/cn";
 import { CliBrandIcon } from "./CliBrandIcon";
+import { HomeCliRouteStrategyControl } from "./HomeCliRouteStrategyControl";
 
 export type HomeWorkStatusCardProps = {
   layout?: "vertical" | "horizontal";
@@ -19,6 +21,13 @@ export type HomeWorkStatusCardProps = {
   cliProxyAppliedToCurrentGateway: Record<CliKey, boolean | null>;
   cliProxyToggling: Record<CliKey, boolean>;
   onSetCliProxyEnabled: (cliKey: CliKey, enabled: boolean) => void;
+
+  sortModes?: SortModeSummary[];
+  sortModesLoading?: boolean;
+  sortModesAvailable?: boolean | null;
+  activeModeByCli?: Record<CliKey, number | null>;
+  activeModeToggling?: Record<CliKey, boolean>;
+  onSetCliActiveMode?: (cliKey: CliKey, modeId: number | null) => void;
 };
 
 export function HomeWorkStatusCard({
@@ -30,9 +39,23 @@ export function HomeWorkStatusCard({
   cliProxyAppliedToCurrentGateway,
   cliProxyToggling,
   onSetCliProxyEnabled,
+  sortModes,
+  sortModesLoading,
+  sortModesAvailable,
+  activeModeByCli,
+  activeModeToggling,
+  onSetCliActiveMode,
 }: HomeWorkStatusCardProps) {
   const horizontal = layout === "horizontal";
   const plain = chrome === "plain";
+  const showRouteStrategy =
+    !horizontal &&
+    sortModes != null &&
+    typeof sortModesLoading === "boolean" &&
+    sortModesAvailable !== undefined &&
+    activeModeByCli != null &&
+    activeModeToggling != null &&
+    onSetCliActiveMode != null;
 
   const content = (
     <>
@@ -51,7 +74,7 @@ export function HomeWorkStatusCard({
           }
         >
           {CLIS.map((cli) => {
-            const cliKey = cli.key as CliKey;
+            const cliKey = cli.key;
             const drifted =
               cliProxyEnabled[cliKey] && cliProxyAppliedToCurrentGateway[cliKey] === false;
 
@@ -60,44 +83,31 @@ export function HomeWorkStatusCard({
                 key={cli.key}
                 className="rounded-lg border border-slate-200 bg-white px-3 py-2.5 shadow-sm transition-all duration-200 hover:bg-slate-50 hover:border-indigo-200 hover:shadow-md dark:border-slate-700 dark:bg-slate-800 dark:shadow-none dark:hover:bg-slate-700 dark:hover:border-indigo-700"
               >
-                <div className="flex items-center justify-between gap-3">
-                  <div className={cn("min-w-0", !horizontal && "flex-1")}>
-                    <div className="flex items-center gap-2 text-left text-xs font-medium text-slate-700 dark:text-slate-300">
-                      <CliBrandIcon
-                        cliKey={cliKey}
-                        className="h-4 w-4 shrink-0 rounded-[4px] object-contain"
-                      />
-                      <span className="truncate">{cli.name}</span>
+                <div className="min-w-0 space-y-1.5">
+                  <div className="flex items-center gap-3">
+                    <div className={cn("min-w-0", !horizontal && "flex-1")}>
+                      <div className="flex items-center gap-2 text-left text-xs font-medium text-slate-700 dark:text-slate-300">
+                        <CliBrandIcon
+                          cliKey={cliKey}
+                          className="h-4 w-4 shrink-0 rounded-[4px] object-contain"
+                        />
+                        <span className="truncate">{cli.name}</span>
+                      </div>
                     </div>
-                  </div>
 
-                  <div className="flex shrink-0 flex-col items-end justify-center gap-1 text-right">
-                    {drifted ? (
-                      <>
-                        <div className="flex items-center justify-end gap-2">
-                          <Button
-                            variant="danger"
-                            size="sm"
-                            className="h-6 px-2 py-0 text-[11px]"
-                            disabled={cliProxyToggling[cliKey]}
-                            onClick={() => onSetCliProxyEnabled(cliKey, true)}
-                            aria-label={`修复 ${cli.name} 代理`}
-                          >
-                            修复
-                          </Button>
-                          <Switch
-                            checked={cliProxyEnabled[cliKey]}
-                            disabled={cliProxyToggling[cliKey]}
-                            onCheckedChange={(next) => onSetCliProxyEnabled(cliKey, next)}
-                            size="sm"
-                            aria-label={`${cli.name} 代理开关`}
-                          />
-                        </div>
-                        <span className="text-[11px] font-medium leading-none text-rose-600 dark:text-rose-400">
-                          当前未指向本网关
-                        </span>
-                      </>
-                    ) : (
+                    <div className="ml-auto flex shrink-0 items-center gap-2">
+                      {drifted ? (
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          className="h-6 px-2 py-0 text-[11px]"
+                          disabled={cliProxyToggling[cliKey]}
+                          onClick={() => onSetCliProxyEnabled(cliKey, true)}
+                          aria-label={`修复 ${cli.name} 代理`}
+                        >
+                          修复
+                        </Button>
+                      ) : null}
                       <Switch
                         checked={cliProxyEnabled[cliKey]}
                         disabled={cliProxyToggling[cliKey]}
@@ -105,8 +115,28 @@ export function HomeWorkStatusCard({
                         size="sm"
                         aria-label={`${cli.name} 代理开关`}
                       />
-                    )}
+                      {showRouteStrategy ? (
+                        <HomeCliRouteStrategyControl
+                          cliKey={cliKey}
+                          cliLabel={cli.name}
+                          sortModes={sortModes}
+                          sortModesLoading={sortModesLoading}
+                          sortModesAvailable={sortModesAvailable}
+                          activeModeByCli={activeModeByCli}
+                          activeModeToggling={activeModeToggling}
+                          onSetCliActiveMode={onSetCliActiveMode}
+                          orientation="vertical"
+                          className="max-w-full"
+                        />
+                      ) : null}
+                    </div>
                   </div>
+
+                  {drifted ? (
+                    <div className="text-[11px] font-medium leading-none text-rose-600 dark:text-rose-400">
+                      当前未指向本网关
+                    </div>
+                  ) : null}
                 </div>
               </div>
             );

--- a/src/components/home/HomeWorkspaceConfigPanel.tsx
+++ b/src/components/home/HomeWorkspaceConfigPanel.tsx
@@ -1,10 +1,8 @@
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { Command, Cpu, Pencil } from "lucide-react";
 import type { CliKey } from "../../services/providers/providers";
-import type { SortModeSummary } from "../../services/providers/sortModes";
 import { EmptyState } from "../../ui/EmptyState";
-import { Select } from "../../ui/Select";
 import { cn } from "../../utils/cn";
 import { CliBrandIcon } from "./CliBrandIcon";
 import type {
@@ -21,36 +19,18 @@ export type HomeWorkspaceConfigPanelProps = {
   configs: HomeCliWorkspaceConfig[];
   selectedCliKey: CliKey | null;
   onSelectCliKey: (cliKey: CliKey) => void;
-  sortModes: SortModeSummary[];
-  sortModesLoading: boolean;
-  sortModesAvailable: boolean | null;
-  activeModeByCli: Record<CliKey, number | null>;
-  activeModeToggling: Record<CliKey, boolean>;
-  onSetCliActiveMode: (cliKey: CliKey, modeId: number | null) => void;
+  headerAddon?: ReactNode;
 };
 
 export function HomeWorkspaceConfigPanel({
   configs,
   selectedCliKey,
   onSelectCliKey,
-  sortModes,
-  sortModesLoading,
-  sortModesAvailable,
-  activeModeByCli,
-  activeModeToggling,
-  onSetCliActiveMode,
+  headerAddon,
 }: HomeWorkspaceConfigPanelProps) {
   const selectedConfig = useMemo(() => {
     return configs.find((row) => row.cliKey === selectedCliKey) ?? configs[0] ?? null;
   }, [configs, selectedCliKey]);
-  const selectedModeValue = selectedConfig
-    ? String(activeModeByCli[selectedConfig.cliKey] ?? "")
-    : "";
-  const sortModeSelectDisabled =
-    selectedConfig == null ||
-    sortModesLoading ||
-    sortModesAvailable === false ||
-    activeModeToggling[selectedConfig.cliKey];
 
   if (!selectedConfig) {
     return <EmptyState title="暂无工作区配置信息" />;
@@ -85,38 +65,19 @@ export function HomeWorkspaceConfigPanel({
         })}
       </div>
 
-      <div className="grid grid-cols-1 gap-2 md:grid-cols-[minmax(0,1fr)_fit-content(240px)]">
+      <div
+        className={cn(
+          "grid grid-cols-1 gap-2",
+          headerAddon != null && "md:grid-cols-[minmax(0,1fr)_fit-content(240px)]"
+        )}
+      >
         <div className="flex min-w-0 items-center gap-2 rounded-lg border border-slate-200 bg-slate-50/70 px-3 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-800/50">
           <span className="shrink-0 font-medium text-slate-500 dark:text-slate-400">工作区：</span>
           <span className="min-w-0 truncate font-medium text-slate-700 dark:text-slate-200">
             {selectedConfig.workspaceName?.trim() || "默认"}
           </span>
         </div>
-        <div className="flex min-w-0 items-center justify-between gap-2 rounded-lg border border-slate-200 bg-slate-50/70 px-3 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-800/50">
-          <span className="shrink-0 font-medium text-slate-500 dark:text-slate-400">
-            路由策略：
-          </span>
-          <Select
-            value={selectedModeValue}
-            onChange={(e) => {
-              const nextValue = e.currentTarget.value;
-              onSetCliActiveMode(
-                selectedConfig.cliKey,
-                nextValue === "" ? null : Number(nextValue)
-              );
-            }}
-            disabled={sortModeSelectDisabled}
-            className="h-7 min-w-[112px] w-auto flex-none border-slate-200 bg-white px-2 pr-7 text-sm dark:border-slate-600 dark:bg-slate-900"
-            aria-label={`${selectedConfig.cliLabel} 路由策略`}
-          >
-            <option value="">Default</option>
-            {sortModes.map((mode) => (
-              <option key={mode.id} value={String(mode.id)}>
-                {mode.name}
-              </option>
-            ))}
-          </Select>
-        </div>
+        {headerAddon}
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto pr-1">

--- a/src/components/home/__tests__/HomeOAuthQuotaPanel.test.tsx
+++ b/src/components/home/__tests__/HomeOAuthQuotaPanel.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HomeOAuthQuotaRow } from "../homeOAuthQuotaTypes";
+import { HomeOAuthQuotaPanelContent } from "../HomeOAuthQuotaPanel";
+
+function makeRow(partial: Partial<HomeOAuthQuotaRow>): HomeOAuthQuotaRow {
+  const nowUnix = Math.floor(Date.now() / 1000);
+  return {
+    providerId: 1,
+    cliKey: "codex",
+    providerName: "TG 合租账号",
+    enabled: true,
+    state: "success",
+    limits: {
+      limit_short_label: "5h",
+      limit_5h_text: "61%",
+      limit_weekly_text: "92%",
+      limit_5h_reset_at: nowUnix + 2 * 3600 + 34 * 60,
+      limit_weekly_reset_at: nowUnix + 3 * 86400 + 2 * 3600 + 29 * 60,
+    },
+    error: null,
+    ...partial,
+  };
+}
+
+describe("components/home/HomeOAuthQuotaPanel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-21T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("lists provider cards and shows a refresh notice when nothing has been fetched", () => {
+    render(
+      <HomeOAuthQuotaPanelContent
+        rows={[makeRow({ state: "idle", limits: null })]}
+        hasProviders={true}
+        hasRefreshed={false}
+        refreshing={false}
+        onRefresh={vi.fn()}
+        onRefreshRow={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("TG 合租账号")).toBeInTheDocument();
+    expect(screen.getByText("点击右上角刷新获取 OAuth 配额")).toBeInTheDocument();
+  });
+
+  it("renders cached quota data with compact summary text", () => {
+    render(
+      <HomeOAuthQuotaPanelContent
+        rows={[makeRow({ state: "success" })]}
+        hasProviders={true}
+        hasRefreshed={false}
+        refreshing={false}
+        onRefresh={vi.fn()}
+        onRefreshRow={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("TG 合租账号")).toBeInTheDocument();
+    expect(screen.queryByText("OAuth")).not.toBeInTheDocument();
+    expect(screen.getByText("5h: 61%·2h34m / 7d: 92%·3d2h29m")).toBeInTheDocument();
+  });
+
+  it("renders loading, empty, and error card states", () => {
+    const { rerender } = render(
+      <HomeOAuthQuotaPanelContent
+        rows={[makeRow({ state: "loading", limits: null })]}
+        hasProviders={true}
+        hasRefreshed={true}
+        refreshing={true}
+        onRefresh={vi.fn()}
+        onRefreshRow={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("刷新中...")).toBeInTheDocument();
+
+    rerender(
+      <HomeOAuthQuotaPanelContent
+        rows={[
+          makeRow({
+            state: "success",
+            limits: {
+              limit_short_label: "5h",
+              limit_5h_text: null,
+              limit_weekly_text: null,
+              limit_5h_reset_at: null,
+              limit_weekly_reset_at: null,
+            },
+          }),
+        ]}
+        hasProviders={true}
+        hasRefreshed={true}
+        refreshing={false}
+        onRefresh={vi.fn()}
+        onRefreshRow={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("暂无 OAuth 配额信息")).toBeInTheDocument();
+
+    rerender(
+      <HomeOAuthQuotaPanelContent
+        rows={[makeRow({ state: "error", limits: null, error: "fetch boom" })]}
+        hasProviders={true}
+        hasRefreshed={true}
+        refreshing={false}
+        onRefresh={vi.fn()}
+        onRefreshRow={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("刷新失败")).toBeInTheDocument();
+    expect(screen.getByText("刷新失败，请重试")).toBeInTheDocument();
+    expect(screen.queryByText("fetch boom")).not.toBeInTheDocument();
+  });
+
+  it("forwards bulk and row refresh actions", () => {
+    const onRefresh = vi.fn();
+    const onRefreshRow = vi.fn();
+
+    render(
+      <HomeOAuthQuotaPanelContent
+        rows={[makeRow({})]}
+        hasProviders={true}
+        hasRefreshed={true}
+        refreshing={false}
+        onRefresh={onRefresh}
+        onRefreshRow={onRefreshRow}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "刷新 OAuth 配额" }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "刷新 TG 合租账号 OAuth 配额" }));
+    expect(onRefreshRow).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/components/home/__tests__/HomeOverviewPanel.test.tsx
+++ b/src/components/home/__tests__/HomeOverviewPanel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { useState, type ComponentProps } from "react";
+import { useState, type ComponentProps, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeOverviewPanel } from "../HomeOverviewPanel";
 
@@ -24,7 +24,13 @@ vi.mock("../HomeTodayProviderUsageOverview", () => ({
 }));
 
 vi.mock("../HomeWorkStatusCard", () => ({
-  HomeWorkStatusCard: ({ layout }: { layout: string }) => <div>{`work-status-card:${layout}`}</div>,
+  HomeWorkStatusCard: ({
+    layout,
+    sortModes,
+  }: {
+    layout: string;
+    sortModes?: Array<{ id: number; name: string }>;
+  }) => <div>{`work-status-card:${layout}:${String(sortModes != null)}`}</div>,
 }));
 
 vi.mock("../HomeActiveSessionsCard", () => ({
@@ -46,9 +52,7 @@ vi.mock("../HomeWorkspaceConfigPanel", () => ({
     configs,
     selectedCliKey,
     onSelectCliKey,
-    sortModes,
-    activeModeByCli,
-    onSetCliActiveMode,
+    headerAddon,
   }: {
     configs: Array<{
       cliKey: "claude" | "codex" | "gemini";
@@ -58,15 +62,10 @@ vi.mock("../HomeWorkspaceConfigPanel", () => ({
     }>;
     selectedCliKey: "claude" | "codex" | "gemini" | null;
     onSelectCliKey: (cliKey: "claude" | "codex" | "gemini") => void;
-    sortModes: Array<{ id: number; name: string }>;
-    activeModeByCli: Record<"claude" | "codex" | "gemini", number | null>;
-    onSetCliActiveMode: (cliKey: "claude" | "codex" | "gemini", modeId: number | null) => void;
+    headerAddon?: ReactNode;
   }) => {
     const selectedConfig =
       configs.find((config) => config.cliKey === selectedCliKey) ?? configs[0] ?? null;
-    const selectedModeValue = selectedConfig
-      ? String(activeModeByCli[selectedConfig.cliKey] ?? "")
-      : "";
 
     if (!selectedConfig) {
       return <div>workspace-config:empty</div>;
@@ -85,27 +84,7 @@ vi.mock("../HomeWorkspaceConfigPanel", () => ({
           <span>工作区：</span>
           <span>{selectedConfig.workspaceName?.trim() || "默认"}</span>
         </div>
-        <label>
-          路由策略：
-          <select
-            aria-label={`${selectedConfig.cliLabel} 路由策略`}
-            value={selectedModeValue}
-            onChange={(event) => {
-              const nextValue = event.currentTarget.value;
-              onSetCliActiveMode(
-                selectedConfig.cliKey,
-                nextValue === "" ? null : Number(nextValue)
-              );
-            }}
-          >
-            <option value="">Default</option>
-            {sortModes.map((mode) => (
-              <option key={mode.id} value={String(mode.id)}>
-                {mode.name}
-              </option>
-            ))}
-          </select>
-        </label>
+        {headerAddon}
         <div>
           {selectedConfig.items.map((item) => (
             <div key={item.id}>{item.name}</div>
@@ -284,7 +263,6 @@ describe("components/home/HomeOverviewPanel", () => {
     fireEvent.click(screen.getByRole("tab", { name: "配置信息" }));
     expect(await screen.findByRole("button", { name: "Claude Code" })).toBeInTheDocument();
     expect(screen.getByText("工作区 A")).toBeInTheDocument();
-    expect(screen.getByText("路由策略：")).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Claude Code 路由策略" })).toHaveValue("1");
     expect(screen.getByRole("option", { name: "工作策略" })).toBeInTheDocument();
     expect(screen.getByText("默认提示词")).toBeInTheDocument();
@@ -298,6 +276,24 @@ describe("components/home/HomeOverviewPanel", () => {
       target: { value: "1" },
     });
     expect(onSetCliActiveMode).toHaveBeenCalledWith("codex", 1);
+  });
+
+  it("moves the route strategy entry into the work status card in logs-primary layout", async () => {
+    window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
+
+    renderPanel({
+      sortModes: [{ id: 1, name: "工作策略", created_at: 1, updated_at: 1 }],
+      activeModeByCli: { claude: 1, codex: null, gemini: null },
+    });
+
+    expect(screen.getByText("work-status-card:vertical:true")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "配置信息" }));
+    expect(await screen.findByText("工作区：")).toBeInTheDocument();
+    expect(screen.queryByText("路由策略：")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: "Claude Code 路由策略" })
+    ).not.toBeInTheDocument();
   });
 
   it("uses CLI priority order for workspace config button order and default selection", async () => {
@@ -394,21 +390,21 @@ describe("components/home/HomeOverviewPanel", () => {
     renderPanel({ showHomeHeatmap: false, showHomeUsage: false });
 
     expect(screen.queryByText(/usage-section:/)).not.toBeInTheDocument();
-    expect(screen.getByText("work-status-card:horizontal")).toBeInTheDocument();
+    expect(screen.getByText("work-status-card:horizontal:false")).toBeInTheDocument();
   });
 
   it("uses the split layout with usage statistics when heatmap is hidden", () => {
     renderPanel({ showHomeHeatmap: false, showHomeUsage: true });
 
     expect(screen.getByText("usage-section:false:true")).toBeInTheDocument();
-    expect(screen.getByText("work-status-card:vertical")).toBeInTheDocument();
+    expect(screen.getByText("work-status-card:vertical:false")).toBeInTheDocument();
   });
 
   it("uses the split layout with heatmap when usage statistics are hidden", () => {
     renderPanel({ showHomeHeatmap: true, showHomeUsage: false });
 
     expect(screen.getByText("usage-section:true:false")).toBeInTheDocument();
-    expect(screen.getByText("work-status-card:vertical")).toBeInTheDocument();
+    expect(screen.getByText("work-status-card:vertical:false")).toBeInTheDocument();
   });
 
   it("uses the legacy overview layout by default", () => {
@@ -433,9 +429,10 @@ describe("components/home/HomeOverviewPanel", () => {
     expect(
       usageSection.compareDocumentPosition(requestLogs) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
-    expect(screen.getAllByText("work-status-card:vertical")).toHaveLength(1);
+    expect(screen.getAllByText("work-status-card:vertical:true")).toHaveLength(1);
     expect(screen.getByRole("tab", { name: "配置信息" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "熔断信息" })).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "供应商限额" })).not.toBeInTheDocument();
     expect(homeRequestLogsPanelMock).toHaveBeenCalled();
     const latestCall = (homeRequestLogsPanelMock as any).mock.calls[
       (homeRequestLogsPanelMock as any).mock.calls.length - 1
@@ -452,10 +449,111 @@ describe("components/home/HomeOverviewPanel", () => {
     renderPanel({ showHomeHeatmap: true, showHomeUsage: false });
 
     expect(screen.getByText("today-provider-usage:false")).toBeInTheDocument();
-    expect(screen.getAllByText("work-status-card:vertical")).toHaveLength(1);
-    expect(screen.queryByText("work-status-card:horizontal")).not.toBeInTheDocument();
+    expect(screen.getAllByText("work-status-card:vertical:true")).toHaveLength(1);
+    expect(screen.queryByText("work-status-card:horizontal:false")).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "配置信息" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "熔断信息" })).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "供应商限额" })).not.toBeInTheDocument();
+  });
+
+  it("hides the provider limit tab in logs-primary layout when there is no data", () => {
+    window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
+
+    renderPanel({
+      providerLimitRows: [],
+      providerLimitAvailable: true,
+      providerLimitLoading: false,
+    });
+
+    expect(screen.queryByRole("tab", { name: "供应商限额" })).not.toBeInTheDocument();
+  });
+
+  it("renders provider limits inside the info panel in logs-primary layout", async () => {
+    window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
+
+    renderPanel({ devPreviewEnabled: true, providerLimitRows: [] });
+
+    fireEvent.click(screen.getByRole("tab", { name: "供应商限额" }));
+    expect(await screen.findByText("provider-limit:3")).toBeInTheDocument();
+  });
+
+  it("switches back to 配置信息 when provider limit data becomes empty in logs-primary layout", async () => {
+    window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
+
+    const { rerender } = renderPanel({
+      providerLimitRows: [{ provider_id: 1 } as any],
+      providerLimitAvailable: true,
+      workspaceConfigs: [
+        {
+          cliKey: "claude",
+          cliLabel: "Claude Code",
+          workspaceId: 1,
+          workspaceName: "工作区 A",
+          loading: false,
+          items: [{ id: "prompt:1", type: "prompts", label: "Prompt", name: "Claude Prompt" }],
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "供应商限额" }));
+    expect(screen.getByText("provider-limit:1")).toBeInTheDocument();
+
+    rerender(
+      <HomeOverviewPanel
+        showCustomTooltip={false}
+        showHomeHeatmap={true}
+        cliPriorityOrder={["claude", "codex", "gemini"]}
+        usageWindowDays={15}
+        usageHeatmapRows={[]}
+        usageHeatmapLoading={false}
+        onRefreshUsageHeatmap={vi.fn()}
+        sortModes={[]}
+        sortModesLoading={false}
+        sortModesAvailable={true}
+        activeModeByCli={{ claude: null, codex: null, gemini: null }}
+        activeModeToggling={{ claude: false, codex: false, gemini: false }}
+        onSetCliActiveMode={vi.fn()}
+        cliProxyLoading={false}
+        cliProxyAvailable={true}
+        cliProxyEnabled={{ claude: false, codex: false, gemini: false }}
+        cliProxyAppliedToCurrentGateway={{ claude: null, codex: null, gemini: null }}
+        cliProxyToggling={{ claude: false, codex: false, gemini: false }}
+        onSetCliProxyEnabled={vi.fn()}
+        activeSessions={[]}
+        activeSessionsLoading={false}
+        activeSessionsAvailable={true}
+        workspaceConfigs={[
+          {
+            cliKey: "claude",
+            cliLabel: "Claude Code",
+            workspaceId: 1,
+            workspaceName: "工作区 A",
+            loading: false,
+            items: [{ id: "prompt:1", type: "prompts", label: "Prompt", name: "Claude Prompt" }],
+          },
+        ]}
+        providerLimitRows={[]}
+        providerLimitLoading={false}
+        providerLimitAvailable={true}
+        providerLimitRefreshing={false}
+        onRefreshProviderLimit={vi.fn()}
+        openCircuits={[]}
+        onResetCircuitProvider={vi.fn()}
+        resettingCircuitProviderIds={new Set()}
+        traces={[]}
+        requestLogs={[]}
+        requestLogsLoading={false}
+        requestLogsRefreshing={false}
+        requestLogsAvailable={true}
+        onRefreshRequestLogs={vi.fn()}
+        selectedLogId={null}
+        onSelectLogId={vi.fn()}
+        personalizedUsageView="summary"
+      />
+    );
+
+    expect(await screen.findByText("工作区：")).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "供应商限额" })).not.toBeInTheDocument();
   });
 
   it("renders the usage chart branch when the personalized usage view switches", () => {
@@ -653,7 +751,7 @@ describe("components/home/HomeOverviewPanel", () => {
     expect(screen.getByText("Claude New Circuit")).toBeInTheDocument();
   });
 
-  it("auto-switches to 熔断信息 when open circuits are removed", () => {
+  it("auto-switches to 配置信息 when open circuits are removed", () => {
     const { rerender } = renderPanel({
       openCircuits: [
         {
@@ -713,7 +811,7 @@ describe("components/home/HomeOverviewPanel", () => {
       />
     );
 
-    expect(screen.getByText("当前没有熔断中的 Provider")).toBeInTheDocument();
+    expect(screen.getByText("workspace-config:empty")).toBeInTheDocument();
   });
 
   it("switches back to 配置信息 when circuits become empty in logs-primary layout", async () => {

--- a/src/components/home/__tests__/HomeOverviewPanel.test.tsx
+++ b/src/components/home/__tests__/HomeOverviewPanel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import type { ComponentProps } from "react";
+import { useState, type ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeOverviewPanel } from "../HomeOverviewPanel";
 
@@ -15,6 +15,12 @@ vi.mock("../HomeUsageSection", () => ({
     showHeatmap: boolean;
     showUsageChart?: boolean;
   }) => <div>{`usage-section:${String(showHeatmap)}:${String(showUsageChart)}`}</div>,
+}));
+
+vi.mock("../HomeTodayProviderUsageOverview", () => ({
+  HomeTodayProviderUsageOverview: ({ devPreviewEnabled }: { devPreviewEnabled?: boolean }) => (
+    <div>{`today-provider-usage:${String(Boolean(devPreviewEnabled))}`}</div>
+  ),
 }));
 
 vi.mock("../HomeWorkStatusCard", () => ({
@@ -183,6 +189,7 @@ function renderPanel(overrides: Partial<ComponentProps<typeof HomeOverviewPanel>
       onRefreshRequestLogs={vi.fn()}
       selectedLogId={null}
       onSelectLogId={vi.fn()}
+      personalizedUsageView="summary"
       {...overrides}
     />
   );
@@ -421,7 +428,7 @@ describe("components/home/HomeOverviewPanel", () => {
     renderPanel();
 
     const requestLogs = screen.getByText("request-logs");
-    const usageSection = screen.getByText("usage-section:false:true");
+    const usageSection = screen.getByText("today-provider-usage:false");
 
     expect(
       usageSection.compareDocumentPosition(requestLogs) & Node.DOCUMENT_POSITION_FOLLOWING
@@ -444,11 +451,104 @@ describe("components/home/HomeOverviewPanel", () => {
 
     renderPanel({ showHomeHeatmap: true, showHomeUsage: false });
 
-    expect(screen.getByText("usage-section:false:true")).toBeInTheDocument();
+    expect(screen.getByText("today-provider-usage:false")).toBeInTheDocument();
     expect(screen.getAllByText("work-status-card:vertical")).toHaveLength(1);
     expect(screen.queryByText("work-status-card:horizontal")).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "配置信息" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "熔断信息" })).toBeInTheDocument();
+  });
+
+  it("renders the usage chart branch when the personalized usage view switches", () => {
+    window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
+
+    function Wrapper() {
+      const [view, setView] = useState<"summary" | "usageChart">("summary");
+
+      return (
+        <>
+          <button type="button" onClick={() => setView("usageChart")}>
+            switch-to-usage-chart
+          </button>
+          <HomeOverviewPanel
+            showCustomTooltip={false}
+            showHomeHeatmap={true}
+            cliPriorityOrder={["claude", "codex", "gemini"]}
+            usageWindowDays={15}
+            usageHeatmapRows={[]}
+            usageHeatmapLoading={false}
+            onRefreshUsageHeatmap={vi.fn()}
+            sortModes={[]}
+            sortModesLoading={false}
+            sortModesAvailable={true}
+            activeModeByCli={{ claude: null, codex: null, gemini: null }}
+            activeModeToggling={{ claude: false, codex: false, gemini: false }}
+            onSetCliActiveMode={vi.fn()}
+            cliProxyLoading={false}
+            cliProxyAvailable={true}
+            cliProxyEnabled={{ claude: false, codex: false, gemini: false }}
+            cliProxyAppliedToCurrentGateway={{ claude: null, codex: null, gemini: null }}
+            cliProxyToggling={{ claude: false, codex: false, gemini: false }}
+            onSetCliProxyEnabled={vi.fn()}
+            activeSessions={[]}
+            activeSessionsLoading={false}
+            activeSessionsAvailable={true}
+            workspaceConfigs={[
+              {
+                cliKey: "claude",
+                cliLabel: "Claude Code",
+                workspaceId: 1,
+                workspaceName: "默认",
+                loading: false,
+                items: [],
+              },
+              {
+                cliKey: "codex",
+                cliLabel: "Codex",
+                workspaceId: 2,
+                workspaceName: "Default",
+                loading: false,
+                items: [],
+              },
+              {
+                cliKey: "gemini",
+                cliLabel: "Gemini",
+                workspaceId: 3,
+                workspaceName: "工作区 2",
+                loading: false,
+                items: [],
+              },
+            ]}
+            providerLimitRows={[]}
+            providerLimitLoading={false}
+            providerLimitAvailable={true}
+            providerLimitRefreshing={false}
+            onRefreshProviderLimit={vi.fn()}
+            openCircuits={[]}
+            onResetCircuitProvider={vi.fn()}
+            resettingCircuitProviderIds={new Set()}
+            traces={[]}
+            requestLogs={[]}
+            requestLogsLoading={false}
+            requestLogsRefreshing={false}
+            requestLogsAvailable={true}
+            onRefreshRequestLogs={vi.fn()}
+            selectedLogId={null}
+            onSelectLogId={vi.fn()}
+            personalizedUsageView={view}
+          />
+        </>
+      );
+    }
+
+    render(<Wrapper />);
+
+    expect(screen.getByText("today-provider-usage:false")).toBeInTheDocument();
+    expect(screen.queryByText("usage-section:false:true")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "switch-to-usage-chart" }));
+
+    expect(screen.getByText("usage-section:false:true")).toBeInTheDocument();
+    expect(screen.queryByText("today-provider-usage:false")).not.toBeInTheDocument();
   });
 
   it("renders preview active sessions when dev preview is enabled and there are no real sessions", async () => {
@@ -546,6 +646,7 @@ describe("components/home/HomeOverviewPanel", () => {
         onRefreshRequestLogs={vi.fn()}
         selectedLogId={null}
         onSelectLogId={vi.fn()}
+        personalizedUsageView="summary"
       />
     );
 
@@ -608,6 +709,7 @@ describe("components/home/HomeOverviewPanel", () => {
         onRefreshRequestLogs={vi.fn()}
         selectedLogId={null}
         onSelectLogId={vi.fn()}
+        personalizedUsageView="summary"
       />
     );
 
@@ -691,6 +793,7 @@ describe("components/home/HomeOverviewPanel", () => {
         onRefreshRequestLogs={vi.fn()}
         selectedLogId={null}
         onSelectLogId={vi.fn()}
+        personalizedUsageView="summary"
       />
     );
 

--- a/src/components/home/__tests__/HomeOverviewPanel.test.tsx
+++ b/src/components/home/__tests__/HomeOverviewPanel.test.tsx
@@ -47,6 +47,34 @@ vi.mock("../HomeProviderLimitPanel", () => ({
   ),
 }));
 
+vi.mock("../HomeOAuthQuotaPanel", () => ({
+  HomeOAuthQuotaPanelContent: ({
+    rows,
+    hasProviders,
+    hasRefreshed,
+    refreshing,
+    onRefresh,
+    onRefreshRow,
+  }: {
+    rows: Array<{ providerId: number }>;
+    hasProviders: boolean;
+    hasRefreshed: boolean;
+    refreshing: boolean;
+    onRefresh?: () => void;
+    onRefreshRow?: (providerId: number) => void;
+  }) => (
+    <div>
+      <div>{`oauth-quota:${rows.length}:${String(hasProviders)}:${String(hasRefreshed)}:${String(refreshing)}`}</div>
+      <button type="button" onClick={() => onRefresh?.()}>
+        refresh-oauth-quota
+      </button>
+      <button type="button" onClick={() => onRefreshRow?.(rows[0]?.providerId ?? 0)}>
+        refresh-oauth-quota-row
+      </button>
+    </div>
+  ),
+}));
+
 vi.mock("../HomeWorkspaceConfigPanel", () => ({
   HomeWorkspaceConfigPanel: ({
     configs,
@@ -157,6 +185,12 @@ function renderPanel(overrides: Partial<ComponentProps<typeof HomeOverviewPanel>
       providerLimitAvailable={true}
       providerLimitRefreshing={false}
       onRefreshProviderLimit={vi.fn()}
+      oauthQuotaRows={[]}
+      oauthQuotaVisible={false}
+      oauthQuotaRefreshing={false}
+      oauthQuotaHasRefreshed={false}
+      onRefreshOAuthQuota={vi.fn()}
+      onRefreshOAuthQuotaRow={vi.fn()}
       openCircuits={[]}
       onResetCircuitProvider={onResetCircuitProvider}
       resettingCircuitProviderIds={new Set()}
@@ -456,11 +490,11 @@ describe("components/home/HomeOverviewPanel", () => {
     expect(screen.queryByRole("tab", { name: "供应商限额" })).not.toBeInTheDocument();
   });
 
-  it("hides the provider limit tab in logs-primary layout when there is no data", () => {
+  it("does not render the provider limit tab in logs-primary layout", () => {
     window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
 
     renderPanel({
-      providerLimitRows: [],
+      providerLimitRows: [{ provider_id: 1 } as any],
       providerLimitAvailable: true,
       providerLimitLoading: false,
     });
@@ -468,21 +502,67 @@ describe("components/home/HomeOverviewPanel", () => {
     expect(screen.queryByRole("tab", { name: "供应商限额" })).not.toBeInTheDocument();
   });
 
-  it("renders provider limits inside the info panel in logs-primary layout", async () => {
+  it("renders the OAuth quota tab only in logs-primary layout and forwards refresh actions", async () => {
     window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
+    const onRefreshOAuthQuota = vi.fn().mockResolvedValue(undefined);
+    const onRefreshOAuthQuotaRow = vi.fn().mockResolvedValue(undefined);
 
-    renderPanel({ devPreviewEnabled: true, providerLimitRows: [] });
+    renderPanel({
+      oauthQuotaVisible: true,
+      oauthQuotaRows: [{ providerId: 9 } as any],
+      oauthQuotaHasRefreshed: true,
+      onRefreshOAuthQuota,
+      onRefreshOAuthQuotaRow,
+    });
 
-    fireEvent.click(screen.getByRole("tab", { name: "供应商限额" }));
-    expect(await screen.findByText("provider-limit:3")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "OAuth 配额" }));
+    expect(await screen.findByText("oauth-quota:1:true:true:false")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "refresh-oauth-quota" }));
+    expect(onRefreshOAuthQuota).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "refresh-oauth-quota-row" }));
+    expect(onRefreshOAuthQuotaRow).toHaveBeenCalledWith(9);
   });
 
-  it("switches back to 配置信息 when provider limit data becomes empty in logs-primary layout", async () => {
+  it("renders preview OAuth quota rows when dev preview is enabled", async () => {
+    window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
+    const onRefreshOAuthQuota = vi.fn().mockResolvedValue(undefined);
+    const onRefreshOAuthQuotaRow = vi.fn().mockResolvedValue(undefined);
+
+    renderPanel({
+      devPreviewEnabled: true,
+      oauthQuotaVisible: true,
+      oauthQuotaRows: [{ providerId: 9 } as any],
+      oauthQuotaHasRefreshed: true,
+      onRefreshOAuthQuota,
+      onRefreshOAuthQuotaRow,
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "OAuth 配额" }));
+    expect(await screen.findByText("oauth-quota:5:true:true:false")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "refresh-oauth-quota" }));
+    fireEvent.click(screen.getByRole("button", { name: "refresh-oauth-quota-row" }));
+    expect(onRefreshOAuthQuota).not.toHaveBeenCalled();
+    expect(onRefreshOAuthQuotaRow).not.toHaveBeenCalled();
+  });
+
+  it("does not render the OAuth quota tab in the legacy layout", () => {
+    renderPanel({
+      oauthQuotaVisible: true,
+      oauthQuotaRows: [{ providerId: 9 } as any],
+    });
+
+    expect(screen.queryByRole("tab", { name: "OAuth 配额" })).not.toBeInTheDocument();
+  });
+
+  it("switches back to 配置信息 when OAuth providers disappear in logs-primary layout", async () => {
     window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
 
     const { rerender } = renderPanel({
-      providerLimitRows: [{ provider_id: 1 } as any],
-      providerLimitAvailable: true,
+      oauthQuotaVisible: true,
+      oauthQuotaRows: [{ providerId: 9 } as any],
       workspaceConfigs: [
         {
           cliKey: "claude",
@@ -495,8 +575,8 @@ describe("components/home/HomeOverviewPanel", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("tab", { name: "供应商限额" }));
-    expect(screen.getByText("provider-limit:1")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "OAuth 配额" }));
+    expect(screen.getByText("oauth-quota:1:true:false:false")).toBeInTheDocument();
 
     rerender(
       <HomeOverviewPanel
@@ -537,6 +617,12 @@ describe("components/home/HomeOverviewPanel", () => {
         providerLimitAvailable={true}
         providerLimitRefreshing={false}
         onRefreshProviderLimit={vi.fn()}
+        oauthQuotaRows={[]}
+        oauthQuotaVisible={false}
+        oauthQuotaRefreshing={false}
+        oauthQuotaHasRefreshed={false}
+        onRefreshOAuthQuota={vi.fn()}
+        onRefreshOAuthQuotaRow={vi.fn()}
         openCircuits={[]}
         onResetCircuitProvider={vi.fn()}
         resettingCircuitProviderIds={new Set()}
@@ -553,6 +639,31 @@ describe("components/home/HomeOverviewPanel", () => {
     );
 
     expect(await screen.findByText("工作区：")).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "OAuth 配额" })).not.toBeInTheDocument();
+  });
+
+  it("falls back to 配置信息 when stored tab order starts with provider limit in logs-primary layout", async () => {
+    window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
+    window.localStorage.setItem(
+      "aio-home-overview-tab-order",
+      JSON.stringify(["providerLimit", "circuit", "workspaceConfig", "sessions", "oauthQuota"])
+    );
+
+    renderPanel({
+      workspaceConfigs: [
+        {
+          cliKey: "claude",
+          cliLabel: "Claude Code",
+          workspaceId: 1,
+          workspaceName: "工作区 A",
+          loading: false,
+          items: [{ id: "prompt:1", type: "prompts", label: "Prompt", name: "Claude Prompt" }],
+        },
+      ],
+    });
+
+    expect(await screen.findByText("工作区：")).toBeInTheDocument();
+    expect(screen.getByText("工作区 A")).toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "供应商限额" })).not.toBeInTheDocument();
   });
 
@@ -621,6 +732,12 @@ describe("components/home/HomeOverviewPanel", () => {
             providerLimitAvailable={true}
             providerLimitRefreshing={false}
             onRefreshProviderLimit={vi.fn()}
+            oauthQuotaRows={[]}
+            oauthQuotaVisible={false}
+            oauthQuotaRefreshing={false}
+            oauthQuotaHasRefreshed={false}
+            onRefreshOAuthQuota={vi.fn()}
+            onRefreshOAuthQuotaRow={vi.fn()}
             openCircuits={[]}
             onResetCircuitProvider={vi.fn()}
             resettingCircuitProviderIds={new Set()}
@@ -726,6 +843,12 @@ describe("components/home/HomeOverviewPanel", () => {
         providerLimitAvailable={true}
         providerLimitRefreshing={false}
         onRefreshProviderLimit={vi.fn()}
+        oauthQuotaRows={[]}
+        oauthQuotaVisible={false}
+        oauthQuotaRefreshing={false}
+        oauthQuotaHasRefreshed={false}
+        onRefreshOAuthQuota={vi.fn()}
+        onRefreshOAuthQuotaRow={vi.fn()}
         openCircuits={[
           {
             cli_key: "claude",
@@ -796,6 +919,12 @@ describe("components/home/HomeOverviewPanel", () => {
         providerLimitAvailable={true}
         providerLimitRefreshing={false}
         onRefreshProviderLimit={vi.fn()}
+        oauthQuotaRows={[]}
+        oauthQuotaVisible={false}
+        oauthQuotaRefreshing={false}
+        oauthQuotaHasRefreshed={false}
+        onRefreshOAuthQuota={vi.fn()}
+        onRefreshOAuthQuotaRow={vi.fn()}
         openCircuits={[]}
         onResetCircuitProvider={vi.fn()}
         resettingCircuitProviderIds={new Set()}
@@ -880,6 +1009,12 @@ describe("components/home/HomeOverviewPanel", () => {
         providerLimitAvailable={true}
         providerLimitRefreshing={false}
         onRefreshProviderLimit={vi.fn()}
+        oauthQuotaRows={[]}
+        oauthQuotaVisible={false}
+        oauthQuotaRefreshing={false}
+        oauthQuotaHasRefreshed={false}
+        onRefreshOAuthQuota={vi.fn()}
+        onRefreshOAuthQuotaRow={vi.fn()}
         openCircuits={[]}
         onResetCircuitProvider={vi.fn()}
         resettingCircuitProviderIds={new Set()}

--- a/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
+++ b/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
@@ -250,9 +250,21 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
     expect(screen.getByText("20")).toBeInTheDocument();
     expect(screen.getByText("今日花费")).toBeInTheDocument();
     expect(screen.getByText("$2.21")).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "供应商（前 3 个）" })).toBeInTheDocument();
+    const providerHeader = screen.getByText("供应商").closest("th");
+    const billableTokenHeader = screen.getByText("计费 Token").closest("th");
+    const cacheHeader = screen.getByText("缓存情况").closest("th");
+    expect(providerHeader).toBeTruthy();
+    expect(billableTokenHeader).toBeTruthy();
+    expect(cacheHeader).toBeTruthy();
+    expect(within(providerHeader as HTMLElement).getByText("（前 3 个）")).toBeInTheDocument();
+    expect(
+      within(billableTokenHeader as HTMLElement).getByText("（输入+输出）")
+    ).toBeInTheDocument();
+    expect(
+      within(cacheHeader as HTMLElement).getByText("（含缓存 / 缓存 / 命中率）")
+    ).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "成功率" })).toBeInTheDocument();
-    expect(screen.getByText("含缓存 / 缓存 / 命中率")).toBeInTheDocument();
+    expect(screen.queryByText("Token 占比")).not.toBeInTheDocument();
 
     const geminiRow = screen.getByText("Gemini Mirror").closest("tr");
     const claudeRow = screen.getByText("Claude Main").closest("tr");
@@ -264,12 +276,14 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
     expect(screen.queryByText("Mistral Edge")).not.toBeInTheDocument();
     expect(screen.queryByText("Local Sandbox")).not.toBeInTheDocument();
 
+    expect(within(geminiRow as HTMLElement).getByText("8.0K / 40.0%")).toBeInTheDocument();
     expect(within(geminiRow as HTMLElement).getByText("10.2K / 2.2K / 20.9%")).toBeInTheDocument();
     expect(within(geminiRow as HTMLElement).getByText("$0.90")).toBeInTheDocument();
     expect(within(geminiRow as HTMLElement).getByText("85.7%")).toBeInTheDocument();
-    expect(within(geminiRow as HTMLElement).getByText("40.0%")).toBeInTheDocument();
     expect(within(claudeRow as HTMLElement).getByText("100.0%")).toBeInTheDocument();
+    expect(within(claudeRow as HTMLElement).getByText("5.0K / 25.0%")).toBeInTheDocument();
     expect(within(claudeRow as HTMLElement).getByText("6.2K / 1.2K / 16.7%")).toBeInTheDocument();
+    expect(within(openaiRow as HTMLElement).getByText("4.0K / 20.0%")).toBeInTheDocument();
     expect(within(openaiRow as HTMLElement).getByText("5.8K / 1.8K / 31.6%")).toBeInTheDocument();
   });
 
@@ -356,8 +370,9 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
     expect(runtimeRow).toBeTruthy();
     expect(screen.queryByText("OpenAI Primary")).not.toBeInTheDocument();
     expect(within(runtimeRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
+    expect(within(runtimeRow as HTMLElement).getByText("— / —")).toBeInTheDocument();
     expect(within(runtimeRow as HTMLElement).getByText("— / — / —")).toBeInTheDocument();
-    expect(within(runtimeRow as HTMLElement).getAllByText("—").length).toBeGreaterThanOrEqual(3);
+    expect(within(runtimeRow as HTMLElement).getAllByText("—").length).toBeGreaterThanOrEqual(2);
   });
 
   it("matches a running provider to the prefixed usage row by provider id", () => {

--- a/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
+++ b/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
@@ -1,0 +1,326 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HomeTodayProviderUsageOverview } from "../HomeTodayProviderUsageOverview";
+import { useHomeTokenCostDataModel } from "../useHomeTokenCostDataModel";
+
+vi.mock("../useHomeTokenCostDataModel", () => ({
+  useHomeTokenCostDataModel: vi.fn(),
+}));
+
+function createActiveSession(providerName: string) {
+  return {
+    cli_key: "claude",
+    session_id: `session-${providerName}`,
+    session_suffix: "abcd",
+    provider_id: 1,
+    provider_name: providerName,
+    expires_at: Date.now(),
+    request_count: 1,
+    total_input_tokens: 100,
+    total_output_tokens: 50,
+    total_cost_usd: 0.1,
+    total_duration_ms: 1000,
+  };
+}
+
+function mockDataModel(overrides: Partial<ReturnType<typeof useHomeTokenCostDataModel>> = {}) {
+  vi.mocked(useHomeTokenCostDataModel).mockReturnValue({
+    summary: {
+      requests_total: 20,
+      requests_with_usage: 20,
+      requests_success: 18,
+      requests_failed: 2,
+      cost_covered_success: 18,
+      avg_duration_ms: 1100,
+      avg_ttfb_ms: 260,
+      avg_output_tokens_per_second: 95.2,
+      input_tokens: 12_000,
+      output_tokens: 8_000,
+      io_total_tokens: 20_000,
+      total_tokens: 25_000,
+      cache_read_input_tokens: 3_000,
+      cache_creation_input_tokens: 1_000,
+      cache_creation_5m_input_tokens: 0,
+      cache_creation_1h_input_tokens: 0,
+    },
+    rows: [
+      {
+        key: "provider-2",
+        name: "Claude Main",
+        requests_total: 5,
+        requests_success: 5,
+        requests_failed: 0,
+        total_tokens: 6_200,
+        io_total_tokens: 5_000,
+        input_tokens: 3_000,
+        output_tokens: 2_000,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 700,
+        avg_duration_ms: 900,
+        avg_ttfb_ms: 220,
+        avg_output_tokens_per_second: 90,
+        cost_usd: 0.5,
+      },
+      {
+        key: "provider-4",
+        name: "Gemini Mirror",
+        requests_total: 7,
+        requests_success: 6,
+        requests_failed: 1,
+        total_tokens: 10_200,
+        io_total_tokens: 8_000,
+        input_tokens: 4_500,
+        output_tokens: 3_500,
+        cache_creation_input_tokens: 800,
+        cache_read_input_tokens: 1_400,
+        avg_duration_ms: 1200,
+        avg_ttfb_ms: 320,
+        avg_output_tokens_per_second: 86,
+        cost_usd: 0.9,
+      },
+      {
+        key: "provider-1",
+        name: "OpenAI Primary",
+        requests_total: 3,
+        requests_success: 3,
+        requests_failed: 0,
+        total_tokens: 5_800,
+        io_total_tokens: 4_000,
+        input_tokens: 2_000,
+        output_tokens: 2_000,
+        cache_creation_input_tokens: 600,
+        cache_read_input_tokens: 1_200,
+        avg_duration_ms: 880,
+        avg_ttfb_ms: 210,
+        avg_output_tokens_per_second: 110,
+        cost_usd: 0.7,
+      },
+      {
+        key: "provider-5",
+        name: "DeepSeek Relay",
+        requests_total: 2,
+        requests_success: 2,
+        requests_failed: 0,
+        total_tokens: 3_500,
+        io_total_tokens: 2_000,
+        input_tokens: 1_400,
+        output_tokens: 600,
+        cache_creation_input_tokens: 700,
+        cache_read_input_tokens: 800,
+        avg_duration_ms: 760,
+        avg_ttfb_ms: 180,
+        avg_output_tokens_per_second: 120,
+        cost_usd: null,
+      },
+      {
+        key: "provider-3",
+        name: "Mistral Edge",
+        requests_total: 2,
+        requests_success: 1,
+        requests_failed: 1,
+        total_tokens: 1_600,
+        io_total_tokens: 800,
+        input_tokens: 500,
+        output_tokens: 300,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 600,
+        avg_duration_ms: 1500,
+        avg_ttfb_ms: 400,
+        avg_output_tokens_per_second: 40,
+        cost_usd: 0.1,
+      },
+      {
+        key: "provider-6",
+        name: "Local Sandbox",
+        requests_total: 1,
+        requests_success: 1,
+        requests_failed: 0,
+        total_tokens: 300,
+        io_total_tokens: 200,
+        input_tokens: 120,
+        output_tokens: 80,
+        cache_creation_input_tokens: 20,
+        cache_read_input_tokens: 80,
+        avg_duration_ms: 600,
+        avg_ttfb_ms: 150,
+        avg_output_tokens_per_second: 60,
+        cost_usd: 0.01,
+      },
+    ],
+    totalCostUsd: 2.21,
+    loading: false,
+    fetching: false,
+    errorText: null,
+    previewActive: false,
+    refresh: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useHomeTokenCostDataModel>);
+}
+
+describe("components/home/HomeTodayProviderUsageOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the fixed today provider query config and renders summary plus top providers", () => {
+    mockDataModel();
+
+    render(<HomeTodayProviderUsageOverview devPreviewEnabled={true} activeSessions={[]} />);
+
+    expect(vi.mocked(useHomeTokenCostDataModel)).toHaveBeenCalledWith({
+      scope: "provider",
+      queryConfig: {
+        period: "daily",
+        input: {
+          startTs: null,
+          endTs: null,
+          cliKey: null,
+          providerId: null,
+        },
+        previewFactor: 1,
+      },
+      devPreviewEnabled: true,
+    });
+
+    const totalWithCacheCard = screen.getByText("含缓存总 Token").parentElement;
+    const totalTokenCard = screen.getByText("总 Token").parentElement;
+    const cacheHitRateCard = screen.getByText("缓存命中率").parentElement;
+    expect(totalWithCacheCard).toBeTruthy();
+    expect(totalTokenCard).toBeTruthy();
+    expect(cacheHitRateCard).toBeTruthy();
+    expect(within(totalWithCacheCard as HTMLElement).getByText("25.0K")).toBeInTheDocument();
+    expect(within(totalTokenCard as HTMLElement).getByText("20.0K")).toBeInTheDocument();
+    expect(within(cacheHitRateCard as HTMLElement).getByText("18.8%")).toBeInTheDocument();
+    expect(screen.getByText("今日请求数")).toBeInTheDocument();
+    expect(screen.getByText("20")).toBeInTheDocument();
+    expect(screen.getByText("今日花费")).toBeInTheDocument();
+    expect(screen.getByText("$2.21")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "供应商（前 3 个）" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "成功率" })).toBeInTheDocument();
+    expect(screen.getByText("含缓存 / 缓存 / 命中率")).toBeInTheDocument();
+
+    const geminiRow = screen.getByText("Gemini Mirror").closest("tr");
+    const claudeRow = screen.getByText("Claude Main").closest("tr");
+    const openaiRow = screen.getByText("OpenAI Primary").closest("tr");
+    expect(geminiRow).toBeTruthy();
+    expect(claudeRow).toBeTruthy();
+    expect(openaiRow).toBeTruthy();
+    expect(screen.queryByText("DeepSeek Relay")).not.toBeInTheDocument();
+    expect(screen.queryByText("Mistral Edge")).not.toBeInTheDocument();
+    expect(screen.queryByText("Local Sandbox")).not.toBeInTheDocument();
+
+    expect(within(geminiRow as HTMLElement).getByText("10.2K / 2.2K / 20.9%")).toBeInTheDocument();
+    expect(within(geminiRow as HTMLElement).getByText("$0.90")).toBeInTheDocument();
+    expect(within(geminiRow as HTMLElement).getByText("85.7%")).toBeInTheDocument();
+    expect(within(geminiRow as HTMLElement).getByText("40.0%")).toBeInTheDocument();
+    expect(within(claudeRow as HTMLElement).getByText("100.0%")).toBeInTheDocument();
+    expect(within(claudeRow as HTMLElement).getByText("6.2K / 1.2K / 16.7%")).toBeInTheDocument();
+    expect(within(openaiRow as HTMLElement).getByText("5.8K / 1.8K / 31.6%")).toBeInTheDocument();
+  });
+
+  it("marks running providers that are already inside the default top three", () => {
+    mockDataModel();
+
+    render(
+      <HomeTodayProviderUsageOverview activeSessions={[createActiveSession("Claude Main")]} />
+    );
+
+    const claudeRow = screen.getByText("Claude Main").closest("tr");
+    expect(claudeRow).toBeTruthy();
+    expect(within(claudeRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
+    expect(screen.getByText("OpenAI Primary")).toBeInTheDocument();
+  });
+
+  it("replaces lower-ranked rows when a running provider is outside the default top three", () => {
+    mockDataModel();
+
+    render(
+      <HomeTodayProviderUsageOverview activeSessions={[createActiveSession("DeepSeek Relay")]} />
+    );
+
+    const deepseekRow = screen.getByText("DeepSeek Relay").closest("tr");
+    expect(deepseekRow).toBeTruthy();
+    expect(screen.queryByText("OpenAI Primary")).not.toBeInTheDocument();
+    expect(within(deepseekRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
+    expect(within(deepseekRow as HTMLElement).getByText("3.5K / 1.5K / 27.6%")).toBeInTheDocument();
+  });
+
+  it("renders a synthetic running row when the provider has no usage row today", () => {
+    mockDataModel();
+
+    render(
+      <HomeTodayProviderUsageOverview activeSessions={[createActiveSession("Runtime Fresh")]} />
+    );
+
+    const runtimeRow = screen.getByText("Runtime Fresh").closest("tr");
+    expect(runtimeRow).toBeTruthy();
+    expect(screen.queryByText("OpenAI Primary")).not.toBeInTheDocument();
+    expect(within(runtimeRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
+    expect(within(runtimeRow as HTMLElement).getByText("— / — / —")).toBeInTheDocument();
+    expect(within(runtimeRow as HTMLElement).getAllByText("—").length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("shows a dash for cache hit rate when the summary has no denominator", () => {
+    mockDataModel({
+      summary: {
+        requests_total: 0,
+        requests_with_usage: 0,
+        requests_success: 0,
+        requests_failed: 0,
+        cost_covered_success: 0,
+        avg_duration_ms: null,
+        avg_ttfb_ms: null,
+        avg_output_tokens_per_second: null,
+        input_tokens: 0,
+        output_tokens: 0,
+        io_total_tokens: 0,
+        total_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_creation_5m_input_tokens: 0,
+        cache_creation_1h_input_tokens: 0,
+      },
+      rows: [],
+    });
+
+    render(<HomeTodayProviderUsageOverview />);
+
+    expect(screen.getByText("缓存命中率")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("今日花费")).toBeInTheDocument();
+  });
+
+  it("renders the error card and retries refresh when loading failed", () => {
+    const refresh = vi.fn();
+    mockDataModel({
+      summary: null,
+      rows: [],
+      errorText: "boom",
+      refresh,
+    });
+
+    render(<HomeTodayProviderUsageOverview />);
+
+    expect(screen.getByText("加载失败")).toBeInTheDocument();
+    expect(
+      screen.getByText("读取今日供应商用量失败，请重试；必要时查看 Console 日志。")
+    ).toBeInTheDocument();
+    expect(screen.getByText("今日暂无供应商用量数据。")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "重试" }));
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders loading skeletons before data arrives", () => {
+    mockDataModel({
+      summary: null,
+      rows: [],
+      loading: true,
+    });
+
+    const { container } = render(<HomeTodayProviderUsageOverview />);
+
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+    expect(screen.queryByText("今日暂无供应商用量数据。")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
+++ b/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeTodayProviderUsageOverview } from "../HomeTodayProviderUsageOverview";
 import { useHomeTokenCostDataModel } from "../useHomeTokenCostDataModel";
@@ -204,6 +204,7 @@ function mockDataModel(overrides: Partial<ReturnType<typeof useHomeTokenCostData
 describe("components/home/HomeTodayProviderUsageOverview", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true });
   });
 
   it("uses the fixed today provider query config and renders summary plus top providers", () => {
@@ -224,6 +225,16 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
         previewFactor: 1,
       },
       devPreviewEnabled: true,
+      queryRefreshConfig: {
+        summary: {
+          refetchIntervalMs: 60_000,
+          refetchOnMount: "always",
+        },
+        leaderboard: {
+          refetchIntervalMs: 60_000,
+          refetchOnMount: "always",
+        },
+      },
     });
 
     const totalWithCacheCard = screen.getByText("含缓存总 Token").parentElement;
@@ -260,6 +271,51 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
     expect(within(claudeRow as HTMLElement).getByText("100.0%")).toBeInTheDocument();
     expect(within(claudeRow as HTMLElement).getByText("6.2K / 1.2K / 16.7%")).toBeInTheDocument();
     expect(within(openaiRow as HTMLElement).getByText("5.8K / 1.8K / 31.6%")).toBeInTheDocument();
+  });
+
+  it("disables polling while the page is hidden", () => {
+    mockDataModel();
+    Object.defineProperty(document, "visibilityState", { value: "hidden", configurable: true });
+
+    render(<HomeTodayProviderUsageOverview />);
+
+    expect(vi.mocked(useHomeTokenCostDataModel)).toHaveBeenCalledWith({
+      scope: "provider",
+      queryConfig: {
+        period: "daily",
+        input: {
+          startTs: null,
+          endTs: null,
+          cliKey: null,
+          providerId: null,
+        },
+        previewFactor: 1,
+      },
+      devPreviewEnabled: false,
+      queryRefreshConfig: {
+        summary: {
+          refetchIntervalMs: false,
+          refetchOnMount: "always",
+        },
+        leaderboard: {
+          refetchIntervalMs: false,
+          refetchOnMount: "always",
+        },
+      },
+    });
+  });
+
+  it("refreshes once when the window returns to the foreground", () => {
+    const refresh = vi.fn();
+    mockDataModel({ refresh });
+
+    render(<HomeTodayProviderUsageOverview />);
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it("marks running providers that are already inside the default top three", () => {

--- a/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
+++ b/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
@@ -2,17 +2,21 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeTodayProviderUsageOverview } from "../HomeTodayProviderUsageOverview";
 import { useHomeTokenCostDataModel } from "../useHomeTokenCostDataModel";
+import type { TraceSession } from "../../../services/gateway/traceStore";
 
 vi.mock("../useHomeTokenCostDataModel", () => ({
   useHomeTokenCostDataModel: vi.fn(),
 }));
 
-function createActiveSession(providerName: string) {
+function createActiveSession(
+  providerName: string,
+  options?: { providerId?: number; cliKey?: string }
+) {
   return {
-    cli_key: "claude",
+    cli_key: options?.cliKey ?? "claude",
     session_id: `session-${providerName}`,
     session_suffix: "abcd",
-    provider_id: 1,
+    provider_id: options?.providerId ?? 1,
     provider_name: providerName,
     expires_at: Date.now(),
     request_count: 1,
@@ -20,6 +24,46 @@ function createActiveSession(providerName: string) {
     total_output_tokens: 50,
     total_cost_usd: 0.1,
     total_duration_ms: 1000,
+  };
+}
+
+function createRunningTrace(
+  providerName: string,
+  options?: { providerId?: number; cliKey?: string; traceId?: string }
+): TraceSession {
+  const cliKey = options?.cliKey ?? "claude";
+  const providerId = options?.providerId ?? 1;
+  const now = Date.now();
+
+  return {
+    trace_id: options?.traceId ?? `trace-${providerName}`,
+    cli_key: cliKey,
+    session_id: `session-${providerName}`,
+    method: "POST",
+    path: "/v1/messages",
+    query: null,
+    requested_model: null,
+    first_seen_ms: now - 5_000,
+    last_seen_ms: now,
+    attempts: [
+      {
+        trace_id: options?.traceId ?? `trace-${providerName}`,
+        cli_key: cliKey,
+        session_id: `session-${providerName}`,
+        method: "POST",
+        path: "/v1/messages",
+        query: null,
+        requested_model: null,
+        attempt_index: 1,
+        provider_id: providerId,
+        provider_name: providerName,
+        base_url: "https://example.com",
+        outcome: "started",
+        status: null,
+        attempt_started_ms: now - 3_000,
+        attempt_duration_ms: 3_000,
+      },
+    ],
   };
 }
 
@@ -252,12 +296,112 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
       <HomeTodayProviderUsageOverview activeSessions={[createActiveSession("Runtime Fresh")]} />
     );
 
-    const runtimeRow = screen.getByText("Runtime Fresh").closest("tr");
+    const runtimeRow = screen.getByText("claude/Runtime Fresh").closest("tr");
     expect(runtimeRow).toBeTruthy();
     expect(screen.queryByText("OpenAI Primary")).not.toBeInTheDocument();
     expect(within(runtimeRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
     expect(within(runtimeRow as HTMLElement).getByText("— / — / —")).toBeInTheDocument();
     expect(within(runtimeRow as HTMLElement).getAllByText("—").length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("matches a running provider to the prefixed usage row by provider id", () => {
+    mockDataModel({
+      rows: [
+        {
+          key: "codex:88",
+          name: "codex/鹿森",
+          requests_total: 9,
+          requests_success: 9,
+          requests_failed: 0,
+          total_tokens: 12_000,
+          io_total_tokens: 10_000,
+          input_tokens: 6_000,
+          output_tokens: 4_000,
+          cache_creation_input_tokens: 700,
+          cache_read_input_tokens: 1_300,
+          avg_duration_ms: 820,
+          avg_ttfb_ms: 210,
+          avg_output_tokens_per_second: 108,
+          cost_usd: 0.88,
+        },
+      ],
+    });
+
+    render(
+      <HomeTodayProviderUsageOverview
+        activeSessions={[createActiveSession("鹿森", { providerId: 88, cliKey: "codex" })]}
+      />
+    );
+
+    const providerRow = screen.getByText("codex/鹿森").closest("tr");
+    expect(providerRow).toBeTruthy();
+    expect(within(providerRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
+    expect(screen.queryByText("codex/codex/鹿森")).not.toBeInTheDocument();
+  });
+
+  it("does not keep showing a running badge when traces are gone", () => {
+    mockDataModel({
+      rows: [
+        {
+          key: "claude:1",
+          name: "Claude Main",
+          requests_total: 5,
+          requests_success: 5,
+          requests_failed: 0,
+          total_tokens: 6_200,
+          io_total_tokens: 5_000,
+          input_tokens: 3_000,
+          output_tokens: 2_000,
+          cache_creation_input_tokens: 500,
+          cache_read_input_tokens: 700,
+          avg_duration_ms: 900,
+          avg_ttfb_ms: 220,
+          avg_output_tokens_per_second: 90,
+          cost_usd: 0.5,
+        },
+      ],
+    });
+
+    render(
+      <HomeTodayProviderUsageOverview
+        activeSessions={[createActiveSession("Claude Main", { providerId: 1, cliKey: "claude" })]}
+        traces={[]}
+      />
+    );
+
+    const providerRow = screen.getByText("Claude Main").closest("tr");
+    expect(providerRow).toBeTruthy();
+    expect(within(providerRow as HTMLElement).queryByLabelText("进行中")).not.toBeInTheDocument();
+  });
+
+  it("marks running providers from live traces when traces are present", () => {
+    mockDataModel({
+      rows: [
+        {
+          key: "claude:1",
+          name: "Claude Main",
+          requests_total: 5,
+          requests_success: 5,
+          requests_failed: 0,
+          total_tokens: 6_200,
+          io_total_tokens: 5_000,
+          input_tokens: 3_000,
+          output_tokens: 2_000,
+          cache_creation_input_tokens: 500,
+          cache_read_input_tokens: 700,
+          avg_duration_ms: 900,
+          avg_ttfb_ms: 220,
+          avg_output_tokens_per_second: 90,
+          cost_usd: 0.5,
+        },
+      ],
+    });
+
+    render(<HomeTodayProviderUsageOverview traces={[createRunningTrace("Claude Main")]} />);
+
+    const providerRow = screen.getByText("Claude Main").closest("tr");
+    expect(providerRow).toBeTruthy();
+    expect(within(providerRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
   });
 
   it("shows a dash for cache hit rate when the summary has no denominator", () => {

--- a/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
+++ b/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeTodayProviderUsageOverview } from "../HomeTodayProviderUsageOverview";
 import { useHomeTokenCostDataModel } from "../useHomeTokenCostDataModel";
 import type { TraceSession } from "../../../services/gateway/traceStore";
+import type { UsageLeaderboardRow } from "../../../services/usage/usage";
 
 vi.mock("../useHomeTokenCostDataModel", () => ({
   useHomeTokenCostDataModel: vi.fn(),
@@ -64,6 +65,31 @@ function createRunningTrace(
         attempt_duration_ms: 3_000,
       },
     ],
+  };
+}
+
+function createLeaderboardRow(
+  overrides: Pick<UsageLeaderboardRow, "key" | "name"> &
+    Partial<Omit<UsageLeaderboardRow, "key" | "name">>
+): UsageLeaderboardRow {
+  const { key, name, ...rest } = overrides;
+  return {
+    key,
+    name,
+    requests_total: 1,
+    requests_success: 1,
+    requests_failed: 0,
+    total_tokens: 1_200,
+    io_total_tokens: 1_000,
+    input_tokens: 700,
+    output_tokens: 300,
+    cache_creation_input_tokens: 100,
+    cache_read_input_tokens: 100,
+    avg_duration_ms: 900,
+    avg_ttfb_ms: 200,
+    avg_output_tokens_per_second: 90,
+    cost_usd: 0.1,
+    ...rest,
   };
 }
 
@@ -238,20 +264,22 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
     });
 
     const totalWithCacheCard = screen.getByText("含缓存总 Token").parentElement;
-    const totalTokenCard = screen.getByText("总 Token").parentElement;
+    const billableTokenCard = screen.getAllByText("计费 Token")[0]?.parentElement;
     const cacheHitRateCard = screen.getByText("缓存命中率").parentElement;
     expect(totalWithCacheCard).toBeTruthy();
-    expect(totalTokenCard).toBeTruthy();
+    expect(billableTokenCard).toBeTruthy();
     expect(cacheHitRateCard).toBeTruthy();
     expect(within(totalWithCacheCard as HTMLElement).getByText("25.0K")).toBeInTheDocument();
-    expect(within(totalTokenCard as HTMLElement).getByText("20.0K")).toBeInTheDocument();
+    expect(within(billableTokenCard as HTMLElement).getByText("20.0K")).toBeInTheDocument();
     expect(within(cacheHitRateCard as HTMLElement).getByText("18.8%")).toBeInTheDocument();
     expect(screen.getByText("今日请求数")).toBeInTheDocument();
     expect(screen.getByText("20")).toBeInTheDocument();
     expect(screen.getByText("今日花费")).toBeInTheDocument();
     expect(screen.getByText("$2.21")).toBeInTheDocument();
     const providerHeader = screen.getByText("供应商").closest("th");
-    const billableTokenHeader = screen.getByText("计费 Token").closest("th");
+    const billableTokenHeader = screen.getByRole("columnheader", {
+      name: /计费 Token/,
+    });
     const cacheHeader = screen.getByText("缓存情况").closest("th");
     expect(providerHeader).toBeTruthy();
     expect(billableTokenHeader).toBeTruthy();
@@ -261,7 +289,7 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
       within(billableTokenHeader as HTMLElement).getByText("（输入+输出）")
     ).toBeInTheDocument();
     expect(
-      within(cacheHeader as HTMLElement).getByText("（含缓存 / 缓存 / 命中率）")
+      within(cacheHeader as HTMLElement).getByText("（含缓存/缓存/命中率）")
     ).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "成功率" })).toBeInTheDocument();
     expect(screen.queryByText("Token 占比")).not.toBeInTheDocument();
@@ -276,15 +304,15 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
     expect(screen.queryByText("Mistral Edge")).not.toBeInTheDocument();
     expect(screen.queryByText("Local Sandbox")).not.toBeInTheDocument();
 
-    expect(within(geminiRow as HTMLElement).getByText("8.0K / 40.0%")).toBeInTheDocument();
-    expect(within(geminiRow as HTMLElement).getByText("10.2K / 2.2K / 20.9%")).toBeInTheDocument();
+    expect(within(geminiRow as HTMLElement).getByLabelText("8.0K/40.0%")).toBeInTheDocument();
+    expect(within(geminiRow as HTMLElement).getByLabelText("10.2K/2.2K/20.9%")).toBeInTheDocument();
     expect(within(geminiRow as HTMLElement).getByText("$0.90")).toBeInTheDocument();
     expect(within(geminiRow as HTMLElement).getByText("85.7%")).toBeInTheDocument();
     expect(within(claudeRow as HTMLElement).getByText("100.0%")).toBeInTheDocument();
-    expect(within(claudeRow as HTMLElement).getByText("5.0K / 25.0%")).toBeInTheDocument();
-    expect(within(claudeRow as HTMLElement).getByText("6.2K / 1.2K / 16.7%")).toBeInTheDocument();
-    expect(within(openaiRow as HTMLElement).getByText("4.0K / 20.0%")).toBeInTheDocument();
-    expect(within(openaiRow as HTMLElement).getByText("5.8K / 1.8K / 31.6%")).toBeInTheDocument();
+    expect(within(claudeRow as HTMLElement).getByLabelText("5.0K/25.0%")).toBeInTheDocument();
+    expect(within(claudeRow as HTMLElement).getByLabelText("6.2K/1.2K/16.7%")).toBeInTheDocument();
+    expect(within(openaiRow as HTMLElement).getByLabelText("4.0K/20.0%")).toBeInTheDocument();
+    expect(within(openaiRow as HTMLElement).getByLabelText("5.8K/1.8K/31.6%")).toBeInTheDocument();
   });
 
   it("disables polling while the page is hidden", () => {
@@ -356,7 +384,9 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
     expect(deepseekRow).toBeTruthy();
     expect(screen.queryByText("OpenAI Primary")).not.toBeInTheDocument();
     expect(within(deepseekRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
-    expect(within(deepseekRow as HTMLElement).getByText("3.5K / 1.5K / 27.6%")).toBeInTheDocument();
+    expect(
+      within(deepseekRow as HTMLElement).getByLabelText("3.5K/1.5K/27.6%")
+    ).toBeInTheDocument();
   });
 
   it("renders a synthetic running row when the provider has no usage row today", () => {
@@ -370,8 +400,8 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
     expect(runtimeRow).toBeTruthy();
     expect(screen.queryByText("OpenAI Primary")).not.toBeInTheDocument();
     expect(within(runtimeRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
-    expect(within(runtimeRow as HTMLElement).getByText("— / —")).toBeInTheDocument();
-    expect(within(runtimeRow as HTMLElement).getByText("— / — / —")).toBeInTheDocument();
+    expect(within(runtimeRow as HTMLElement).getByLabelText("—/—")).toBeInTheDocument();
+    expect(within(runtimeRow as HTMLElement).getByLabelText("—/—/—")).toBeInTheDocument();
     expect(within(runtimeRow as HTMLElement).getAllByText("—").length).toBeGreaterThanOrEqual(2);
   });
 
@@ -408,6 +438,50 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
     expect(providerRow).toBeTruthy();
     expect(within(providerRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
     expect(screen.queryByText("codex/codex/鹿森")).not.toBeInTheDocument();
+  });
+
+  it("does not mark same-name providers across CLI when the live trace provider id is missing", () => {
+    mockDataModel({
+      rows: [
+        createLeaderboardRow({
+          key: "claude:21",
+          name: "claude/Shared Relay",
+          total_tokens: 10_000,
+          io_total_tokens: 9_000,
+          input_tokens: 5_000,
+          output_tokens: 4_000,
+        }),
+        createLeaderboardRow({
+          key: "codex:22",
+          name: "codex/Shared Relay",
+          total_tokens: 9_000,
+          io_total_tokens: 8_000,
+          input_tokens: 4_500,
+          output_tokens: 3_500,
+        }),
+        createLeaderboardRow({
+          key: "gemini:23",
+          name: "gemini/Other Relay",
+          total_tokens: 2_000,
+          io_total_tokens: 1_500,
+          input_tokens: 1_000,
+          output_tokens: 500,
+        }),
+      ],
+    });
+
+    render(
+      <HomeTodayProviderUsageOverview
+        traces={[createRunningTrace("Shared Relay", { providerId: 0, cliKey: "codex" })]}
+      />
+    );
+
+    const claudeRow = screen.getByText("claude/Shared Relay").closest("tr");
+    const codexRow = screen.getByText("codex/Shared Relay").closest("tr");
+    expect(claudeRow).toBeTruthy();
+    expect(codexRow).toBeTruthy();
+    expect(within(codexRow as HTMLElement).getByLabelText("进行中")).toBeInTheDocument();
+    expect(within(claudeRow as HTMLElement).queryByLabelText("进行中")).not.toBeInTheDocument();
   });
 
   it("does not keep showing a running badge when traces are gone", () => {

--- a/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
+++ b/src/components/home/__tests__/HomeTodayProviderUsageOverview.test.tsx
@@ -264,30 +264,27 @@ describe("components/home/HomeTodayProviderUsageOverview", () => {
     });
 
     const totalWithCacheCard = screen.getByText("含缓存总 Token").parentElement;
-    const billableTokenCard = screen.getAllByText("计费 Token")[0]?.parentElement;
+    const inputOutputTokenCard = screen.getAllByText("输入+输出 Token")[0]?.parentElement;
     const cacheHitRateCard = screen.getByText("缓存命中率").parentElement;
     expect(totalWithCacheCard).toBeTruthy();
-    expect(billableTokenCard).toBeTruthy();
+    expect(inputOutputTokenCard).toBeTruthy();
     expect(cacheHitRateCard).toBeTruthy();
     expect(within(totalWithCacheCard as HTMLElement).getByText("25.0K")).toBeInTheDocument();
-    expect(within(billableTokenCard as HTMLElement).getByText("20.0K")).toBeInTheDocument();
+    expect(within(inputOutputTokenCard as HTMLElement).getByText("20.0K")).toBeInTheDocument();
     expect(within(cacheHitRateCard as HTMLElement).getByText("18.8%")).toBeInTheDocument();
     expect(screen.getByText("今日请求数")).toBeInTheDocument();
     expect(screen.getByText("20")).toBeInTheDocument();
     expect(screen.getByText("今日花费")).toBeInTheDocument();
     expect(screen.getByText("$2.21")).toBeInTheDocument();
     const providerHeader = screen.getByText("供应商").closest("th");
-    const billableTokenHeader = screen.getByRole("columnheader", {
-      name: /计费 Token/,
+    const inputOutputTokenHeader = screen.getByRole("columnheader", {
+      name: /输入\+输出 Token/,
     });
     const cacheHeader = screen.getByText("缓存情况").closest("th");
     expect(providerHeader).toBeTruthy();
-    expect(billableTokenHeader).toBeTruthy();
+    expect(inputOutputTokenHeader).toBeTruthy();
     expect(cacheHeader).toBeTruthy();
     expect(within(providerHeader as HTMLElement).getByText("（前 3 个）")).toBeInTheDocument();
-    expect(
-      within(billableTokenHeader as HTMLElement).getByText("（输入+输出）")
-    ).toBeInTheDocument();
     expect(
       within(cacheHeader as HTMLElement).getByText("（含缓存/缓存/命中率）")
     ).toBeInTheDocument();

--- a/src/components/home/__tests__/HomeTokenCostPanel.test.tsx
+++ b/src/components/home/__tests__/HomeTokenCostPanel.test.tsx
@@ -100,7 +100,7 @@ describe("components/home/HomeTokenCostPanel", () => {
     render(<HomeTokenCostPanel devPreviewEnabled={true} />);
 
     const cachedTotalCard = screen.getByText("含缓存总 Token");
-    const billableTokenCard = screen.getAllByText("计费 Token")[0];
+    const inputOutputTokenCard = screen.getAllByText("输入+输出 Token")[0];
     const totalCostCard = screen.getAllByText("总花费")[0];
     const costCoverageCard = screen.getByText("成本覆盖率");
     const successCard = screen.getByText("成功请求");
@@ -117,17 +117,18 @@ describe("components/home/HomeTokenCostPanel", () => {
     expect(within(providerRow as HTMLElement).getByLabelText("12K/2K/16.7%")).toBeInTheDocument();
     expect(screen.getByText("81.0%")).toBeInTheDocument();
     expect(screen.getByText("18.2%")).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: /计费 Token/ })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /输入\+输出 Token/ })).toBeInTheDocument();
     const cacheHeader = screen.getByRole("columnheader", { name: /缓存情况/ });
     expect(within(cacheHeader).getByText("（含缓存/缓存/命中率）")).toBeInTheDocument();
     expect(screen.queryByText("Token 明细")).not.toBeInTheDocument();
     expect(screen.queryByText("含缓存总量 / 缓存量 / 缓存命中率")).not.toBeInTheDocument();
     expect(screen.queryByText("平均耗时")).not.toBeInTheDocument();
     expect(
-      cachedTotalCard.compareDocumentPosition(billableTokenCard) & Node.DOCUMENT_POSITION_FOLLOWING
+      cachedTotalCard.compareDocumentPosition(inputOutputTokenCard) &
+        Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      billableTokenCard.compareDocumentPosition(totalCostCard) & Node.DOCUMENT_POSITION_FOLLOWING
+      inputOutputTokenCard.compareDocumentPosition(totalCostCard) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
       totalCostCard.compareDocumentPosition(costCoverageCard) & Node.DOCUMENT_POSITION_FOLLOWING

--- a/src/components/home/__tests__/HomeTokenCostPanel.test.tsx
+++ b/src/components/home/__tests__/HomeTokenCostPanel.test.tsx
@@ -152,7 +152,8 @@ describe("components/home/HomeTokenCostPanel", () => {
         cliKey: null,
         providerId: null,
         limit: null,
-      })
+      }),
+      undefined
     );
   });
 
@@ -187,7 +188,8 @@ describe("components/home/HomeTokenCostPanel", () => {
         endTs: Math.floor(new Date(2026, 3, 16, 0, 0, 0).getTime() / 1000),
         cliKey: null,
         providerId: null,
-      })
+      }),
+      undefined
     );
     expect(vi.mocked(useUsageLeaderboardV2Query)).toHaveBeenLastCalledWith(
       "provider",
@@ -198,7 +200,8 @@ describe("components/home/HomeTokenCostPanel", () => {
         cliKey: null,
         providerId: null,
         limit: null,
-      })
+      }),
+      undefined
     );
 
     fireEvent.click(screen.getByRole("button", { name: "最近3天" }));
@@ -210,7 +213,8 @@ describe("components/home/HomeTokenCostPanel", () => {
         endTs: Math.floor(new Date(2026, 3, 17, 0, 0, 0).getTime() / 1000),
         cliKey: null,
         providerId: null,
-      })
+      }),
+      undefined
     );
     expect(vi.mocked(useUsageLeaderboardV2Query)).toHaveBeenLastCalledWith(
       "provider",
@@ -221,26 +225,35 @@ describe("components/home/HomeTokenCostPanel", () => {
         cliKey: null,
         providerId: null,
         limit: null,
-      })
+      }),
+      undefined
     );
 
     fireEvent.click(screen.getByRole("button", { name: "最近7天" }));
 
-    expect(vi.mocked(useUsageSummaryV2Query)).toHaveBeenLastCalledWith("weekly", {
-      startTs: null,
-      endTs: null,
-      cliKey: null,
-      providerId: null,
-    });
+    expect(vi.mocked(useUsageSummaryV2Query)).toHaveBeenLastCalledWith(
+      "weekly",
+      {
+        startTs: null,
+        endTs: null,
+        cliKey: null,
+        providerId: null,
+      },
+      undefined
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "当月" }));
 
-    expect(vi.mocked(useUsageSummaryV2Query)).toHaveBeenLastCalledWith("monthly", {
-      startTs: null,
-      endTs: null,
-      cliKey: null,
-      providerId: null,
-    });
+    expect(vi.mocked(useUsageSummaryV2Query)).toHaveBeenLastCalledWith(
+      "monthly",
+      {
+        startTs: null,
+        endTs: null,
+        cliKey: null,
+        providerId: null,
+      },
+      undefined
+    );
   });
 
   it("renders preview rows when dev preview is enabled and queries are empty", () => {

--- a/src/components/home/__tests__/HomeTokenCostPanel.test.tsx
+++ b/src/components/home/__tests__/HomeTokenCostPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeTokenCostPanel } from "../HomeTokenCostPanel";
 import { useUsageLeaderboardV2Query, useUsageSummaryV2Query } from "../../../query/usage";
@@ -100,7 +100,7 @@ describe("components/home/HomeTokenCostPanel", () => {
     render(<HomeTokenCostPanel devPreviewEnabled={true} />);
 
     const cachedTotalCard = screen.getByText("含缓存总 Token");
-    const totalCard = screen.getByText("总 Token");
+    const billableTokenCard = screen.getAllByText("计费 Token")[0];
     const totalCostCard = screen.getAllByText("总花费")[0];
     const costCoverageCard = screen.getByText("成本覆盖率");
     const successCard = screen.getByText("成功请求");
@@ -111,16 +111,23 @@ describe("components/home/HomeTokenCostPanel", () => {
     expect(screen.getByText("OpenAI 主供应商")).toBeInTheDocument();
     expect(screen.getByText("18.0K")).toBeInTheDocument();
     expect(screen.getAllByText("$1.20")).toHaveLength(2);
-    expect(screen.getByText("12K / 2K / 16.7%")).toBeInTheDocument();
+    const providerRow = screen.getByText("OpenAI 主供应商").closest("tr");
+    expect(providerRow).toBeTruthy();
+    expect(within(providerRow as HTMLElement).getByText("10K")).toBeInTheDocument();
+    expect(within(providerRow as HTMLElement).getByLabelText("12K/2K/16.7%")).toBeInTheDocument();
     expect(screen.getByText("81.0%")).toBeInTheDocument();
     expect(screen.getByText("18.2%")).toBeInTheDocument();
-    expect(screen.getByText("含缓存总量 / 缓存量 / 缓存命中率")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /计费 Token/ })).toBeInTheDocument();
+    const cacheHeader = screen.getByRole("columnheader", { name: /缓存情况/ });
+    expect(within(cacheHeader).getByText("（含缓存/缓存/命中率）")).toBeInTheDocument();
+    expect(screen.queryByText("Token 明细")).not.toBeInTheDocument();
+    expect(screen.queryByText("含缓存总量 / 缓存量 / 缓存命中率")).not.toBeInTheDocument();
     expect(screen.queryByText("平均耗时")).not.toBeInTheDocument();
     expect(
-      cachedTotalCard.compareDocumentPosition(totalCard) & Node.DOCUMENT_POSITION_FOLLOWING
+      cachedTotalCard.compareDocumentPosition(billableTokenCard) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      totalCard.compareDocumentPosition(totalCostCard) & Node.DOCUMENT_POSITION_FOLLOWING
+      billableTokenCard.compareDocumentPosition(totalCostCard) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
       totalCostCard.compareDocumentPosition(costCoverageCard) & Node.DOCUMENT_POSITION_FOLLOWING
@@ -279,7 +286,12 @@ describe("components/home/HomeTokenCostPanel", () => {
     expect(screen.getByText("Gemini Mirror")).toBeInTheDocument();
     expect(screen.getByText("99.0K")).toBeInTheDocument();
     expect(screen.getByText("$3.36")).toBeInTheDocument();
-    expect(screen.getByText("49.2K / 7.2K / 13.1%")).toBeInTheDocument();
+    const previewProviderRow = screen.getByText("OpenAI Primary").closest("tr");
+    expect(previewProviderRow).toBeTruthy();
+    expect(within(previewProviderRow as HTMLElement).getByText("42K")).toBeInTheDocument();
+    expect(
+      within(previewProviderRow as HTMLElement).getByLabelText("49.2K/7.2K/13.1%")
+    ).toBeInTheDocument();
     expect(screen.getByText("100.0%")).toBeInTheDocument();
     expect(screen.getByText("17.0%")).toBeInTheDocument();
 
@@ -350,8 +362,8 @@ describe("components/home/HomeTokenCostPanel", () => {
 
     render(<HomeTokenCostPanel />);
 
-    // Row cell renders trimmed compact form: "16K / 9K / 90%"
-    expect(screen.getByText("16K / 9K / 90%")).toBeInTheDocument();
+    // Row cell renders trimmed compact form: "16K/9K/90%"
+    expect(screen.getByLabelText("16K/9K/90%")).toBeInTheDocument();
     // Old "占比" 56.3% must NOT be rendered for this row
     expect(screen.queryByText(/56\.3%/)).not.toBeInTheDocument();
     // KPI card uses the same hit-rate formula → also 90.0% (untrimmed)
@@ -411,7 +423,7 @@ describe("components/home/HomeTokenCostPanel", () => {
 
     render(<HomeTokenCostPanel />);
 
-    expect(screen.getByText("0 / — / —")).toBeInTheDocument();
+    expect(screen.getByLabelText("0/—/—")).toBeInTheDocument();
   });
 
   it("retries summary and leaderboard queries from the error card", () => {

--- a/src/components/home/__tests__/HomeTokenCostPanel.test.tsx
+++ b/src/components/home/__tests__/HomeTokenCostPanel.test.tsx
@@ -178,6 +178,29 @@ describe("components/home/HomeTokenCostPanel", () => {
 
     render(<HomeTokenCostPanel />);
 
+    fireEvent.click(screen.getByRole("button", { name: "昨天" }));
+
+    expect(vi.mocked(useUsageSummaryV2Query)).toHaveBeenLastCalledWith(
+      "custom",
+      expect.objectContaining({
+        startTs: Math.floor(new Date(2026, 3, 15, 0, 0, 0).getTime() / 1000),
+        endTs: Math.floor(new Date(2026, 3, 16, 0, 0, 0).getTime() / 1000),
+        cliKey: null,
+        providerId: null,
+      })
+    );
+    expect(vi.mocked(useUsageLeaderboardV2Query)).toHaveBeenLastCalledWith(
+      "provider",
+      "custom",
+      expect.objectContaining({
+        startTs: Math.floor(new Date(2026, 3, 15, 0, 0, 0).getTime() / 1000),
+        endTs: Math.floor(new Date(2026, 3, 16, 0, 0, 0).getTime() / 1000),
+        cliKey: null,
+        providerId: null,
+        limit: null,
+      })
+    );
+
     fireEvent.click(screen.getByRole("button", { name: "最近3天" }));
 
     expect(vi.mocked(useUsageSummaryV2Query)).toHaveBeenLastCalledWith(

--- a/src/components/home/__tests__/HomeWorkStatusCard.test.tsx
+++ b/src/components/home/__tests__/HomeWorkStatusCard.test.tsx
@@ -2,29 +2,33 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { HomeWorkStatusCard } from "../HomeWorkStatusCard";
 
+const baseProxyProps = {
+  cliProxyLoading: false,
+  cliProxyAvailable: true,
+  cliProxyEnabled: { claude: true, codex: false, gemini: false } as any,
+  cliProxyAppliedToCurrentGateway: { claude: true, codex: null, gemini: null } as any,
+  cliProxyToggling: { claude: false, codex: false, gemini: false } as any,
+  onSetCliProxyEnabled: vi.fn(),
+};
+
+const baseRouteStrategyProps = {
+  sortModes: [{ id: 1, name: "工作策略", created_at: 1, updated_at: 1 }],
+  sortModesLoading: false,
+  sortModesAvailable: true,
+  activeModeByCli: { claude: 1, codex: null, gemini: null } as any,
+  activeModeToggling: { claude: false, codex: false, gemini: false } as any,
+  onSetCliActiveMode: vi.fn(),
+};
+
 describe("components/home/HomeWorkStatusCard", () => {
   it("renders loading and unavailable states", () => {
     render(
-      <HomeWorkStatusCard
-        cliProxyLoading={true}
-        cliProxyAvailable={null}
-        cliProxyEnabled={{ claude: true, codex: false, gemini: false } as any}
-        cliProxyAppliedToCurrentGateway={{ claude: true, codex: null, gemini: null } as any}
-        cliProxyToggling={{ claude: false, codex: false, gemini: false } as any}
-        onSetCliProxyEnabled={vi.fn()}
-      />
+      <HomeWorkStatusCard {...baseProxyProps} cliProxyLoading={true} cliProxyAvailable={null} />
     );
     expect(screen.getByText("加载中…")).toBeInTheDocument();
 
     render(
-      <HomeWorkStatusCard
-        cliProxyLoading={false}
-        cliProxyAvailable={false}
-        cliProxyEnabled={{ claude: true, codex: false, gemini: false } as any}
-        cliProxyAppliedToCurrentGateway={{ claude: true, codex: null, gemini: null } as any}
-        cliProxyToggling={{ claude: false, codex: false, gemini: false } as any}
-        onSetCliProxyEnabled={vi.fn()}
-      />
+      <HomeWorkStatusCard {...baseProxyProps} cliProxyLoading={false} cliProxyAvailable={false} />
     );
     expect(screen.getByText("数据不可用")).toBeInTheDocument();
   });
@@ -32,16 +36,7 @@ describe("components/home/HomeWorkStatusCard", () => {
   it("drives proxy toggles", () => {
     const onSetCliProxyEnabled = vi.fn();
 
-    render(
-      <HomeWorkStatusCard
-        cliProxyLoading={false}
-        cliProxyAvailable={true}
-        cliProxyEnabled={{ claude: true, codex: false, gemini: false } as any}
-        cliProxyAppliedToCurrentGateway={{ claude: true, codex: null, gemini: null } as any}
-        cliProxyToggling={{ claude: false, codex: false, gemini: false } as any}
-        onSetCliProxyEnabled={onSetCliProxyEnabled}
-      />
-    );
+    render(<HomeWorkStatusCard {...baseProxyProps} onSetCliProxyEnabled={onSetCliProxyEnabled} />);
 
     const switches = screen.getAllByRole("switch");
     fireEvent.click(switches[0]);
@@ -49,38 +44,72 @@ describe("components/home/HomeWorkStatusCard", () => {
   });
 
   it("supports horizontal layout for the second overview row", () => {
-    render(
-      <HomeWorkStatusCard
-        layout="horizontal"
-        cliProxyLoading={false}
-        cliProxyAvailable={true}
-        cliProxyEnabled={{ claude: true, codex: false, gemini: false } as any}
-        cliProxyAppliedToCurrentGateway={{ claude: true, codex: null, gemini: null } as any}
-        cliProxyToggling={{ claude: false, codex: false, gemini: false } as any}
-        onSetCliProxyEnabled={vi.fn()}
-      />
-    );
-
-    expect(screen.getByText("代理状态")).toBeInTheDocument();
-    expect(screen.getAllByRole("switch").length).toBe(3);
-  });
-
-  it("supports plain chrome when embedded into the info panel", () => {
-    render(
-      <HomeWorkStatusCard
-        layout="vertical"
-        chrome="plain"
-        cliProxyLoading={false}
-        cliProxyAvailable={true}
-        cliProxyEnabled={{ claude: true, codex: false, gemini: false } as any}
-        cliProxyAppliedToCurrentGateway={{ claude: true, codex: null, gemini: null } as any}
-        cliProxyToggling={{ claude: false, codex: false, gemini: false } as any}
-        onSetCliProxyEnabled={vi.fn()}
-      />
-    );
+    render(<HomeWorkStatusCard {...baseProxyProps} layout="horizontal" />);
 
     expect(screen.getByText("代理状态")).toBeInTheDocument();
     expect(screen.getAllByRole("switch")).toHaveLength(3);
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("supports plain chrome when embedded into the info panel", () => {
+    render(<HomeWorkStatusCard {...baseProxyProps} layout="vertical" chrome="plain" />);
+
+    expect(screen.getByText("代理状态")).toBeInTheDocument();
+    expect(screen.getAllByRole("switch")).toHaveLength(3);
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("renders route strategy selectors in the vertical plain card and forwards changes", () => {
+    const onSetCliActiveMode = vi.fn();
+
+    render(
+      <HomeWorkStatusCard
+        {...baseProxyProps}
+        layout="vertical"
+        chrome="plain"
+        {...baseRouteStrategyProps}
+        onSetCliActiveMode={onSetCliActiveMode}
+      />
+    );
+
+    expect(screen.getByRole("combobox", { name: "Claude Code 路由策略" })).toHaveValue("1");
+    expect(screen.getByRole("combobox", { name: "Codex 路由策略" })).toHaveValue("");
+    expect(screen.getByRole("combobox", { name: "Gemini 路由策略" })).toHaveValue("");
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Codex 路由策略" }), {
+      target: { value: "1" },
+    });
+    expect(onSetCliActiveMode).toHaveBeenCalledWith("codex", 1);
+  });
+
+  it("disables route strategy selectors while loading or unavailable", () => {
+    const { rerender } = render(
+      <HomeWorkStatusCard
+        {...baseProxyProps}
+        layout="vertical"
+        chrome="plain"
+        {...baseRouteStrategyProps}
+        sortModesLoading={true}
+      />
+    );
+
+    expect(screen.getByRole("combobox", { name: "Claude Code 路由策略" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "Codex 路由策略" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "Gemini 路由策略" })).toBeDisabled();
+
+    rerender(
+      <HomeWorkStatusCard
+        {...baseProxyProps}
+        layout="vertical"
+        chrome="plain"
+        {...baseRouteStrategyProps}
+        sortModesAvailable={false}
+      />
+    );
+
+    expect(screen.getByRole("combobox", { name: "Claude Code 路由策略" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "Codex 路由策略" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "Gemini 路由策略" })).toBeDisabled();
   });
 
   it("shows drift warning and repair button for enabled rows not pointing to current gateway", () => {
@@ -88,11 +117,9 @@ describe("components/home/HomeWorkStatusCard", () => {
 
     render(
       <HomeWorkStatusCard
-        cliProxyLoading={false}
-        cliProxyAvailable={true}
+        {...baseProxyProps}
         cliProxyEnabled={{ claude: false, codex: true, gemini: false } as any}
         cliProxyAppliedToCurrentGateway={{ claude: null, codex: false, gemini: null } as any}
-        cliProxyToggling={{ claude: false, codex: false, gemini: false } as any}
         onSetCliProxyEnabled={onSetCliProxyEnabled}
       />
     );
@@ -106,12 +133,9 @@ describe("components/home/HomeWorkStatusCard", () => {
   it("does not show drift warning before the current gateway origin is known", () => {
     render(
       <HomeWorkStatusCard
-        cliProxyLoading={false}
-        cliProxyAvailable={true}
+        {...baseProxyProps}
         cliProxyEnabled={{ claude: false, codex: true, gemini: false } as any}
         cliProxyAppliedToCurrentGateway={{ claude: null, codex: null, gemini: null } as any}
-        cliProxyToggling={{ claude: false, codex: false, gemini: false } as any}
-        onSetCliProxyEnabled={vi.fn()}
       />
     );
 
@@ -124,11 +148,9 @@ describe("components/home/HomeWorkStatusCard", () => {
 
     render(
       <HomeWorkStatusCard
-        cliProxyLoading={false}
-        cliProxyAvailable={true}
+        {...baseProxyProps}
         cliProxyEnabled={{ claude: false, codex: true, gemini: false } as any}
         cliProxyAppliedToCurrentGateway={{ claude: null, codex: false, gemini: null } as any}
-        cliProxyToggling={{ claude: false, codex: false, gemini: false } as any}
         onSetCliProxyEnabled={onSetCliProxyEnabled}
       />
     );
@@ -138,18 +160,23 @@ describe("components/home/HomeWorkStatusCard", () => {
     expect(onSetCliProxyEnabled).toHaveBeenCalledWith("codex", false);
   });
 
-  it("disables the repair button while proxy status is toggling", () => {
+  it("keeps route strategy visible for drifted rows and disables only the toggling cli", () => {
     render(
       <HomeWorkStatusCard
-        cliProxyLoading={false}
-        cliProxyAvailable={true}
+        {...baseProxyProps}
+        layout="vertical"
+        chrome="plain"
+        {...baseRouteStrategyProps}
         cliProxyEnabled={{ claude: false, codex: true, gemini: false } as any}
         cliProxyAppliedToCurrentGateway={{ claude: null, codex: false, gemini: null } as any}
         cliProxyToggling={{ claude: false, codex: true, gemini: false } as any}
-        onSetCliProxyEnabled={vi.fn()}
+        activeModeToggling={{ claude: false, codex: true, gemini: false } as any}
       />
     );
 
+    expect(screen.getByText("当前未指向本网关")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "修复 Codex 代理" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "Codex 路由策略" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "Claude Code 路由策略" })).not.toBeDisabled();
   });
 });

--- a/src/components/home/__tests__/HomeWorkspaceConfigPanel.test.tsx
+++ b/src/components/home/__tests__/HomeWorkspaceConfigPanel.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { HomeWorkspaceConfigPanel } from "../HomeWorkspaceConfigPanel";
+import type { HomeCliWorkspaceConfig } from "../homeWorkspaceConfigTypes";
+
+const configs: HomeCliWorkspaceConfig[] = [
+  {
+    cliKey: "claude",
+    cliLabel: "Claude Code",
+    workspaceId: 1,
+    workspaceName: "工作区 A",
+    loading: false,
+    items: [
+      { id: "prompt:1", type: "prompts", label: "Prompt", name: "默认提示词" },
+      { id: "mcp:1", type: "mcp", label: "MCP", name: "filesystem" },
+    ],
+  },
+  {
+    cliKey: "codex",
+    cliLabel: "Codex",
+    workspaceId: 2,
+    workspaceName: "Default",
+    loading: false,
+    items: [{ id: "skill:1", type: "skills", label: "Skill", name: "code-review" }],
+  },
+];
+
+describe("components/home/HomeWorkspaceConfigPanel", () => {
+  it("renders workspace info and items without a built-in route strategy control", () => {
+    render(
+      <HomeWorkspaceConfigPanel
+        configs={configs}
+        selectedCliKey="claude"
+        onSelectCliKey={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("工作区：")).toBeInTheDocument();
+    expect(screen.getByText("工作区 A")).toBeInTheDocument();
+    expect(screen.getByText("默认提示词")).toBeInTheDocument();
+    expect(screen.getByText("filesystem")).toBeInTheDocument();
+    expect(screen.queryByText("路由策略：")).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("renders the optional header addon and keeps cli switching available", () => {
+    const onSelectCliKey = vi.fn();
+
+    render(
+      <HomeWorkspaceConfigPanel
+        configs={configs}
+        selectedCliKey="claude"
+        onSelectCliKey={onSelectCliKey}
+        headerAddon={<div>route-addon</div>}
+      />
+    );
+
+    expect(screen.getByText("route-addon")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Codex" }));
+    expect(onSelectCliKey).toHaveBeenCalledWith("codex");
+  });
+});

--- a/src/components/home/homeOAuthQuotaTypes.ts
+++ b/src/components/home/homeOAuthQuotaTypes.ts
@@ -1,0 +1,17 @@
+import type { CliKey, OAuthLimitsResult } from "../../services/providers/providers";
+
+export type HomeOAuthQuotaRowState = "idle" | "loading" | "success" | "error";
+
+export type HomeOAuthQuotaRow = {
+  providerId: number;
+  cliKey: CliKey;
+  providerName: string;
+  enabled: boolean;
+  state: HomeOAuthQuotaRowState;
+  limits: OAuthLimitsResult | null;
+  error: string | null;
+};
+
+export function hasHomeOAuthQuotaText(limits: OAuthLimitsResult | null): boolean {
+  return Boolean(limits?.limit_5h_text || limits?.limit_weekly_text);
+}

--- a/src/components/home/useHomeTokenCostDataModel.ts
+++ b/src/components/home/useHomeTokenCostDataModel.ts
@@ -3,7 +3,11 @@
 
 import { useCallback, useMemo } from "react";
 import type { UsageLeaderboardRow, UsagePeriod, UsageSummary } from "../../services/usage/usage";
-import { useUsageLeaderboardV2Query, useUsageSummaryV2Query } from "../../query/usage";
+import {
+  useUsageLeaderboardV2Query,
+  useUsageSummaryV2Query,
+  type UsageV2QueryOptions,
+} from "../../query/usage";
 import { formatUnknownError } from "../../utils/errors";
 import {
   buildPreviewTokenSummary,
@@ -25,6 +29,11 @@ type TokenCostQueryConfig = {
   period: UsagePeriod;
   input: TokenCostQueryInput;
   previewFactor: number;
+};
+
+export type HomeTokenCostDataModelQueryRefreshConfig = {
+  summary?: UsageV2QueryOptions;
+  leaderboard?: UsageV2QueryOptions;
 };
 
 const EMPTY_ROWS: UsageLeaderboardRow[] = [];
@@ -64,10 +73,12 @@ export function useHomeTokenCostDataModel({
   scope,
   queryConfig,
   devPreviewEnabled,
+  queryRefreshConfig,
 }: {
   scope: TokenCostScope;
   queryConfig: TokenCostQueryConfig;
   devPreviewEnabled: boolean;
+  queryRefreshConfig?: HomeTokenCostDataModelQueryRefreshConfig;
 }): HomeTokenCostDataModel {
   const queryInput = useMemo(
     () => ({
@@ -89,8 +100,17 @@ export function useHomeTokenCostDataModel({
     [previewRowsByScope.provider]
   );
 
-  const summaryQuery = useUsageSummaryV2Query(queryConfig.period, queryConfig.input);
-  const leaderboardQuery = useUsageLeaderboardV2Query(scope, queryConfig.period, queryInput);
+  const summaryQuery = useUsageSummaryV2Query(
+    queryConfig.period,
+    queryConfig.input,
+    queryRefreshConfig?.summary
+  );
+  const leaderboardQuery = useUsageLeaderboardV2Query(
+    scope,
+    queryConfig.period,
+    queryInput,
+    queryRefreshConfig?.leaderboard
+  );
 
   const summaryRaw = summaryQuery.data ?? null;
   const rowsRaw = leaderboardQuery.data ?? EMPTY_ROWS;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -28,6 +28,7 @@ import { useHomeCircuitState } from "./home/hooks/useHomeCircuitState";
 import { useHomeSortMode } from "./home/hooks/useHomeSortMode";
 import { useHomeCliProxy } from "./home/hooks/useHomeCliProxy";
 import { useHomeOverviewFeed } from "./home/hooks/useHomeOverviewFeed";
+import { useHomeOAuthQuota } from "./home/hooks/useHomeOAuthQuota";
 import { useHomeWorkspaceConfigs } from "./home/hooks/useHomeWorkspaceConfigs";
 
 type HomeTabKey = "overview" | "cost" | "tokenCost";
@@ -73,6 +74,7 @@ export function HomePage() {
   const showOverviewUsageSection = showHomeHeatmap || showHomeUsage;
   const homeUsagePeriod = settingsQuery.data?.home_usage_period ?? DEFAULT_HOME_USAGE_PERIOD;
   const homeUsageWindowDays = resolveHomeUsageWindowDays(homeUsagePeriod);
+  const cliPriorityOrder = normalizeCliPriorityOrder(settingsQuery.data?.cli_priority_order);
   const isDevMode = import.meta.env.DEV;
   const devPreview = useDevPreviewData();
   const personalizedLayoutEnabled = useSyncExternalStore(
@@ -112,10 +114,6 @@ export function HomePage() {
     ? null
     : sessionsQuery.data != null;
 
-  const sortMode = useHomeSortMode(activeSessions);
-  const cliProxyState = useHomeCliProxy();
-  const workspaceConfigs = useHomeWorkspaceConfigs({ enabled: tab === "overview" });
-
   const {
     usageHeatmapRows,
     usageHeatmapLoading,
@@ -137,6 +135,14 @@ export function HomePage() {
     shouldRefetchOverviewUsageSeries,
     homeUsageWindowDays,
     providerLimitEnabled: !personalizedLayoutEnabled,
+  });
+  const sortMode = useHomeSortMode(activeSessions);
+  const cliProxyState = useHomeCliProxy();
+  const workspaceConfigs = useHomeWorkspaceConfigs({ enabled: tab === "overview" });
+  const oauthQuota = useHomeOAuthQuota({
+    cliPriorityOrder,
+    requestLogs,
+    enabled: tab === "overview" && personalizedLayoutEnabled,
   });
   const { pendingSortModeSwitch } = sortMode;
   const { pendingCliProxyEnablePrompt } = cliProxyState;
@@ -187,7 +193,7 @@ export function HomePage() {
             devPreviewEnabled={devPreview.enabled}
             showHomeHeatmap={showHomeHeatmap}
             showHomeUsage={showHomeUsage}
-            cliPriorityOrder={normalizeCliPriorityOrder(settingsQuery.data?.cli_priority_order)}
+            cliPriorityOrder={cliPriorityOrder}
             usageWindowDays={homeUsageWindowDays}
             usageHeatmapRows={usageHeatmapRows}
             usageHeatmapLoading={usageHeatmapLoading}
@@ -213,6 +219,12 @@ export function HomePage() {
             providerLimitAvailable={providerLimitAvailable}
             providerLimitRefreshing={providerLimitRefreshing}
             onRefreshProviderLimit={refreshProviderLimit}
+            oauthQuotaRows={oauthQuota.oauthQuotaRows}
+            oauthQuotaVisible={oauthQuota.oauthQuotaVisible}
+            oauthQuotaRefreshing={oauthQuota.oauthQuotaRefreshing}
+            oauthQuotaHasRefreshed={oauthQuota.oauthQuotaHasRefreshed}
+            onRefreshOAuthQuota={oauthQuota.refreshOAuthQuota}
+            onRefreshOAuthQuotaRow={oauthQuota.refreshOAuthQuotaRow}
             openCircuits={circuit.openCircuits}
             onResetCircuitProvider={circuit.handleResetProvider}
             resettingCircuitProviderIds={circuit.resettingProviderIds}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,7 +2,10 @@
 
 import { lazy, Suspense, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { CLIS } from "../constants/clis";
-import { HomeOverviewPanel } from "../components/home/HomeOverviewPanel";
+import {
+  HomeOverviewPanel,
+  type HomeOverviewUsageView,
+} from "../components/home/HomeOverviewPanel";
 import { useDevPreviewData } from "../hooks/useDevPreviewData";
 import { useDocumentVisibility } from "../hooks/useDocumentVisibility";
 import { useGatewaySessionsListQuery } from "../query/gateway";
@@ -84,6 +87,15 @@ export function HomePage() {
 
   const [tab, setTab] = useState<HomeTabKey>("overview");
   const [selectedLogId, setSelectedLogId] = useState<number | null>(null);
+  const [personalizedUsageView, setPersonalizedUsageView] =
+    useState<HomeOverviewUsageView>("summary");
+  const personalizedUsageChartVisible =
+    personalizedLayoutEnabled && personalizedUsageView === "usageChart";
+  const overviewUsageSeriesEnabled =
+    tab === "overview" &&
+    (personalizedUsageChartVisible || (!personalizedLayoutEnabled && showOverviewUsageSection));
+  const shouldRefetchOverviewUsageSeries =
+    personalizedUsageChartVisible || (!personalizedLayoutEnabled && showOverviewUsageSection);
 
   // --- Delegated state hooks ---
   const circuit = useHomeCircuitState();
@@ -121,8 +133,10 @@ export function HomePage() {
   } = useHomeOverviewFeed({
     overviewActive: tab === "overview",
     foregroundActive,
-    showOverviewUsageSection,
+    overviewUsageSeriesEnabled,
+    shouldRefetchOverviewUsageSeries,
     homeUsageWindowDays,
+    providerLimitEnabled: !personalizedLayoutEnabled,
   });
   const { pendingSortModeSwitch } = sortMode;
   const { pendingCliProxyEnablePrompt } = cliProxyState;
@@ -145,6 +159,19 @@ export function HomePage() {
                   onClick={() => devPreview.toggle()}
                 >
                   {devPreview.enabled ? "Dev关闭预览数据" : "Dev开启预览数据"}
+                </Button>
+              ) : null}
+              {personalizedLayoutEnabled && tab === "overview" ? (
+                <Button
+                  variant="secondary"
+                  size="md"
+                  onClick={() =>
+                    setPersonalizedUsageView((current) =>
+                      current === "summary" ? "usageChart" : "summary"
+                    )
+                  }
+                >
+                  {personalizedUsageView === "summary" ? "查看曲线" : "查看总览"}
                 </Button>
               ) : null}
               <TabList ariaLabel="首页视图切换" items={homeTabs} value={tab} onChange={setTab} />
@@ -197,6 +224,7 @@ export function HomePage() {
             onRefreshRequestLogs={refreshRequestLogs}
             selectedLogId={selectedLogId}
             onSelectLogId={setSelectedLogId}
+            personalizedUsageView={personalizedUsageView}
           />
         ) : tab === "cost" ? (
           <Suspense

--- a/src/pages/__tests__/HomePage.test.tsx
+++ b/src/pages/__tests__/HomePage.test.tsx
@@ -54,6 +54,7 @@ vi.mock("../../components/home/HomeOverviewPanel", () => ({
     devPreviewEnabled,
     showHomeHeatmap,
     showHomeUsage,
+    personalizedUsageView,
     openCircuits,
     onResetCircuitProvider,
   }: any) => (
@@ -62,6 +63,7 @@ vi.mock("../../components/home/HomeOverviewPanel", () => ({
       <div>dev-preview:{String(devPreviewEnabled)}</div>
       <div>show-heatmap:{String(showHomeHeatmap)}</div>
       <div>show-usage:{String(showHomeUsage)}</div>
+      <div>personalized-usage-view:{String(personalizedUsageView)}</div>
       <div>open-circuits:{openCircuits.length}</div>
       <button type="button" onClick={() => onResetCircuitProvider(1)}>
         reset-1
@@ -631,6 +633,46 @@ describe("pages/HomePage", () => {
     expect(screen.queryByRole("tab", { name: "花费" })).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "用量" })).toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "更多" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "查看曲线" })).toBeInTheDocument();
+    expect(vi.mocked(useUsageHourlySeriesQuery)).toHaveBeenLastCalledWith(
+      15,
+      expect.objectContaining({ enabled: false })
+    );
+  });
+
+  it("places the personalized usage toggle in the page header and enables the chart query after switching", async () => {
+    setTauriRuntime();
+
+    const client = createTestQueryClient();
+    mockHomePageBaseQueries();
+    vi.mocked(useCliProxy).mockReturnValue({
+      enabled: { claude: false, codex: false, gemini: false },
+      appliedToCurrentGateway: { claude: null, codex: null, gemini: null },
+      toggling: { claude: false, codex: false, gemini: false },
+      setCliProxyEnabled: vi.fn(),
+    } as any);
+
+    window.localStorage.setItem("aio-home-overview-logs-primary-layout", "true");
+
+    renderWithProviders(client, <HomePage />);
+
+    expect(screen.getByText("personalized-usage-view:summary")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "查看曲线" })).toBeInTheDocument();
+    expect(vi.mocked(useUsageHourlySeriesQuery)).toHaveBeenLastCalledWith(
+      15,
+      expect.objectContaining({ enabled: false })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "查看曲线" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("personalized-usage-view:usageChart")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "查看总览" })).toBeInTheDocument();
+    });
+    expect(vi.mocked(useUsageHourlySeriesQuery)).toHaveBeenLastCalledWith(
+      15,
+      expect.objectContaining({ enabled: true })
+    );
   });
 
   it("enables CLI proxy directly when no env conflicts are found", async () => {

--- a/src/pages/home/hooks/__tests__/useHomeOAuthQuota.test.tsx
+++ b/src/pages/home/hooks/__tests__/useHomeOAuthQuota.test.tsx
@@ -1,0 +1,322 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RequestLogSummary } from "../../../../services/gateway/requestLogs";
+import type { ProviderSummary } from "../../../../services/providers/providers";
+import { providerOAuthFetchLimits, providersList } from "../../../../services/providers/providers";
+import { oauthLimitsKeys } from "../../../../query/keys";
+import { createQueryWrapper, createTestQueryClient } from "../../../../test/utils/reactQuery";
+import { useHomeOAuthQuota } from "../useHomeOAuthQuota";
+
+vi.mock("../../../../services/providers/providers", async () => {
+  const actual = await vi.importActual<typeof import("../../../../services/providers/providers")>(
+    "../../../../services/providers/providers"
+  );
+  return {
+    ...actual,
+    providersList: vi.fn(),
+    providerOAuthFetchLimits: vi.fn(),
+  };
+});
+
+function makeProvider(
+  partial: Partial<ProviderSummary> & Pick<ProviderSummary, "id" | "cli_key" | "name">
+): ProviderSummary {
+  return {
+    id: partial.id,
+    cli_key: partial.cli_key,
+    name: partial.name,
+    base_urls: partial.base_urls ?? [],
+    base_url_mode: partial.base_url_mode ?? "order",
+    claude_models: partial.claude_models ?? {},
+    enabled: partial.enabled ?? true,
+    priority: partial.priority ?? 0,
+    cost_multiplier: partial.cost_multiplier ?? 1,
+    limit_5h_usd: partial.limit_5h_usd ?? null,
+    limit_daily_usd: partial.limit_daily_usd ?? null,
+    daily_reset_mode: partial.daily_reset_mode ?? "fixed",
+    daily_reset_time: partial.daily_reset_time ?? "00:00:00",
+    limit_weekly_usd: partial.limit_weekly_usd ?? null,
+    limit_monthly_usd: partial.limit_monthly_usd ?? null,
+    limit_total_usd: partial.limit_total_usd ?? null,
+    tags: partial.tags ?? [],
+    note: partial.note ?? "",
+    created_at: partial.created_at ?? 0,
+    updated_at: partial.updated_at ?? 0,
+    auth_mode: partial.auth_mode ?? "api_key",
+    oauth_provider_type: partial.oauth_provider_type ?? null,
+    oauth_email: partial.oauth_email ?? null,
+    oauth_expires_at: partial.oauth_expires_at ?? null,
+    oauth_last_error: partial.oauth_last_error ?? null,
+    source_provider_id: partial.source_provider_id ?? null,
+    bridge_type: partial.bridge_type ?? null,
+    stream_idle_timeout_seconds: partial.stream_idle_timeout_seconds ?? null,
+    api_key_configured: partial.api_key_configured ?? false,
+  };
+}
+
+function makeRequestLog(
+  partial: Partial<RequestLogSummary> & Pick<RequestLogSummary, "id">
+): RequestLogSummary {
+  return {
+    id: partial.id,
+    trace_id: partial.trace_id ?? `trace-${partial.id}`,
+    cli_key: partial.cli_key ?? "codex",
+    session_id: partial.session_id ?? null,
+    method: partial.method ?? "POST",
+    path: partial.path ?? "/v1/messages",
+    excluded_from_stats: partial.excluded_from_stats ?? false,
+    special_settings_json: partial.special_settings_json ?? null,
+    requested_model: partial.requested_model ?? null,
+    status: partial.status ?? 200,
+    error_code: partial.error_code ?? null,
+    duration_ms: partial.duration_ms ?? 1000,
+    ttfb_ms: partial.ttfb_ms ?? null,
+    attempt_count: partial.attempt_count ?? 1,
+    has_failover: partial.has_failover ?? false,
+    start_provider_id: partial.start_provider_id ?? 0,
+    start_provider_name: partial.start_provider_name ?? "start",
+    final_provider_id: partial.final_provider_id ?? 0,
+    final_provider_name: partial.final_provider_name ?? "final",
+    final_provider_source_id: partial.final_provider_source_id ?? null,
+    final_provider_source_name: partial.final_provider_source_name ?? null,
+    route: partial.route ?? [],
+    session_reuse: partial.session_reuse ?? false,
+    input_tokens: partial.input_tokens ?? null,
+    output_tokens: partial.output_tokens ?? null,
+    total_tokens: partial.total_tokens ?? null,
+    cache_read_input_tokens: partial.cache_read_input_tokens ?? null,
+    cache_creation_input_tokens: partial.cache_creation_input_tokens ?? null,
+    cache_creation_5m_input_tokens: partial.cache_creation_5m_input_tokens ?? null,
+    cache_creation_1h_input_tokens: partial.cache_creation_1h_input_tokens ?? null,
+    cost_usd: partial.cost_usd ?? null,
+    provider_chain_json: partial.provider_chain_json ?? null,
+    error_details_json: partial.error_details_json ?? null,
+    cost_multiplier: partial.cost_multiplier ?? 1,
+    created_at_ms: partial.created_at_ms ?? (partial.created_at ?? 0) * 1000,
+    created_at: partial.created_at ?? 0,
+  };
+}
+
+describe("pages/home/hooks/useHomeOAuthQuota", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(providersList).mockImplementation(async (cliKey) => {
+      if (cliKey === "codex") {
+        return [
+          makeProvider({
+            id: 11,
+            cli_key: "codex",
+            name: "Codex OAuth",
+            auth_mode: "oauth",
+          }),
+        ];
+      }
+      return [];
+    });
+  });
+
+  it("does not fetch OAuth limits automatically", async () => {
+    const client = createTestQueryClient();
+    const wrapper = createQueryWrapper(client);
+
+    const { result } = renderHook(
+      () => useHomeOAuthQuota({ cliPriorityOrder: ["claude", "codex", "gemini"] }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.oauthQuotaVisible).toBe(true));
+    expect(providerOAuthFetchLimits).not.toHaveBeenCalled();
+    expect(result.current.oauthQuotaRows[0]?.state).toBe("idle");
+  });
+
+  it("reuses existing OAuth limit cache without issuing a new request", async () => {
+    const client = createTestQueryClient();
+    client.setQueryData(oauthLimitsKeys.detail(11), {
+      limit_short_label: "5h",
+      limit_5h_text: "61%",
+      limit_weekly_text: "92%",
+      limit_5h_reset_at: null,
+      limit_weekly_reset_at: null,
+    });
+    const wrapper = createQueryWrapper(client);
+
+    const { result } = renderHook(
+      () => useHomeOAuthQuota({ cliPriorityOrder: ["claude", "codex", "gemini"] }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.oauthQuotaRows[0]?.state).toBe("success"));
+    expect(providerOAuthFetchLimits).not.toHaveBeenCalled();
+    expect(result.current.oauthQuotaRows[0]?.limits?.limit_5h_text).toBe("61%");
+  });
+
+  it("refreshes OAuth limits manually and writes the result into cache", async () => {
+    const client = createTestQueryClient();
+    const wrapper = createQueryWrapper(client);
+    vi.mocked(providerOAuthFetchLimits).mockResolvedValue({
+      limit_short_label: "5h",
+      limit_5h_text: "44%",
+      limit_weekly_text: "88%",
+      limit_5h_reset_at: null,
+      limit_weekly_reset_at: null,
+    });
+
+    const { result } = renderHook(
+      () => useHomeOAuthQuota({ cliPriorityOrder: ["claude", "codex", "gemini"] }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.oauthQuotaVisible).toBe(true));
+
+    await act(async () => {
+      await result.current.refreshOAuthQuota();
+    });
+
+    expect(providerOAuthFetchLimits).toHaveBeenCalledWith(11);
+    expect(result.current.oauthQuotaHasRefreshed).toBe(true);
+    expect(client.getQueryData(oauthLimitsKeys.detail(11))).toEqual({
+      limit_short_label: "5h",
+      limit_5h_text: "44%",
+      limit_weekly_text: "88%",
+      limit_5h_reset_at: null,
+      limit_weekly_reset_at: null,
+    });
+  });
+
+  it("refreshes only the selected OAuth provider when using row refresh", async () => {
+    vi.mocked(providersList).mockImplementation(async (cliKey) => {
+      if (cliKey === "codex") {
+        return [
+          makeProvider({
+            id: 11,
+            cli_key: "codex",
+            name: "Codex OAuth",
+            auth_mode: "oauth",
+          }),
+        ];
+      }
+      if (cliKey === "gemini") {
+        return [
+          makeProvider({
+            id: 22,
+            cli_key: "gemini",
+            name: "Gemini OAuth",
+            auth_mode: "oauth",
+          }),
+        ];
+      }
+      return [];
+    });
+
+    const client = createTestQueryClient();
+    const wrapper = createQueryWrapper(client);
+    vi.mocked(providerOAuthFetchLimits).mockImplementation(async (providerId) => ({
+      limit_short_label: providerId === 11 ? "5h" : "短窗",
+      limit_5h_text: providerId === 11 ? "44%" : "12%",
+      limit_weekly_text: providerId === 11 ? "88%" : "63%",
+      limit_5h_reset_at: null,
+      limit_weekly_reset_at: null,
+    }));
+
+    const { result } = renderHook(
+      () => useHomeOAuthQuota({ cliPriorityOrder: ["claude", "codex", "gemini"] }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.oauthQuotaRows).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.refreshOAuthQuotaRow(22);
+    });
+
+    expect(providerOAuthFetchLimits).toHaveBeenCalledTimes(1);
+    expect(providerOAuthFetchLimits).toHaveBeenCalledWith(22);
+    expect(client.getQueryData(oauthLimitsKeys.detail(11))).toBeUndefined();
+    expect(client.getQueryData(oauthLimitsKeys.detail(22))).toEqual({
+      limit_short_label: "短窗",
+      limit_5h_text: "12%",
+      limit_weekly_text: "63%",
+      limit_5h_reset_at: null,
+      limit_weekly_reset_at: null,
+    });
+  });
+
+  it("sorts OAuth providers by recent usage from request logs", async () => {
+    vi.mocked(providersList).mockImplementation(async (cliKey) => {
+      if (cliKey === "codex") {
+        return [
+          makeProvider({
+            id: 11,
+            cli_key: "codex",
+            name: "Codex OAuth",
+            auth_mode: "oauth",
+          }),
+        ];
+      }
+      if (cliKey === "gemini") {
+        return [
+          makeProvider({
+            id: 22,
+            cli_key: "gemini",
+            name: "Gemini OAuth",
+            auth_mode: "oauth",
+          }),
+        ];
+      }
+      return [];
+    });
+
+    const client = createTestQueryClient();
+    const wrapper = createQueryWrapper(client);
+    const requestLogs: RequestLogSummary[] = [
+      makeRequestLog({
+        id: 1,
+        cli_key: "codex",
+        final_provider_id: 11,
+        final_provider_name: "Codex OAuth",
+        route: [
+          {
+            provider_id: 11,
+            provider_name: "Codex OAuth",
+            ok: true,
+            attempts: 1,
+            skipped: false,
+            status: 200,
+          },
+        ],
+        created_at_ms: 1_000,
+        created_at: 1,
+      }),
+      makeRequestLog({
+        id: 2,
+        cli_key: "gemini",
+        final_provider_id: 22,
+        final_provider_name: "Gemini OAuth",
+        route: [
+          {
+            provider_id: 22,
+            provider_name: "Gemini OAuth",
+            ok: true,
+            attempts: 1,
+            skipped: false,
+            status: 200,
+          },
+        ],
+        created_at_ms: 2_000,
+        created_at: 2,
+      }),
+    ];
+
+    const { result } = renderHook(
+      () =>
+        useHomeOAuthQuota({
+          cliPriorityOrder: ["claude", "codex", "gemini"],
+          requestLogs,
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.oauthQuotaRows).toHaveLength(2));
+    expect(result.current.oauthQuotaRows.map((row) => row.providerId)).toEqual([22, 11]);
+  });
+});

--- a/src/pages/home/hooks/__tests__/useHomeOverviewFeed.test.tsx
+++ b/src/pages/home/hooks/__tests__/useHomeOverviewFeed.test.tsx
@@ -87,14 +87,16 @@ describe("pages/home/hooks/useHomeOverviewFeed", () => {
       (props: {
         overviewActive: boolean;
         foregroundActive: boolean;
-        showOverviewUsageSection: boolean;
+        overviewUsageSeriesEnabled: boolean;
+        shouldRefetchOverviewUsageSeries: boolean;
         homeUsageWindowDays: number;
       }) => useHomeOverviewFeed(props),
       {
         initialProps: {
           overviewActive: false,
           foregroundActive: true,
-          showOverviewUsageSection: true,
+          overviewUsageSeriesEnabled: true,
+          shouldRefetchOverviewUsageSeries: true,
           homeUsageWindowDays: 7,
         },
       }
@@ -103,7 +105,8 @@ describe("pages/home/hooks/useHomeOverviewFeed", () => {
     view.rerender({
       overviewActive: true,
       foregroundActive: true,
-      showOverviewUsageSection: true,
+      overviewUsageSeriesEnabled: true,
+      shouldRefetchOverviewUsageSeries: true,
       homeUsageWindowDays: 7,
     });
 
@@ -147,7 +150,8 @@ describe("pages/home/hooks/useHomeOverviewFeed", () => {
       useHomeOverviewFeed({
         overviewActive: true,
         foregroundActive: true,
-        showOverviewUsageSection: true,
+        overviewUsageSeriesEnabled: true,
+        shouldRefetchOverviewUsageSeries: true,
         homeUsageWindowDays: 7,
       })
     );
@@ -185,7 +189,8 @@ describe("pages/home/hooks/useHomeOverviewFeed", () => {
       useHomeOverviewFeed({
         overviewActive: true,
         foregroundActive: true,
-        showOverviewUsageSection: true,
+        overviewUsageSeriesEnabled: true,
+        shouldRefetchOverviewUsageSeries: true,
         homeUsageWindowDays: 7,
       })
     );

--- a/src/pages/home/hooks/useHomeOAuthQuota.ts
+++ b/src/pages/home/hooks/useHomeOAuthQuota.ts
@@ -1,0 +1,264 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { HomeOAuthQuotaRow } from "../../../components/home/homeOAuthQuotaTypes";
+import {
+  readProviderOAuthLimitsCache,
+  refreshProviderOAuthLimits,
+  useProvidersListQuery,
+} from "../../../query/providers";
+import type { RequestLogSummary } from "../../../services/gateway/requestLogs";
+import type { CliKey, ProviderSummary } from "../../../services/providers/providers";
+
+type UseHomeOAuthQuotaOptions = {
+  cliPriorityOrder: CliKey[];
+  requestLogs?: RequestLogSummary[];
+  enabled?: boolean;
+};
+
+export type UseHomeOAuthQuotaResult = {
+  oauthQuotaRows: HomeOAuthQuotaRow[];
+  oauthQuotaVisible: boolean;
+  oauthQuotaRefreshing: boolean;
+  oauthQuotaHasRefreshed: boolean;
+  refreshOAuthQuota: () => Promise<void>;
+  refreshOAuthQuotaRow: (providerId: number) => Promise<void>;
+};
+
+type OAuthProviderSummary = {
+  providerId: number;
+  cliKey: CliKey;
+  providerName: string;
+  enabled: boolean;
+};
+
+function readOAuthProviders(rows: ProviderSummary[] | null | undefined): OAuthProviderSummary[] {
+  if (!rows?.length) return [];
+  return rows
+    .filter((row) => row.auth_mode === "oauth")
+    .map((row) => ({
+      providerId: row.id,
+      cliKey: row.cli_key,
+      providerName: row.name,
+      enabled: row.enabled,
+    }));
+}
+
+function formatRefreshError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  return "读取 OAuth 配额失败";
+}
+
+function removeProviderErrors(
+  current: Record<number, string>,
+  providerIds: number[]
+): Record<number, string> {
+  if (providerIds.length === 0) return current;
+  const next = { ...current };
+  providerIds.forEach((providerId) => {
+    delete next[providerId];
+  });
+  return next;
+}
+
+function readProviderIdsFromRequestLog(log: RequestLogSummary): number[] {
+  const providerIds = new Set<number>();
+
+  for (const hop of log.route) {
+    if (!Number.isSafeInteger(hop.provider_id) || hop.provider_id <= 0) continue;
+    if (hop.skipped) continue;
+    providerIds.add(hop.provider_id);
+  }
+
+  if (Number.isSafeInteger(log.final_provider_id) && log.final_provider_id > 0) {
+    providerIds.add(log.final_provider_id);
+  }
+
+  if (
+    providerIds.size === 0 &&
+    Number.isSafeInteger(log.start_provider_id) &&
+    log.start_provider_id > 0
+  ) {
+    providerIds.add(log.start_provider_id);
+  }
+
+  return Array.from(providerIds);
+}
+
+function readRequestLogTimestampMs(log: RequestLogSummary): number {
+  if (log.created_at_ms != null && Number.isFinite(log.created_at_ms)) {
+    return log.created_at_ms;
+  }
+  return log.created_at * 1000;
+}
+
+export function useHomeOAuthQuota({
+  cliPriorityOrder,
+  requestLogs = [],
+  enabled = true,
+}: UseHomeOAuthQuotaOptions): UseHomeOAuthQuotaResult {
+  const queryClient = useQueryClient();
+  const claudeProvidersQuery = useProvidersListQuery("claude", { enabled });
+  const codexProvidersQuery = useProvidersListQuery("codex", { enabled });
+  const geminiProvidersQuery = useProvidersListQuery("gemini", { enabled });
+  const [refreshingProviderIds, setRefreshingProviderIds] = useState<Set<number>>(new Set());
+  const [providerErrors, setProviderErrors] = useState<Record<number, string>>({});
+  const [oauthQuotaHasRefreshed, setOauthQuotaHasRefreshed] = useState(false);
+  const recentUsedAtByProvider = useMemo(() => {
+    const timestamps = new Map<number, number>();
+
+    for (const log of requestLogs) {
+      const timestampMs = readRequestLogTimestampMs(log);
+      for (const providerId of readProviderIdsFromRequestLog(log)) {
+        const previous = timestamps.get(providerId) ?? 0;
+        if (timestampMs > previous) {
+          timestamps.set(providerId, timestampMs);
+        }
+      }
+    }
+
+    return timestamps;
+  }, [requestLogs]);
+
+  const oauthProviders = useMemo(() => {
+    const providersByCli: Record<CliKey, OAuthProviderSummary[]> = {
+      claude: readOAuthProviders(claudeProvidersQuery.data),
+      codex: readOAuthProviders(codexProvidersQuery.data),
+      gemini: readOAuthProviders(geminiProvidersQuery.data),
+    };
+
+    const orderedProviders = cliPriorityOrder.flatMap((cliKey) => providersByCli[cliKey] ?? []);
+
+    return orderedProviders
+      .map((provider, index) => ({
+        provider,
+        index,
+        lastUsedAt: recentUsedAtByProvider.get(provider.providerId) ?? null,
+      }))
+      .sort((left, right) => {
+        if (
+          left.lastUsedAt != null &&
+          right.lastUsedAt != null &&
+          left.lastUsedAt !== right.lastUsedAt
+        ) {
+          return right.lastUsedAt - left.lastUsedAt;
+        }
+        if (left.lastUsedAt != null) return -1;
+        if (right.lastUsedAt != null) return 1;
+        return left.index - right.index;
+      })
+      .map((item) => item.provider);
+  }, [
+    claudeProvidersQuery.data,
+    cliPriorityOrder,
+    codexProvidersQuery.data,
+    geminiProvidersQuery.data,
+    recentUsedAtByProvider,
+  ]);
+
+  const oauthQuotaRows = useMemo<HomeOAuthQuotaRow[]>(() => {
+    return oauthProviders.map((provider) => {
+      const error = providerErrors[provider.providerId] ?? null;
+      const limits = readProviderOAuthLimitsCache(queryClient, provider.providerId);
+
+      if (error) {
+        return {
+          ...provider,
+          state: "error",
+          limits: null,
+          error,
+        };
+      }
+
+      if (refreshingProviderIds.has(provider.providerId)) {
+        return {
+          ...provider,
+          state: "loading",
+          limits,
+          error: null,
+        };
+      }
+
+      if (limits) {
+        return {
+          ...provider,
+          state: "success",
+          limits,
+          error: null,
+        };
+      }
+
+      return {
+        ...provider,
+        state: "idle",
+        limits: null,
+        error: null,
+      };
+    });
+  }, [oauthProviders, providerErrors, queryClient, refreshingProviderIds]);
+
+  const refreshOAuthProviders = useCallback(
+    async (providers: OAuthProviderSummary[]) => {
+      if (!providers.length) return;
+
+      const providerIds = providers.map((provider) => provider.providerId);
+      setRefreshingProviderIds((current) => {
+        const next = new Set(current);
+        providerIds.forEach((providerId) => next.add(providerId));
+        return next;
+      });
+      setProviderErrors((current) => removeProviderErrors(current, providerIds));
+      setOauthQuotaHasRefreshed(true);
+
+      const settled = await Promise.allSettled(
+        providers.map(async (provider) => {
+          await refreshProviderOAuthLimits(queryClient, provider.providerId);
+          return provider.providerId;
+        })
+      );
+
+      const nextErrors: Record<number, string> = {};
+
+      settled.forEach((result, index) => {
+        if (result.status === "fulfilled") return;
+        const providerId = providers[index]?.providerId;
+        if (providerId == null) return;
+        nextErrors[providerId] = formatRefreshError(result.reason);
+      });
+
+      setProviderErrors((current) => ({
+        ...removeProviderErrors(current, providerIds),
+        ...nextErrors,
+      }));
+      setRefreshingProviderIds((current) => {
+        const next = new Set(current);
+        providerIds.forEach((providerId) => next.delete(providerId));
+        return next;
+      });
+    },
+    [queryClient]
+  );
+
+  const refreshOAuthQuota = useCallback(async () => {
+    if (!oauthProviders.length) return;
+    await refreshOAuthProviders(oauthProviders);
+  }, [oauthProviders, refreshOAuthProviders]);
+
+  const refreshOAuthQuotaRow = useCallback(
+    async (providerId: number) => {
+      const target = oauthProviders.find((provider) => provider.providerId === providerId);
+      if (!target) return;
+      await refreshOAuthProviders([target]);
+    },
+    [oauthProviders, refreshOAuthProviders]
+  );
+
+  return {
+    oauthQuotaRows,
+    oauthQuotaVisible: oauthProviders.length > 0,
+    oauthQuotaRefreshing: refreshingProviderIds.size > 0,
+    oauthQuotaHasRefreshed,
+    refreshOAuthQuota,
+    refreshOAuthQuotaRow,
+  };
+}

--- a/src/pages/home/hooks/useHomeOverviewFeed.ts
+++ b/src/pages/home/hooks/useHomeOverviewFeed.ts
@@ -11,24 +11,28 @@ import { useHomeFreshnessOwner } from "./useHomeFreshnessOwner";
 type UseHomeOverviewFeedOptions = {
   overviewActive: boolean;
   foregroundActive: boolean;
-  showOverviewUsageSection: boolean;
+  overviewUsageSeriesEnabled: boolean;
+  shouldRefetchOverviewUsageSeries: boolean;
   homeUsageWindowDays: number;
+  providerLimitEnabled?: boolean;
 };
 
 export function useHomeOverviewFeed({
   overviewActive,
   foregroundActive,
-  showOverviewUsageSection,
+  overviewUsageSeriesEnabled,
+  shouldRefetchOverviewUsageSeries,
   homeUsageWindowDays,
+  providerLimitEnabled = true,
 }: UseHomeOverviewFeedOptions) {
   const previousOverviewActiveRef = useRef(false);
   const overviewForegroundActive = overviewActive && foregroundActive;
 
   const usageHeatmapQuery = useUsageHourlySeriesQuery(homeUsageWindowDays, {
-    enabled: overviewActive && showOverviewUsageSection,
+    enabled: overviewActive && overviewUsageSeriesEnabled,
   });
   const providerLimitQuery = useProviderLimitUsageV1Query(null, {
-    enabled: overviewForegroundActive,
+    enabled: providerLimitEnabled && overviewForegroundActive,
   });
   const requestLogsFeed = useRequestLogsFeed({
     limit: 50,
@@ -36,14 +40,14 @@ export function useHomeOverviewFeed({
   });
 
   const refetchUsageHeatmapSilently = useCallback(async () => {
-    if (!showOverviewUsageSection) return null;
+    if (!shouldRefetchOverviewUsageSeries) return null;
     return usageHeatmapQuery.refetch();
-  }, [showOverviewUsageSection, usageHeatmapQuery]);
+  }, [shouldRefetchOverviewUsageSeries, usageHeatmapQuery]);
 
   const refetchProviderLimitSilently = useCallback(async () => {
-    if (!overviewForegroundActive) return null;
+    if (!providerLimitEnabled || !overviewForegroundActive) return null;
     return providerLimitQuery.refetch();
-  }, [overviewForegroundActive, providerLimitQuery]);
+  }, [overviewForegroundActive, providerLimitEnabled, providerLimitQuery]);
 
   const refetchRequestLogsSilently = useCallback(async () => {
     return requestLogsFeed.refreshRequestLogs();
@@ -98,12 +102,17 @@ export function useHomeOverviewFeed({
   });
 
   return {
-    usageHeatmapRows: usageHeatmapQuery.data ?? [],
-    usageHeatmapLoading: usageHeatmapQuery.isFetching,
-    providerLimitRows: providerLimitQuery.data ?? [],
-    providerLimitLoading: providerLimitQuery.isLoading,
-    providerLimitRefreshing: providerLimitQuery.isFetching && !providerLimitQuery.isLoading,
-    providerLimitAvailable: providerLimitQuery.isLoading ? null : providerLimitQuery.data != null,
+    usageHeatmapRows: overviewUsageSeriesEnabled ? (usageHeatmapQuery.data ?? []) : [],
+    usageHeatmapLoading: overviewUsageSeriesEnabled && usageHeatmapQuery.isFetching,
+    providerLimitRows: providerLimitEnabled ? (providerLimitQuery.data ?? []) : [],
+    providerLimitLoading: providerLimitEnabled && providerLimitQuery.isLoading,
+    providerLimitRefreshing:
+      providerLimitEnabled && providerLimitQuery.isFetching && !providerLimitQuery.isLoading,
+    providerLimitAvailable: providerLimitEnabled
+      ? providerLimitQuery.isLoading
+        ? null
+        : providerLimitQuery.data != null
+      : null,
     requestLogs: requestLogsFeed.requestLogs,
     requestLogsLoading: requestLogsFeed.requestLogsLoading,
     requestLogsRefreshing: requestLogsFeed.requestLogsRefreshing,

--- a/src/pages/home/hooks/useHomeOverviewFeed.ts
+++ b/src/pages/home/hooks/useHomeOverviewFeed.ts
@@ -33,6 +33,7 @@ export function useHomeOverviewFeed({
   });
   const providerLimitQuery = useProviderLimitUsageV1Query(null, {
     enabled: providerLimitEnabled && overviewForegroundActive,
+    refetchIntervalMs: providerLimitEnabled && overviewForegroundActive ? 30000 : false,
   });
   const requestLogsFeed = useRequestLogsFeed({
     limit: 50,

--- a/src/pages/providers/Cx2ccSection.tsx
+++ b/src/pages/providers/Cx2ccSection.tsx
@@ -1,9 +1,22 @@
+import { useEffect, useState } from "react";
 import { FormField } from "../../ui/FormField";
 import { Input } from "../../ui/Input";
 import { Select } from "../../ui/Select";
 import { TagsField } from "./TagsField";
 import { CX2CC_GLOBAL_SOURCE_VALUE, CX2CC_PROXY_TOKEN } from "./providerEditorUtils";
 import type { UseProviderEditorFormReturn } from "./useProviderEditorForm";
+
+const CX2CC_DEFAULT_MODEL = "gpt-5.5";
+const CX2CC_DEFAULT_MODEL_OPTIONS = [CX2CC_DEFAULT_MODEL, "gpt-5.4"] as const;
+const CX2CC_MANUAL_MODEL_VALUE = "__manual__";
+const CX2CC_MODEL_MAPPING_KEYS = [
+  "main_model",
+  "reasoning_model",
+  "haiku_model",
+  "sonnet_model",
+  "opus_model",
+] as const;
+type Cx2ccFallbackModels = { main: string; haiku: string; sonnet: string; opus: string } | null;
 
 export function Cx2ccSection(props: { form: UseProviderEditorFormReturn }) {
   const {
@@ -19,8 +32,28 @@ export function Cx2ccSection(props: { form: UseProviderEditorFormReturn }) {
     selectedCx2ccSourceProvider,
     codexGatewayBaseUrl,
     cx2ccFallbackModels,
+    claudeModels,
+    setClaudeModels,
     codexProviders,
   } = props.form;
+  const [manualModelSelected, setManualModelSelected] = useState(false);
+  const selectedDefaultModel = manualModelSelected
+    ? CX2CC_MANUAL_MODEL_VALUE
+    : resolveCx2ccDefaultModelSelectValue(claudeModels);
+  const defaultModelOptions =
+    selectedDefaultModel !== CX2CC_MANUAL_MODEL_VALUE &&
+    !CX2CC_DEFAULT_MODEL_OPTIONS.includes(
+      selectedDefaultModel as (typeof CX2CC_DEFAULT_MODEL_OPTIONS)[number]
+    )
+      ? ([selectedDefaultModel, ...CX2CC_DEFAULT_MODEL_OPTIONS] as const)
+      : CX2CC_DEFAULT_MODEL_OPTIONS;
+
+  useEffect(() => {
+    setClaudeModels((prev) => {
+      if (normalizeModelName(prev.main_model)) return prev;
+      return withCx2ccDefaultModel(prev, CX2CC_DEFAULT_MODEL);
+    });
+  }, [setClaudeModels]);
 
   return (
     <>
@@ -42,48 +75,93 @@ export function Cx2ccSection(props: { form: UseProviderEditorFormReturn }) {
         <Input placeholder="可选备注信息" disabled={saving} {...register("note")} />
       </FormField>
 
-      <FormField label="源 Codex 来源">
-        <Select
-          value={cx2ccSourceValue}
-          onChange={(e) => {
-            setCx2ccSourceValue(e.target.value);
-          }}
-          disabled={saving}
-          className="w-full"
-        >
-          <option value="">请选择 Codex 来源…</option>
-          <option value={CX2CC_GLOBAL_SOURCE_VALUE}>
-            当前 AIO 服务 Codex 网关（跟随当前分流）
-          </option>
-          {codexProviders
-            .filter((p) => p.enabled && p.source_provider_id == null && p.bridge_type == null)
-            .map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name} ({p.auth_mode === "oauth" ? "OAuth" : "API Key"})
+      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(12rem,16rem)]">
+        <FormField label="源 Codex 来源">
+          {(id) => (
+            <Select
+              id={id}
+              value={cx2ccSourceValue}
+              onChange={(e) => {
+                setCx2ccSourceValue(e.target.value);
+              }}
+              disabled={saving}
+              className="w-full"
+            >
+              <option value="">请选择 Codex 来源…</option>
+              <option value={CX2CC_GLOBAL_SOURCE_VALUE}>
+                当前 AIO 服务 Codex 网关（跟随当前分流）
               </option>
-            ))}
-        </Select>
+              {codexProviders
+                .filter((p) => p.enabled && p.source_provider_id == null && p.bridge_type == null)
+                .map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name} ({p.auth_mode === "oauth" ? "OAuth" : "API Key"})
+                  </option>
+                ))}
+            </Select>
+          )}
+        </FormField>
+
+        <FormField label="默认模型" hint="用于 CX2CC 转译">
+          {(id) => (
+            <Select
+              id={id}
+              value={selectedDefaultModel}
+              onChange={(e) => {
+                const value = e.currentTarget.value;
+                if (value === CX2CC_MANUAL_MODEL_VALUE) {
+                  setManualModelSelected(true);
+                  return;
+                }
+                setManualModelSelected(false);
+                setClaudeModels((prev) => ({
+                  ...prev,
+                  main_model: value,
+                  reasoning_model: value,
+                  haiku_model: value,
+                  sonnet_model: value,
+                  opus_model: value,
+                }));
+              }}
+              disabled={saving}
+              mono
+            >
+              <option value={CX2CC_MANUAL_MODEL_VALUE}>手动</option>
+              {defaultModelOptions.map((model) => (
+                <option key={model} value={model}>
+                  {model.toUpperCase()}
+                </option>
+              ))}
+            </Select>
+          )}
+        </FormField>
+      </div>
+
+      <div>
         {isCodexGatewaySource ? (
           <Cx2ccGatewaySourceInfo
             codexGatewayBaseUrl={codexGatewayBaseUrl}
             cx2ccFallbackModels={cx2ccFallbackModels}
+            claudeModels={claudeModels}
           />
         ) : selectedCx2ccSourceProvider ? (
           <Cx2ccProviderSourceInfo
             provider={selectedCx2ccSourceProvider}
             cx2ccFallbackModels={cx2ccFallbackModels}
+            claudeModels={claudeModels}
           />
         ) : null}
-      </FormField>
+      </div>
     </>
   );
 }
 
 function Cx2ccGatewaySourceInfo(props: {
   codexGatewayBaseUrl: string;
-  cx2ccFallbackModels: { main: string; haiku: string; sonnet: string; opus: string } | null;
+  cx2ccFallbackModels: Cx2ccFallbackModels;
+  claudeModels: UseProviderEditorFormReturn["claudeModels"];
 }) {
-  const { codexGatewayBaseUrl, cx2ccFallbackModels } = props;
+  const { codexGatewayBaseUrl, cx2ccFallbackModels, claudeModels } = props;
 
   return (
     <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2.5 text-xs text-slate-500 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400">
@@ -118,16 +196,20 @@ function Cx2ccGatewaySourceInfo(props: {
       <p className="mt-1 text-[11px] leading-5">
         说明：转译后的请求会进入当前 AIO 服务 Codex 网关，再按当前 Codex 分流继续路由。
       </p>
-      <Cx2ccFallbackModelsInfo cx2ccFallbackModels={cx2ccFallbackModels} />
+      <Cx2ccFallbackModelsInfo
+        cx2ccFallbackModels={cx2ccFallbackModels}
+        claudeModels={claudeModels}
+      />
     </div>
   );
 }
 
 function Cx2ccProviderSourceInfo(props: {
   provider: { name: string; auth_mode: string; cost_multiplier: number; base_urls: string[] };
-  cx2ccFallbackModels: { main: string; haiku: string; sonnet: string; opus: string } | null;
+  cx2ccFallbackModels: Cx2ccFallbackModels;
+  claudeModels: UseProviderEditorFormReturn["claudeModels"];
 }) {
-  const { provider, cx2ccFallbackModels } = props;
+  const { provider, cx2ccFallbackModels, claudeModels } = props;
 
   return (
     <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2.5 text-xs text-slate-500 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400">
@@ -158,34 +240,77 @@ function Cx2ccProviderSourceInfo(props: {
           </span>
         </span>
       </div>
-      <Cx2ccFallbackModelsInfo cx2ccFallbackModels={cx2ccFallbackModels} />
+      <Cx2ccFallbackModelsInfo
+        cx2ccFallbackModels={cx2ccFallbackModels}
+        claudeModels={claudeModels}
+      />
     </div>
   );
 }
 
 function Cx2ccFallbackModelsInfo(props: {
-  cx2ccFallbackModels: { main: string; haiku: string; sonnet: string; opus: string } | null;
+  cx2ccFallbackModels: Cx2ccFallbackModels;
+  claudeModels: UseProviderEditorFormReturn["claudeModels"];
 }) {
-  const { cx2ccFallbackModels } = props;
+  const { cx2ccFallbackModels, claudeModels } = props;
 
   return (
     <p className="mt-1 text-[11px] leading-5">
-      默认模型映射： 主模型
+      当前模型映射： 主模型
       <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
-        {cx2ccFallbackModels?.main ?? "全局默认值"}
+        {effectiveCx2ccModel(claudeModels.main_model, cx2ccFallbackModels?.main)}
       </span>
       / Haiku
       <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
-        {cx2ccFallbackModels?.haiku ?? "全局默认值"}
+        {effectiveCx2ccModel(claudeModels.haiku_model, cx2ccFallbackModels?.haiku)}
       </span>
       / Sonnet
       <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
-        {cx2ccFallbackModels?.sonnet ?? "全局默认值"}
+        {effectiveCx2ccModel(claudeModels.sonnet_model, cx2ccFallbackModels?.sonnet)}
       </span>
       / Opus
       <span className="mx-1 font-mono text-slate-700 dark:text-slate-200">
-        {cx2ccFallbackModels?.opus ?? "全局默认值"}
+        {effectiveCx2ccModel(claudeModels.opus_model, cx2ccFallbackModels?.opus)}
       </span>
     </p>
   );
+}
+
+function normalizeModelName(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  return trimmed || null;
+}
+
+function withCx2ccDefaultModel(
+  value: UseProviderEditorFormReturn["claudeModels"],
+  defaultModel: string
+) {
+  return {
+    ...value,
+    main_model: normalizeModelName(value.main_model) ?? defaultModel,
+    reasoning_model: normalizeModelName(value.reasoning_model) ?? defaultModel,
+    haiku_model: normalizeModelName(value.haiku_model) ?? defaultModel,
+    sonnet_model: normalizeModelName(value.sonnet_model) ?? defaultModel,
+    opus_model: normalizeModelName(value.opus_model) ?? defaultModel,
+  };
+}
+
+function resolveCx2ccDefaultModelSelectValue(value: UseProviderEditorFormReturn["claudeModels"]) {
+  const normalizedValues = CX2CC_MODEL_MAPPING_KEYS.map((key) => normalizeModelName(value[key]));
+  const configuredValues = normalizedValues.filter((model): model is string => model != null);
+  if (configuredValues.length === 0) return CX2CC_DEFAULT_MODEL;
+
+  const firstModel = normalizedValues[0];
+  if (firstModel && normalizedValues.every((model) => model === firstModel)) {
+    return firstModel;
+  }
+
+  return CX2CC_MANUAL_MODEL_VALUE;
+}
+
+function effectiveCx2ccModel(
+  providerModel: string | null | undefined,
+  fallbackModel: string | null | undefined
+) {
+  return normalizeModelName(providerModel) ?? normalizeModelName(fallbackModel) ?? "全局默认值";
 }

--- a/src/pages/providers/__tests__/ProviderEditorDialog.test.tsx
+++ b/src/pages/providers/__tests__/ProviderEditorDialog.test.tsx
@@ -480,15 +480,15 @@ describe("pages/providers/ProviderEditorDialog", () => {
     fireEvent.change(dialog.getByPlaceholderText("default"), {
       target: { value: "Bridge Provider" },
     });
-    fireEvent.change(dialog.getByRole("combobox"), { target: { value: "7" } });
+    fireEvent.change(dialog.getByLabelText("源 Codex 来源"), { target: { value: "7" } });
 
     await waitFor(() => {
       expect(dialog.getByText("Codex Source")).toBeInTheDocument();
       expect(dialog.getByText("API Key")).toBeInTheDocument();
       expect(dialog.getByText("x1.80")).toBeInTheDocument();
       expect(dialog.getByText("https://codex.example.com/v1")).toBeInTheDocument();
-      expect(dialog.getByText(/默认模型映射：/)).toBeInTheDocument();
-      expect(dialog.getAllByText("gpt-5.4").length).toBeGreaterThanOrEqual(1);
+      expect(dialog.getByText(/当前模型映射：/)).toBeInTheDocument();
+      expect(dialog.getAllByText("gpt-5.5").length).toBeGreaterThanOrEqual(1);
     });
 
     fireEvent.click(dialog.getByRole("button", { name: "保存" }));
@@ -536,9 +536,24 @@ describe("pages/providers/ProviderEditorDialog", () => {
     fireEvent.change(dialog.getByPlaceholderText("default"), {
       target: { value: "Bridge Gateway Provider" },
     });
-    fireEvent.change(dialog.getByRole("combobox"), {
+    fireEvent.change(dialog.getByLabelText("源 Codex 来源"), {
       target: { value: "__codex_gateway__" },
     });
+    const defaultModelSelect = dialog.getByLabelText("默认模型");
+    await waitFor(() => {
+      expect(defaultModelSelect).toHaveValue("gpt-5.5");
+      expect(dialog.getByPlaceholderText(/kimi-k2-thinking/)).toHaveValue("gpt-5.5");
+    });
+    const thinkingInput = dialog.getByPlaceholderText(/kimi-k2-thinking/);
+    fireEvent.change(defaultModelSelect, { target: { value: "__manual__" } });
+    expect(defaultModelSelect).toHaveValue("__manual__");
+    expect(thinkingInput).toHaveValue("gpt-5.5");
+    fireEvent.change(defaultModelSelect, { target: { value: "gpt-5.4" } });
+    expect(thinkingInput).toHaveValue("gpt-5.4");
+    fireEvent.change(thinkingInput, { target: { value: "manual-thinking" } });
+    expect(defaultModelSelect).toHaveValue("__manual__");
+    fireEvent.change(defaultModelSelect, { target: { value: "gpt-5.5" } });
+    expect(thinkingInput).toHaveValue("gpt-5.5");
 
     await waitFor(() => {
       expect(dialog.getByText("当前 AIO 服务 Codex 网关")).toBeInTheDocument();
@@ -547,6 +562,7 @@ describe("pages/providers/ProviderEditorDialog", () => {
       expect(dialog.getByText("http://127.0.0.1:37123/v1")).toBeInTheDocument();
       expect(dialog.getByText("aio-coding-hub")).toBeInTheDocument();
       expect(dialog.getByText(/转译后的请求会进入当前 AIO 服务 Codex 网关/)).toBeInTheDocument();
+      expect(dialog.getAllByText("gpt-5.5").length).toBeGreaterThanOrEqual(1);
     });
 
     fireEvent.click(dialog.getByRole("button", { name: "保存" }));
@@ -558,6 +574,13 @@ describe("pages/providers/ProviderEditorDialog", () => {
           costMultiplier: 0,
           sourceProviderId: null,
           bridgeType: "cx2cc",
+          claudeModels: {
+            main_model: "gpt-5.5",
+            reasoning_model: "gpt-5.5",
+            haiku_model: "gpt-5.5",
+            sonnet_model: "gpt-5.5",
+            opus_model: "gpt-5.5",
+          },
         })
       )
     );

--- a/src/pages/settings/__tests__/SettingsMainColumn.test.tsx
+++ b/src/pages/settings/__tests__/SettingsMainColumn.test.tsx
@@ -261,7 +261,7 @@ describe("pages/settings/SettingsMainColumn", () => {
 
     expect(screen.getByRole("button", { name: "供应商限额" })).toBeInTheDocument();
     expect(window.localStorage.getItem("aio-home-overview-tab-order")).toBe(
-      JSON.stringify(["providerLimit", "workspaceConfig", "circuit", "sessions"])
+      JSON.stringify(["providerLimit", "workspaceConfig", "circuit", "sessions", "oauthQuota"])
     );
   });
 

--- a/src/query/__tests__/usage.test.tsx
+++ b/src/query/__tests__/usage.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UsageSummary } from "../../services/usage/usage";
 import {
   usageHourlySeries,
@@ -10,6 +10,7 @@ import {
 } from "../../services/usage/usage";
 import { createQueryWrapper, createTestQueryClient } from "../../test/utils/reactQuery";
 import { setTauriRuntime } from "../../test/utils/tauriRuntime";
+import { usageKeys } from "../keys";
 import {
   useUsageHourlySeriesQuery,
   useUsageLeaderboardV2Query,
@@ -17,6 +18,13 @@ import {
   useUsageSummaryQuery,
   useUsageSummaryV2Query,
 } from "../usage";
+
+function queryRefreshOptions(query: { options?: unknown } | undefined) {
+  return (query?.options ?? {}) as {
+    refetchInterval?: number | false;
+    refetchOnMount?: boolean | "always";
+  };
+}
 
 vi.mock("../../services/usage/usage", async () => {
   const actual = await vi.importActual<typeof import("../../services/usage/usage")>(
@@ -55,6 +63,10 @@ function makeUsageSummary(overrides: Partial<UsageSummary> = {}): UsageSummary {
 }
 
 describe("query/usage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("calls usageHourlySeries with tauri runtime", async () => {
     setTauriRuntime();
 
@@ -132,33 +144,37 @@ describe("query/usage", () => {
     expect(usageSummary).not.toHaveBeenCalled();
   });
 
-  it("calls usageSummaryV2 with tauri runtime", async () => {
+  it("calls usageSummaryV2 with tauri runtime and forwards refresh options", async () => {
     setTauriRuntime();
 
     vi.mocked(usageSummaryV2).mockResolvedValue(makeUsageSummary());
 
     const client = createTestQueryClient();
     const wrapper = createQueryWrapper(client);
+    const input = {
+      startTs: 1,
+      endTs: 2,
+      cliKey: "claude" as const,
+      providerId: 7,
+    };
 
     renderHook(
       () =>
-        useUsageSummaryV2Query("daily", {
-          startTs: 1,
-          endTs: 2,
-          cliKey: "claude",
-          providerId: 7,
+        useUsageSummaryV2Query("daily", input, {
+          refetchIntervalMs: 60_000,
+          refetchOnMount: "always",
         }),
       { wrapper }
     );
 
     await waitFor(() => {
-      expect(usageSummaryV2).toHaveBeenCalledWith("daily", {
-        startTs: 1,
-        endTs: 2,
-        cliKey: "claude",
-        providerId: 7,
-      });
+      expect(usageSummaryV2).toHaveBeenCalledWith("daily", input);
     });
+
+    const query = client.getQueryCache().find({ queryKey: usageKeys.summaryV2("daily", input) });
+    const options = queryRefreshOptions(query);
+    expect(options.refetchInterval).toBe(60_000);
+    expect(options.refetchOnMount).toBe("always");
   });
 
   it("does not call usageSummaryV2 when disabled", async () => {
@@ -172,7 +188,7 @@ describe("query/usage", () => {
         useUsageSummaryV2Query(
           "daily",
           { startTs: 1, endTs: 2, cliKey: "claude", providerId: null },
-          { enabled: false }
+          { enabled: false, refetchIntervalMs: 60_000, refetchOnMount: "always" }
         ),
       { wrapper }
     );
@@ -181,35 +197,40 @@ describe("query/usage", () => {
     expect(usageSummaryV2).not.toHaveBeenCalled();
   });
 
-  it("calls usageLeaderboardV2 with tauri runtime", async () => {
+  it("calls usageLeaderboardV2 with tauri runtime and forwards refresh options", async () => {
     setTauriRuntime();
 
     vi.mocked(usageLeaderboardV2).mockResolvedValue([]);
 
     const client = createTestQueryClient();
     const wrapper = createQueryWrapper(client);
+    const input = {
+      startTs: 1,
+      endTs: 2,
+      cliKey: "claude" as const,
+      providerId: 9,
+      limit: null,
+    };
 
     renderHook(
       () =>
-        useUsageLeaderboardV2Query("provider", "weekly", {
-          startTs: 1,
-          endTs: 2,
-          cliKey: "claude",
-          providerId: 9,
-          limit: null,
+        useUsageLeaderboardV2Query("provider", "weekly", input, {
+          refetchIntervalMs: 60_000,
+          refetchOnMount: "always",
         }),
       { wrapper }
     );
 
     await waitFor(() => {
-      expect(usageLeaderboardV2).toHaveBeenCalledWith("provider", "weekly", {
-        startTs: 1,
-        endTs: 2,
-        cliKey: "claude",
-        providerId: 9,
-        limit: null,
-      });
+      expect(usageLeaderboardV2).toHaveBeenCalledWith("provider", "weekly", input);
     });
+
+    const query = client
+      .getQueryCache()
+      .find({ queryKey: usageKeys.leaderboardV2("provider", "weekly", input) });
+    const options = queryRefreshOptions(query);
+    expect(options.refetchInterval).toBe(60_000);
+    expect(options.refetchOnMount).toBe("always");
   });
 
   it("does not call usageLeaderboardV2 when disabled", async () => {
@@ -230,7 +251,7 @@ describe("query/usage", () => {
             providerId: null,
             limit: null,
           },
-          { enabled: false }
+          { enabled: false, refetchIntervalMs: 60_000, refetchOnMount: "always" }
         ),
       { wrapper }
     );

--- a/src/query/providers.ts
+++ b/src/query/providers.ts
@@ -1,4 +1,10 @@
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  QueryClient,
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   providerClaudeTerminalLaunchCommand,
   providerUpsert,
@@ -49,6 +55,38 @@ export async function fetchProviderOAuthStatus(
     queryKey: providersKeys.oauthStatus(providerId),
     queryFn: () => providerOAuthStatus(providerId),
   });
+}
+
+const EMPTY_OAUTH_LIMITS_RESULT: OAuthLimitsResult = {
+  limit_short_label: null,
+  limit_5h_text: null,
+  limit_weekly_text: null,
+  limit_5h_reset_at: null,
+  limit_weekly_reset_at: null,
+};
+
+export function normalizeProviderOAuthLimitsResult(
+  result: OAuthLimitsResult | null | undefined
+): OAuthLimitsResult {
+  if (!result) return EMPTY_OAUTH_LIMITS_RESULT;
+  return result;
+}
+
+export function readProviderOAuthLimitsCache(
+  queryClient: QueryClient,
+  providerId: number
+): OAuthLimitsResult | null {
+  const state = queryClient.getQueryState<OAuthLimitsResult>(oauthLimitsKeys.detail(providerId));
+  return state?.data ?? null;
+}
+
+export async function refreshProviderOAuthLimits(
+  queryClient: QueryClient,
+  providerId: number
+): Promise<OAuthLimitsResult> {
+  const next = normalizeProviderOAuthLimitsResult(await providerOAuthFetchLimits(providerId));
+  queryClient.setQueryData(oauthLimitsKeys.detail(providerId), next);
+  return next;
 }
 
 export function useProviderSetEnabledMutation() {
@@ -189,17 +227,7 @@ export function useOAuthLimitsQuery(providerId: number, enabled: boolean) {
   return useQuery({
     queryKey: oauthLimitsKeys.detail(providerId),
     queryFn: async (): Promise<OAuthLimitsResult> => {
-      const result = await providerOAuthFetchLimits(providerId);
-      if (!result) {
-        return {
-          limit_short_label: null,
-          limit_5h_text: null,
-          limit_weekly_text: null,
-          limit_5h_reset_at: null,
-          limit_weekly_reset_at: null,
-        };
-      }
-      return result;
+      return normalizeProviderOAuthLimitsResult(await providerOAuthFetchLimits(providerId));
     },
     enabled,
     staleTime: 180_000,

--- a/src/query/providers.ts
+++ b/src/query/providers.ts
@@ -1,10 +1,5 @@
-import {
-  QueryClient,
-  keepPreviousData,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 import {
   providerClaudeTerminalLaunchCommand,
   providerUpsert,

--- a/src/query/usage.ts
+++ b/src/query/usage.ts
@@ -12,10 +12,19 @@ import {
 } from "../services/usage/usage";
 import { usageKeys } from "./keys";
 
+type UsageQueryOptions = {
+  enabled?: boolean;
+  refetchIntervalMs?: number | false;
+};
+
+export type UsageV2QueryOptions = UsageQueryOptions & {
+  refetchOnMount?: boolean | "always";
+};
+
 export function useUsageSummaryQuery(
   range: UsageRange,
   input: { cliKey: CliKey | null },
-  options?: { enabled?: boolean; refetchIntervalMs?: number | false }
+  options?: UsageQueryOptions
 ) {
   return useQuery({
     queryKey: usageKeys.summary(range, input),
@@ -26,10 +35,7 @@ export function useUsageSummaryQuery(
   });
 }
 
-export function useUsageHourlySeriesQuery(
-  days: number,
-  options?: { enabled?: boolean; refetchIntervalMs?: number | false }
-) {
+export function useUsageHourlySeriesQuery(days: number, options?: UsageQueryOptions) {
   return useQuery({
     queryKey: usageKeys.hourlySeries(days),
     queryFn: () => usageHourlySeries(days),
@@ -47,13 +53,15 @@ export function useUsageSummaryV2Query(
     cliKey: CliKey | null;
     providerId: number | null;
   },
-  options?: { enabled?: boolean }
+  options?: UsageV2QueryOptions
 ) {
   return useQuery({
     queryKey: usageKeys.summaryV2(period, input),
     queryFn: () => usageSummaryV2(period, input),
     enabled: options?.enabled ?? true,
     placeholderData: keepPreviousData,
+    refetchInterval: options?.refetchIntervalMs ?? false,
+    refetchOnMount: options?.refetchOnMount,
   });
 }
 
@@ -67,13 +75,15 @@ export function useUsageLeaderboardV2Query(
     providerId: number | null;
     limit: number | null;
   },
-  options?: { enabled?: boolean }
+  options?: UsageV2QueryOptions
 ) {
   return useQuery({
     queryKey: usageKeys.leaderboardV2(scope, period, input),
     queryFn: () => usageLeaderboardV2(scope, period, input),
     enabled: options?.enabled ?? true,
     placeholderData: keepPreviousData,
+    refetchInterval: options?.refetchIntervalMs ?? false,
+    refetchOnMount: options?.refetchOnMount,
   });
 }
 

--- a/src/services/home/__tests__/homeOverviewTabOrder.test.ts
+++ b/src/services/home/__tests__/homeOverviewTabOrder.test.ts
@@ -26,7 +26,7 @@ describe("services/home/homeOverviewTabOrder", () => {
         "bad-key",
         "providerLimit",
       ])
-    ).toEqual(["sessions", "workspaceConfig", "providerLimit", "circuit"]);
+    ).toEqual(["sessions", "workspaceConfig", "providerLimit", "circuit", "oauthQuota"]);
   });
 
   it("reads tab order from storage and falls back for empty or malformed values", () => {
@@ -41,6 +41,7 @@ describe("services/home/homeOverviewTabOrder", () => {
       "workspaceConfig",
       "circuit",
       "sessions",
+      "oauthQuota",
     ]);
 
     window.localStorage.setItem(HOME_OVERVIEW_TAB_ORDER_STORAGE_KEY, "{bad json");
@@ -80,7 +81,7 @@ describe("services/home/homeOverviewTabOrder", () => {
 
     expect(setItemSpy).toHaveBeenCalledWith(
       HOME_OVERVIEW_TAB_ORDER_STORAGE_KEY,
-      JSON.stringify(["sessions", "providerLimit", "workspaceConfig", "circuit"])
+      JSON.stringify(["sessions", "providerLimit", "workspaceConfig", "circuit", "oauthQuota"])
     );
 
     setItemSpy.mockImplementation(() => {

--- a/src/services/home/homeOverviewTabOrder.ts
+++ b/src/services/home/homeOverviewTabOrder.ts
@@ -1,4 +1,9 @@
-export type HomeOverviewTabKey = "workspaceConfig" | "circuit" | "sessions" | "providerLimit";
+export type HomeOverviewTabKey =
+  | "workspaceConfig"
+  | "circuit"
+  | "sessions"
+  | "providerLimit"
+  | "oauthQuota";
 
 export const HOME_OVERVIEW_TAB_ORDER_STORAGE_KEY = "aio-home-overview-tab-order";
 
@@ -7,6 +12,7 @@ export const HOME_OVERVIEW_TABS: Array<{ key: HomeOverviewTabKey; label: string 
   { key: "circuit", label: "熔断信息" },
   { key: "sessions", label: "活跃 Session" },
   { key: "providerLimit", label: "供应商限额" },
+  { key: "oauthQuota", label: "OAuth 配额" },
 ];
 
 export function normalizeHomeOverviewTabOrder(input: unknown): HomeOverviewTabKey[] {


### PR DESCRIPTION
- 个性化布局下，首页新增“今日供应商用量总览”，并支持与原用量曲线切换展示
- 总览改为展示今日汇总卡片和供应商列表，列表默认展示前 3 个，并优先保留进行中的供应商
- 首页“用量”面板时间筛选新增“昨天”
- 修正供应商运行态判定，改为跟随 live trace，并按 provider_id 优先匹配
- 调整供应商运行中图标位置，移到名称右侧，减少布局抖动