### PR TITLE
style(scrollbar): 统一滚动条样式为 scrollbar-overlay

### DIFF
--- a/src/components/ClaudeModelValidationHistoryStepCard.tsx
+++ b/src/components/ClaudeModelValidationHistoryStepCard.tsx
@@ -249,7 +249,7 @@ export function ClaudeModelValidationHistoryStepCard({
                   <Copy className="h-4 w-4" />
                 </Button>
               </div>
-              <pre className="custom-scrollbar max-h-60 overflow-auto rounded-lg bg-slate-950 p-4 font-mono text-[10px] leading-relaxed text-slate-300">
+              <pre className="scrollbar-overlay max-h-60 overflow-auto rounded-lg bg-slate-950 p-4 font-mono text-[10px] leading-relaxed text-slate-300">
                 {sseText ? (
                   sseText
                 ) : (

--- a/src/components/claude-model-validation/DebugPanels.tsx
+++ b/src/components/claude-model-validation/DebugPanels.tsx
@@ -247,7 +247,7 @@ export function NonSuiteDebugPanel({
           </div>
         </summary>
         <div className="border-t border-slate-100 dark:border-slate-700 p-0">
-          <pre className="custom-scrollbar max-h-60 overflow-auto bg-slate-950 p-4 font-mono text-[10px] leading-relaxed text-slate-300">
+          <pre className="scrollbar-overlay max-h-60 overflow-auto bg-slate-950 p-4 font-mono text-[10px] leading-relaxed text-slate-300">
             <span className="text-slate-500 dark:text-slate-400">
               {(() => {
                 const t = getClaudeValidationTemplate(activeResultTemplateKey);

--- a/src/components/claude-model-validation/DetailsPane.tsx
+++ b/src/components/claude-model-validation/DetailsPane.tsx
@@ -335,7 +335,7 @@ export function DetailsPane(props: DetailsPaneProps) {
   };
 
   return (
-    <div className="flex flex-col gap-4 h-full min-h-0 min-w-0 flex-1 overflow-y-auto custom-scrollbar pr-1">
+    <div className="flex flex-col gap-4 h-full min-h-0 min-w-0 flex-1 overflow-y-auto scrollbar-overlay pr-1">
       <div className="sticky top-0 z-20 bg-white/90 dark:bg-slate-900/80 backdrop-blur border-b border-slate-100 dark:border-slate-700 pb-3 pt-2">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div className="min-w-0">
@@ -577,7 +577,7 @@ function StepDetailPanel({
             <div className="text-[11px] font-semibold text-slate-700 dark:text-slate-300">
               SSE \u539f\u6587
             </div>
-            <pre className="custom-scrollbar max-h-60 overflow-auto rounded-lg bg-slate-950 p-4 font-mono text-[10px] leading-relaxed text-slate-300">
+            <pre className="scrollbar-overlay max-h-60 overflow-auto rounded-lg bg-slate-950 p-4 font-mono text-[10px] leading-relaxed text-slate-300">
               {sseText ? (
                 sseText
               ) : (

--- a/src/components/claude-model-validation/HistoryListPanel.tsx
+++ b/src/components/claude-model-validation/HistoryListPanel.tsx
@@ -82,7 +82,7 @@ export function HistoryListPanel({
               <span className="text-xs">No History</span>
             </div>
           ) : (
-            <div className="custom-scrollbar h-full overflow-y-auto p-3 space-y-2">
+            <div className="scrollbar-overlay h-full overflow-y-auto p-3 space-y-2">
               {historyGroups.map((group) => (
                 <HistoryGroupButton
                   key={group.key}

--- a/src/components/claude-model-validation/OverviewTabContent.tsx
+++ b/src/components/claude-model-validation/OverviewTabContent.tsx
@@ -234,7 +234,7 @@ function SingleHistoryOverview({
             <div className="text-[11px] font-semibold text-slate-700 dark:text-slate-300">
               SSE \u539f\u6587
             </div>
-            <pre className="custom-scrollbar max-h-60 overflow-auto rounded-lg bg-slate-950 p-4 font-mono text-[10px] leading-relaxed text-slate-300">
+            <pre className="scrollbar-overlay max-h-60 overflow-auto rounded-lg bg-slate-950 p-4 font-mono text-[10px] leading-relaxed text-slate-300">
               {sseText ? (
                 sseText
               ) : (

--- a/src/pages/ConsolePage.tsx
+++ b/src/pages/ConsolePage.tsx
@@ -228,14 +228,14 @@ const ConsoleLogRow = memo(function ConsoleLogRow({
       {isOpen ? (
         <div className={cn(ROW_GRID_CLASS, "px-4 pb-4 pt-0")}>
           <div className="col-start-3 col-span-2 space-y-2">
-            <pre className="custom-scrollbar max-h-60 overflow-auto rounded-md bg-slate-100 dark:bg-slate-950 p-3 text-[11px] leading-relaxed text-slate-700 dark:text-slate-400 font-mono border border-slate-200 dark:border-white/5 mx-1 whitespace-pre-wrap">
+            <pre className="scrollbar-overlay max-h-60 overflow-auto rounded-md bg-slate-100 dark:bg-slate-950 p-3 text-[11px] leading-relaxed text-slate-700 dark:text-slate-400 font-mono border border-slate-200 dark:border-white/5 mx-1 whitespace-pre-wrap">
               {smartText == null ? "加载中…" : smartText ? smartText : "// 无可显示的详情"}
             </pre>
             <details className="group/raw">
               <summary className="text-[10px] text-slate-500 cursor-pointer hover:text-slate-700 dark:hover:text-slate-400 select-none mx-1">
                 原始数据
               </summary>
-              <pre className="custom-scrollbar max-h-40 overflow-auto rounded-md bg-slate-100 dark:bg-slate-950 p-3 text-[11px] leading-relaxed text-slate-600 dark:text-slate-500 font-mono border border-slate-200 dark:border-white/5 mx-1 mt-1">
+              <pre className="scrollbar-overlay max-h-40 overflow-auto rounded-md bg-slate-100 dark:bg-slate-950 p-3 text-[11px] leading-relaxed text-slate-600 dark:text-slate-500 font-mono border border-slate-200 dark:border-white/5 mx-1 mt-1">
                 {rawText == null ? "加载中…" : rawText ? rawText : "// 无原始数据"}
               </pre>
             </details>
@@ -436,7 +436,7 @@ export function ConsolePage() {
           ref={logsContainerRef}
           onScroll={handleScroll}
           className={cn(
-            "custom-scrollbar min-h-0 flex-1 overflow-auto",
+            "scrollbar-overlay min-h-0 flex-1 overflow-auto",
             "bg-gradient-to-b from-slate-50 to-white dark:from-slate-950 dark:to-slate-900 font-mono text-[12px] leading-relaxed text-slate-700 dark:text-slate-200",
             "shadow-inner"
           )}

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -288,7 +288,7 @@ export function WorkspacesPage() {
                   "mt-4 min-h-0 flex-1",
                   rightTab === "skills"
                     ? "lg:overflow-hidden"
-                    : "lg:overflow-y-auto custom-scrollbar lg:pr-1"
+                    : "lg:overflow-y-auto scrollbar-overlay lg:pr-1"
                 )}
               >
                 {rightTab === "overview" ? (


### PR DESCRIPTION
## Summary
- 项目中存在两种滚动条样式类：`scrollbar-overlay`（在 `globals.css` 中有完整定义）和 `custom-scrollbar`（无任何 CSS 定义，使用浏览器默认样式）
- 将 7 个文件中 10 处 `custom-scrollbar` 统一替换为 `scrollbar-overlay`，消除滚动条视觉不一致问题

## Changes
- `src/pages/ConsolePage.tsx`：3 处替换
- `src/components/claude-model-validation/DetailsPane.tsx`：2 处替换
- `src/components/claude-model-validation/DebugPanels.tsx`：1 处替换
- `src/components/claude-model-validation/HistoryListPanel.tsx`：1 处替换
- `src/components/claude-model-validation/OverviewTabContent.tsx`：1 处替换
- `src/components/ClaudeModelValidationHistoryStepCard.tsx`：1 处替换
- `src/pages/WorkspacesPage.tsx`：1 处替换

## Test plan
- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过
- [x] 全部 4 分片单元测试通过（1380 tests）
- [x] 确认代码库中不再存在 `custom-scrollbar` 引用