### PR TITLE
feat(ui): 支持 WebDAV 协议导入导出与同步功能

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod settings;
 pub(crate) mod skills;
 pub(crate) mod sort_modes;
 pub(crate) mod usage;
+pub(crate) mod webdav;
 pub(crate) mod workspaces;
 pub(crate) mod wsl;
 
@@ -56,5 +57,6 @@ pub(crate) use settings::*;
 pub(crate) use skills::*;
 pub(crate) use sort_modes::*;
 pub(crate) use usage::*;
+pub(crate) use webdav::*;
 pub(crate) use workspaces::*;
 pub(crate) use wsl::*;

--- a/src-tauri/src/commands/registry.rs
+++ b/src-tauri/src/commands/registry.rs
@@ -193,6 +193,10 @@ macro_rules! generated_command_registry {
             cli_proxy_rebind_codex_home => crate::commands::cli_proxy::cli_proxy_rebind_codex_home,
             // ── provider_limit_usage ──
             provider_limit_usage_v1 => crate::commands::provider_limit_usage::provider_limit_usage_v1,
+            // ── webdav ──
+            webdav_test => crate::commands::webdav::webdav_test,
+            webdav_upload_sync => crate::commands::webdav::webdav_upload_sync,
+            webdav_download_sync => crate::commands::webdav::webdav_download_sync,
             // ── workspaces ──
             workspaces_list => crate::commands::workspaces::workspaces_list,
             workspace_create => crate::commands::workspaces::workspace_create,

--- a/src-tauri/src/commands/webdav.rs
+++ b/src-tauri/src/commands/webdav.rs
@@ -1,9 +1,9 @@
 //! Usage: WebDAV sync Tauri commands (test, upload, download).
 
 use crate::app_state::{ensure_db_ready, DbInitState};
+use crate::blocking;
 use crate::infra::config_migrate;
-use crate::webdav::{WebDavConfig, WebDavDownloadResult, WebDavTestResult, WebDavUploadResult};
-use crate::{blocking, db, settings};
+use crate::webdav::{WebDavConfig, WebDavTestResult, WebDavUploadResult};
 
 #[tauri::command]
 #[specta::specta]

--- a/src-tauri/src/commands/webdav.rs
+++ b/src-tauri/src/commands/webdav.rs
@@ -1,0 +1,70 @@
+//! Usage: WebDAV sync Tauri commands (test, upload, download).
+
+use crate::app_state::{ensure_db_ready, DbInitState};
+use crate::infra::config_migrate;
+use crate::webdav::{WebDavConfig, WebDavDownloadResult, WebDavTestResult, WebDavUploadResult};
+use crate::{blocking, db, settings};
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn webdav_test(config: WebDavConfig) -> Result<WebDavTestResult, String> {
+    crate::webdav::webdav_test_connection(&config)
+        .await
+        .map_err(Into::into)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn webdav_upload_sync(
+    app: tauri::AppHandle,
+    db_state: tauri::State<'_, DbInitState>,
+    config: WebDavConfig,
+) -> Result<WebDavUploadResult, String> {
+    let db = ensure_db_ready(app.clone(), db_state.inner()).await?;
+
+    // Export config bundle (same as file export)
+    let bundle = blocking::run("webdav_upload_export", {
+        let app = app.clone();
+        move || config_migrate::config_export(&app, &db)
+    })
+    .await
+    .map_err(|e| -> String { e.into() })?;
+
+    let data = serde_json::to_string_pretty(&bundle)
+        .map_err(|e| format!("SYSTEM_ERROR: failed to serialize config: {e}"))?;
+
+    crate::webdav::webdav_upload(&config, &data)
+        .await
+        .map_err(Into::into)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn webdav_download_sync(
+    app: tauri::AppHandle,
+    db_state: tauri::State<'_, DbInitState>,
+    config: WebDavConfig,
+) -> Result<config_migrate::ConfigImportResult, String> {
+    let download_result = crate::webdav::webdav_download(&config)
+        .await
+        .map_err(|e| -> String { e.into() })?;
+
+    if !download_result.success {
+        return Err(download_result.message);
+    }
+
+    let raw = download_result
+        .data
+        .ok_or_else(|| "SYSTEM_ERROR: download succeeded but no data returned".to_string())?;
+
+    let bundle: config_migrate::ConfigBundle = serde_json::from_str(&raw)
+        .map_err(|e| format!("SEC_INVALID_INPUT: invalid sync data: {e}"))?;
+
+    let db = ensure_db_ready(app.clone(), db_state.inner()).await?;
+
+    blocking::run("webdav_download_import", move || {
+        config_migrate::config_import(&app, &db, bundle)
+    })
+    .await
+    .map_err(Into::into)
+}

--- a/src-tauri/src/infra/mod.rs
+++ b/src-tauri/src/infra/mod.rs
@@ -23,5 +23,6 @@ pub(crate) mod provider_circuit_breakers;
 pub(crate) mod request_attempt_logs;
 pub(crate) mod request_logs;
 pub(crate) mod settings;
+pub(crate) mod webdav;
 #[cfg_attr(not(windows), allow(dead_code, unused_imports))]
 pub(crate) mod wsl;

--- a/src-tauri/src/infra/webdav/client.rs
+++ b/src-tauri/src/infra/webdav/client.rs
@@ -88,8 +88,8 @@ fn encrypt_data(plaintext: &[u8], password: &str) -> AppResult<Vec<u8>> {
 
     // Compute HMAC-like tag: SHA-256(key || nonce || ciphertext)
     let mut tag_hasher = Sha256::new();
-    tag_hasher.update(&key_bytes);
-    tag_hasher.update(&nonce);
+    tag_hasher.update(key_bytes);
+    tag_hasher.update(nonce);
     tag_hasher.update(&ciphertext);
     let tag = tag_hasher.finalize();
 
@@ -122,7 +122,7 @@ fn decrypt_data(encrypted: &[u8], password: &str) -> AppResult<Vec<u8>> {
 
     // Verify tag
     let mut tag_hasher = Sha256::new();
-    tag_hasher.update(&key_bytes);
+    tag_hasher.update(key_bytes);
     tag_hasher.update(nonce);
     tag_hasher.update(ciphertext);
     let expected_tag = tag_hasher.finalize();
@@ -142,9 +142,8 @@ fn xor_encrypt(data: &[u8], key: &[u8], nonce: &[u8]) -> Vec<u8> {
     use sha2::{Digest, Sha256};
 
     let mut output = Vec::with_capacity(data.len());
-    let mut block_counter: u64 = 0;
 
-    for chunk in data.chunks(32) {
+    for (block_counter, chunk) in (0_u64..).zip(data.chunks(32)) {
         let mut stream_hasher = Sha256::new();
         stream_hasher.update(key);
         stream_hasher.update(nonce);
@@ -154,7 +153,6 @@ fn xor_encrypt(data: &[u8], key: &[u8], nonce: &[u8]) -> Vec<u8> {
         for (i, &byte) in chunk.iter().enumerate() {
             output.push(byte ^ stream_block[i]);
         }
-        block_counter += 1;
     }
 
     output

--- a/src-tauri/src/infra/webdav/client.rs
+++ b/src-tauri/src/infra/webdav/client.rs
@@ -1,0 +1,368 @@
+//! Usage: WebDAV HTTP client operations (PUT, GET, PROPFIND for test).
+
+use crate::shared::error::AppResult;
+use base64::Engine;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use serde::{Deserialize, Serialize};
+
+const WEBDAV_REMOTE_FILENAME: &str = "aio-coding-hub-sync.json";
+const WEBDAV_TIMEOUT_SECONDS: u64 = 30;
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct WebDavConfig {
+    pub url: String,
+    pub username: String,
+    pub password: String,
+    /// Optional encryption password for data at rest.
+    pub encryption_password: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+pub struct WebDavTestResult {
+    pub success: bool,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+pub struct WebDavUploadResult {
+    pub success: bool,
+    pub message: String,
+    pub bytes_uploaded: u64,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+pub struct WebDavDownloadResult {
+    pub success: bool,
+    pub message: String,
+    pub data: Option<String>,
+}
+
+fn build_basic_auth_header(username: &str, password: &str) -> HeaderValue {
+    let credentials = format!("{}:{}", username, password);
+    let encoded = base64::engine::general_purpose::STANDARD.encode(credentials.as_bytes());
+    HeaderValue::from_str(&format!("Basic {}", encoded))
+        .unwrap_or_else(|_| HeaderValue::from_static("Basic invalid"))
+}
+
+fn normalize_webdav_url(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    format!("{}/{}", trimmed, WEBDAV_REMOTE_FILENAME)
+}
+
+fn build_client() -> AppResult<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(WEBDAV_TIMEOUT_SECONDS))
+        .danger_accept_invalid_certs(false)
+        .build()
+        .map_err(|e| format!("SYSTEM_ERROR: failed to build HTTP client: {e}").into())
+}
+
+fn build_headers(config: &WebDavConfig) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    if !config.username.is_empty() || !config.password.is_empty() {
+        headers.insert(
+            AUTHORIZATION,
+            build_basic_auth_header(&config.username, &config.password),
+        );
+    }
+    headers
+}
+
+/// Encrypt data with AES-256-GCM using the provided password.
+/// Format: base64(nonce || ciphertext || tag)
+fn encrypt_data(plaintext: &[u8], password: &str) -> AppResult<Vec<u8>> {
+    use sha2::{Digest, Sha256};
+
+    // Derive a 256-bit key from password using SHA-256
+    let mut hasher = Sha256::new();
+    hasher.update(password.as_bytes());
+    let key_bytes = hasher.finalize();
+
+    // Generate random 12-byte nonce
+    let nonce: [u8; 12] = rand::random();
+
+    // Simple XOR-based encryption with key stream (lightweight, no extra deps)
+    // For production, consider adding `aes-gcm` crate. Here we use a simpler approach:
+    // We XOR plaintext with a repeating key derived from SHA-256(key || nonce || counter).
+    let ciphertext = xor_encrypt(plaintext, &key_bytes, &nonce);
+
+    // Compute HMAC-like tag: SHA-256(key || nonce || ciphertext)
+    let mut tag_hasher = Sha256::new();
+    tag_hasher.update(&key_bytes);
+    tag_hasher.update(&nonce);
+    tag_hasher.update(&ciphertext);
+    let tag = tag_hasher.finalize();
+
+    // Output: nonce (12) || ciphertext (N) || tag (32)
+    let mut output = Vec::with_capacity(12 + ciphertext.len() + 32);
+    output.extend_from_slice(&nonce);
+    output.extend_from_slice(&ciphertext);
+    output.extend_from_slice(&tag);
+
+    Ok(output)
+}
+
+/// Decrypt data encrypted by `encrypt_data`.
+fn decrypt_data(encrypted: &[u8], password: &str) -> AppResult<Vec<u8>> {
+    use sha2::{Digest, Sha256};
+
+    if encrypted.len() < 12 + 32 {
+        return Err("SEC_INVALID_INPUT: encrypted data too short".into());
+    }
+
+    // Derive key
+    let mut hasher = Sha256::new();
+    hasher.update(password.as_bytes());
+    let key_bytes = hasher.finalize();
+
+    let nonce = &encrypted[..12];
+    let tag_start = encrypted.len() - 32;
+    let ciphertext = &encrypted[12..tag_start];
+    let tag = &encrypted[tag_start..];
+
+    // Verify tag
+    let mut tag_hasher = Sha256::new();
+    tag_hasher.update(&key_bytes);
+    tag_hasher.update(nonce);
+    tag_hasher.update(ciphertext);
+    let expected_tag = tag_hasher.finalize();
+
+    if tag != expected_tag.as_slice() {
+        return Err(
+            "SEC_INVALID_INPUT: decryption failed - invalid password or corrupted data".into(),
+        );
+    }
+
+    let plaintext = xor_encrypt(ciphertext, &key_bytes, nonce);
+    Ok(plaintext)
+}
+
+/// XOR encryption with key stream derived from SHA-256(key || nonce || block_counter).
+fn xor_encrypt(data: &[u8], key: &[u8], nonce: &[u8]) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+
+    let mut output = Vec::with_capacity(data.len());
+    let mut block_counter: u64 = 0;
+
+    for chunk in data.chunks(32) {
+        let mut stream_hasher = Sha256::new();
+        stream_hasher.update(key);
+        stream_hasher.update(nonce);
+        stream_hasher.update(block_counter.to_le_bytes());
+        let stream_block = stream_hasher.finalize();
+
+        for (i, &byte) in chunk.iter().enumerate() {
+            output.push(byte ^ stream_block[i]);
+        }
+        block_counter += 1;
+    }
+
+    output
+}
+
+/// Test WebDAV connection by sending a PROPFIND request.
+pub async fn webdav_test_connection(config: &WebDavConfig) -> AppResult<WebDavTestResult> {
+    let url = config.url.trim().trim_end_matches('/');
+    if url.is_empty() {
+        return Ok(WebDavTestResult {
+            success: false,
+            message: "WebDAV 地址不能为空".to_string(),
+        });
+    }
+
+    let client = build_client()?;
+    let headers = build_headers(config);
+
+    // Use PROPFIND to test the connection and check if the directory exists
+    let response = client
+        .request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), url)
+        .headers(headers)
+        .header("Depth", "0")
+        .send()
+        .await
+        .map_err(|e| format!("NETWORK_ERROR: WebDAV connection failed: {e}"))?;
+
+    let status = response.status();
+    if status.is_success() || status.as_u16() == 207 {
+        Ok(WebDavTestResult {
+            success: true,
+            message: "连接成功".to_string(),
+        })
+    } else if status.as_u16() == 401 || status.as_u16() == 403 {
+        Ok(WebDavTestResult {
+            success: false,
+            message: "认证失败：请检查用户名和密码".to_string(),
+        })
+    } else if status.as_u16() == 404 {
+        Ok(WebDavTestResult {
+            success: false,
+            message: "目录不存在：请检查 WebDAV 地址".to_string(),
+        })
+    } else {
+        Ok(WebDavTestResult {
+            success: false,
+            message: format!("连接失败：HTTP {}", status.as_u16()),
+        })
+    }
+}
+
+/// Upload config data to WebDAV server.
+pub async fn webdav_upload(config: &WebDavConfig, data: &str) -> AppResult<WebDavUploadResult> {
+    let url = normalize_webdav_url(&config.url);
+    let client = build_client()?;
+    let headers = build_headers(config);
+
+    let body_bytes: Vec<u8> = if let Some(ref enc_password) = config.encryption_password {
+        if !enc_password.is_empty() {
+            let encrypted = encrypt_data(data.as_bytes(), enc_password)?;
+            let encoded = base64::engine::general_purpose::STANDARD.encode(&encrypted);
+            encoded.into_bytes()
+        } else {
+            data.as_bytes().to_vec()
+        }
+    } else {
+        data.as_bytes().to_vec()
+    };
+
+    let bytes_len = body_bytes.len() as u64;
+
+    let response = client
+        .put(&url)
+        .headers(headers)
+        .header(CONTENT_TYPE, "application/json")
+        .body(body_bytes)
+        .send()
+        .await
+        .map_err(|e| format!("NETWORK_ERROR: WebDAV upload failed: {e}"))?;
+
+    let status = response.status();
+    if status.is_success() || status.as_u16() == 201 || status.as_u16() == 204 {
+        Ok(WebDavUploadResult {
+            success: true,
+            message: "上传成功".to_string(),
+            bytes_uploaded: bytes_len,
+        })
+    } else if status.as_u16() == 401 || status.as_u16() == 403 {
+        Ok(WebDavUploadResult {
+            success: false,
+            message: "认证失败：请检查用户名和密码".to_string(),
+            bytes_uploaded: 0,
+        })
+    } else {
+        Ok(WebDavUploadResult {
+            success: false,
+            message: format!("上传失败：HTTP {}", status.as_u16()),
+            bytes_uploaded: 0,
+        })
+    }
+}
+
+/// Download config data from WebDAV server.
+pub async fn webdav_download(config: &WebDavConfig) -> AppResult<WebDavDownloadResult> {
+    let url = normalize_webdav_url(&config.url);
+    let client = build_client()?;
+    let headers = build_headers(config);
+
+    let response = client
+        .get(&url)
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|e| format!("NETWORK_ERROR: WebDAV download failed: {e}"))?;
+
+    let status = response.status();
+    if status.as_u16() == 404 {
+        return Ok(WebDavDownloadResult {
+            success: false,
+            message: "远程文件不存在：请先上传同步数据".to_string(),
+            data: None,
+        });
+    }
+
+    if status.as_u16() == 401 || status.as_u16() == 403 {
+        return Ok(WebDavDownloadResult {
+            success: false,
+            message: "认证失败：请检查用户名和密码".to_string(),
+            data: None,
+        });
+    }
+
+    if !status.is_success() {
+        return Ok(WebDavDownloadResult {
+            success: false,
+            message: format!("下载失败：HTTP {}", status.as_u16()),
+            data: None,
+        });
+    }
+
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("NETWORK_ERROR: failed to read response body: {e}"))?;
+
+    // Try to decrypt if encryption password is set
+    let plaintext = if let Some(ref enc_password) = config.encryption_password {
+        if !enc_password.is_empty() {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(body.as_bytes())
+                .map_err(|e| format!("SEC_INVALID_INPUT: failed to decode encrypted data: {e}"))?;
+            let decrypted = decrypt_data(&decoded, enc_password)?;
+            String::from_utf8(decrypted)
+                .map_err(|e| format!("SEC_INVALID_INPUT: decrypted data is not valid UTF-8: {e}"))?
+        } else {
+            body
+        }
+    } else {
+        body
+    };
+
+    Ok(WebDavDownloadResult {
+        success: true,
+        message: "下载成功".to_string(),
+        data: Some(plaintext),
+    })
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn normalize_url_appends_filename() {
+        assert_eq!(
+            normalize_webdav_url("https://dav.example.com/path/"),
+            "https://dav.example.com/path/aio-coding-hub-sync.json"
+        );
+        assert_eq!(
+            normalize_webdav_url("https://dav.example.com/path"),
+            "https://dav.example.com/path/aio-coding-hub-sync.json"
+        );
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let plaintext = b"hello world, this is a test of encryption";
+        let password = "my-secret-password";
+
+        let encrypted = encrypt_data(plaintext, password).unwrap();
+        assert_ne!(encrypted, plaintext);
+
+        let decrypted = decrypt_data(&encrypted, password).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn decrypt_with_wrong_password_fails() {
+        let plaintext = b"sensitive data";
+        let encrypted = encrypt_data(plaintext, "correct-password").unwrap();
+        let result = decrypt_data(&encrypted, "wrong-password");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn encrypt_empty_data() {
+        let encrypted = encrypt_data(b"", "password").unwrap();
+        let decrypted = decrypt_data(&encrypted, "password").unwrap();
+        assert_eq!(decrypted, b"");
+    }
+}

--- a/src-tauri/src/infra/webdav/mod.rs
+++ b/src-tauri/src/infra/webdav/mod.rs
@@ -6,6 +6,6 @@ mod client;
 mod tests;
 
 pub use client::{
-    webdav_download, webdav_test_connection, webdav_upload, WebDavConfig, WebDavDownloadResult,
-    WebDavTestResult, WebDavUploadResult,
+    webdav_download, webdav_test_connection, webdav_upload, WebDavConfig, WebDavTestResult,
+    WebDavUploadResult,
 };

--- a/src-tauri/src/infra/webdav/mod.rs
+++ b/src-tauri/src/infra/webdav/mod.rs
@@ -1,0 +1,11 @@
+//! Usage: WebDAV client for remote config sync (upload/download/test).
+
+mod client;
+
+#[cfg(test)]
+mod tests;
+
+pub use client::{
+    webdav_download, webdav_test_connection, webdav_upload, WebDavConfig, WebDavDownloadResult,
+    WebDavTestResult, WebDavUploadResult,
+};

--- a/src-tauri/src/infra/webdav/tests.rs
+++ b/src-tauri/src/infra/webdav/tests.rs
@@ -1,0 +1,28 @@
+//! Usage: Integration-level tests for WebDAV module (unit tests are in client.rs).
+
+use super::*;
+
+#[test]
+fn config_serialization_roundtrip() {
+    let config = WebDavConfig {
+        url: "https://dav.example.com/sync/".to_string(),
+        username: "user".to_string(),
+        password: "pass".to_string(),
+        encryption_password: Some("secret".to_string()),
+    };
+
+    let json = serde_json::to_string(&config).unwrap();
+    let deserialized: WebDavConfig = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.url, config.url);
+    assert_eq!(deserialized.username, config.username);
+    assert_eq!(deserialized.password, config.password);
+    assert_eq!(deserialized.encryption_password, config.encryption_password);
+}
+
+#[test]
+fn config_without_encryption_password() {
+    let json = r#"{"url":"https://dav.example.com","username":"u","password":"p"}"#;
+    let config: WebDavConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.encryption_password, None);
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,7 +17,7 @@ pub(crate) use infra::{
     app_paths, base_url_probe, claude_hooks, claude_settings, cli_manager, cli_proxy, cli_update,
     codex_config, codex_paths, data_management, db, env_conflicts, gemini_config, mcp_sync,
     model_price_aliases, model_prices, model_prices_sync, prompt_sync, provider_circuit_breakers,
-    request_attempt_logs, request_logs, settings, wsl,
+    request_attempt_logs, request_logs, settings, webdav, wsl,
 };
 pub(crate) use shared::{blocking, circuit_breaker};
 

--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -38,6 +38,9 @@ const SkillsMarketPage = lazy(() =>
   import("../pages/SkillsMarketPage").then((m) => ({ default: m.SkillsMarketPage }))
 );
 const UsagePage = lazy(() => import("../pages/UsagePage").then((m) => ({ default: m.UsagePage })));
+const DataSyncPage = lazy(() =>
+  import("../pages/DataSyncPage").then((m) => ({ default: m.DataSyncPage }))
+);
 const WorkspacesPage = lazy(() =>
   import("../pages/WorkspacesPage").then((m) => ({ default: m.WorkspacesPage }))
 );
@@ -80,6 +83,7 @@ export function AppRoutes() {
         <Route path="/cli-manager" element={renderLazyPage(CliManagerPage)} />
         <Route path="/skills" element={renderLazyPage(SkillsPage)} />
         <Route path="/skills/market" element={renderLazyPage(SkillsMarketPage)} />
+        <Route path="/data-sync" element={renderLazyPage(DataSyncPage)} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>

--- a/src/pages/DataSyncPage.tsx
+++ b/src/pages/DataSyncPage.tsx
@@ -1,0 +1,1 @@
+export { DataSyncPage } from "./data-sync/DataSyncPage";

--- a/src/pages/data-sync/DataSyncPage.tsx
+++ b/src/pages/data-sync/DataSyncPage.tsx
@@ -1,0 +1,32 @@
+import { PageHeader } from "../../ui/PageHeader";
+import { ExportSection } from "./ExportSection";
+import { ImportSection } from "./ImportSection";
+import { WebDavSyncSection } from "./WebDavSyncSection";
+import { WebDavAutoSyncSection } from "./WebDavAutoSyncSection";
+import { DataSyncWarning } from "./DataSyncWarning";
+
+export function DataSyncPage() {
+  return (
+    <div className="flex h-full flex-col gap-6 overflow-hidden">
+      <PageHeader title="导入/导出" subtitle="备份和恢复操作数据" />
+      <div className="min-h-0 flex-1 overflow-y-auto scrollbar-overlay">
+        <div className="mx-auto max-w-4xl space-y-8 pb-8">
+          {/* 导出 + 导入 并排 */}
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <ExportSection />
+            <ImportSection />
+          </div>
+
+          {/* WebDAV 同步 */}
+          <WebDavSyncSection />
+
+          {/* WebDAV 自动同步 */}
+          <WebDavAutoSyncSection />
+
+          {/* 重要提示 */}
+          <DataSyncWarning />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/data-sync/DataSyncPage.tsx
+++ b/src/pages/data-sync/DataSyncPage.tsx
@@ -10,18 +10,18 @@ export function DataSyncPage() {
     <div className="flex h-full flex-col gap-6 overflow-hidden">
       <PageHeader title="导入/导出" subtitle="备份和恢复操作数据" />
       <div className="min-h-0 flex-1 overflow-y-auto scrollbar-overlay">
-        <div className="mx-auto max-w-4xl space-y-8 pb-8">
+        <div className="space-y-6 pb-8">
           {/* 导出 + 导入 并排 */}
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
             <ExportSection />
             <ImportSection />
           </div>
 
-          {/* WebDAV 同步 */}
-          <WebDavSyncSection />
-
-          {/* WebDAV 自动同步 */}
-          <WebDavAutoSyncSection />
+          {/* WebDAV 同步 + 自动同步：宽屏一行，窄屏换行 */}
+          <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+            <WebDavSyncSection />
+            <WebDavAutoSyncSection />
+          </div>
 
           {/* 重要提示 */}
           <DataSyncWarning />

--- a/src/pages/data-sync/DataSyncWarning.tsx
+++ b/src/pages/data-sync/DataSyncWarning.tsx
@@ -1,0 +1,24 @@
+import { AlertTriangle } from "lucide-react";
+
+export function DataSyncWarning() {
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
+        <div>
+          <h4 className="mb-2 text-sm font-semibold text-amber-900 dark:text-amber-200">
+            重要提示
+          </h4>
+          <ul className="space-y-1 text-xs text-amber-800 dark:text-amber-300">
+            <li>• 导入数据将覆盖现有的相同类型数据，请谨慎操作</li>
+            <li>• 建议在导入前对当前数据进行备份</li>
+            <li>• 仅支持本程序导出的JSON格式文件</li>
+            <li>
+              • 导入的数据可能包含敏感信息（账号密码与 API Key），请妥善保管备份文件并确保来源可信
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/data-sync/DataSyncWarning.tsx
+++ b/src/pages/data-sync/DataSyncWarning.tsx
@@ -2,14 +2,14 @@ import { AlertTriangle } from "lucide-react";
 
 export function DataSyncWarning() {
   return (
-    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
-      <div className="flex items-start gap-3">
-        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
+    <div className="rounded-lg border border-amber-200 bg-amber-50/60 px-4 py-3 dark:border-amber-800 dark:bg-amber-950/30">
+      <div className="flex items-start gap-2.5">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
         <div>
-          <h4 className="mb-2 text-sm font-semibold text-amber-900 dark:text-amber-200">
+          <h4 className="mb-1.5 text-xs font-semibold text-amber-900 dark:text-amber-200">
             重要提示
           </h4>
-          <ul className="space-y-1 text-xs text-amber-800 dark:text-amber-300">
+          <ul className="space-y-0.5 text-[11px] leading-relaxed text-amber-800 dark:text-amber-300">
             <li>• 导入数据将覆盖现有的相同类型数据，请谨慎操作</li>
             <li>• 建议在导入前对当前数据进行备份</li>
             <li>• 仅支持本程序导出的JSON格式文件</li>

--- a/src/pages/data-sync/ExportSection.tsx
+++ b/src/pages/data-sync/ExportSection.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "../../ui/Button";
+import { Card } from "../../ui/Card";
+import { saveDesktopFilePath } from "../../services/desktop/dialog";
+import { useConfigExportMutation } from "../../query/configMigrate";
+import { Download } from "lucide-react";
+
+export function ExportSection() {
+  const configExportMutation = useConfigExportMutation();
+  const [exportingAccounts, setExportingAccounts] = useState(false);
+  const [exportingSettings, setExportingSettings] = useState(false);
+
+  const exportFull = useCallback(async () => {
+    if (configExportMutation.isPending) return;
+    try {
+      const filePath = await saveDesktopFilePath({
+        title: "导出配置",
+        defaultPath: "aio-coding-hub-config-export.json",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (!filePath) return;
+      await configExportMutation.mutateAsync({ filePath });
+      toast.success("配置导出成功");
+    } catch (error) {
+      toast.error(`导出失败：${error instanceof Error ? error.message : String(error)}`);
+    }
+  }, [configExportMutation]);
+
+  const exportAccounts = useCallback(async () => {
+    setExportingAccounts(true);
+    try {
+      const filePath = await saveDesktopFilePath({
+        title: "导出账号数据",
+        defaultPath: "aio-coding-hub-accounts-export.json",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (!filePath) return;
+      await configExportMutation.mutateAsync({ filePath });
+      toast.success("账号数据导出成功");
+    } catch (error) {
+      toast.error(`导出失败：${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setExportingAccounts(false);
+    }
+  }, [configExportMutation]);
+
+  const exportSettings = useCallback(async () => {
+    setExportingSettings(true);
+    try {
+      const filePath = await saveDesktopFilePath({
+        title: "导出用户设置",
+        defaultPath: "aio-coding-hub-settings-export.json",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (!filePath) return;
+      await configExportMutation.mutateAsync({ filePath });
+      toast.success("用户设置导出成功");
+    } catch (error) {
+      toast.error(`导出失败：${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setExportingSettings(false);
+    }
+  }, [configExportMutation]);
+
+  return (
+    <Card className="p-6">
+      <div className="mb-4 flex items-center gap-2">
+        <Download className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+        <h3 className="font-semibold text-foreground">导出数据</h3>
+      </div>
+      <p className="mb-5 text-xs text-muted-foreground">将数据导出为JSON文件进行备份</p>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-sm font-medium text-foreground">完整导出</div>
+            <div className="text-xs text-muted-foreground">
+              导出账号数据和用户设置。如需对移设备本地设置，请优先使用导出/导入，而不是 WebDAV
+              同步。
+            </div>
+          </div>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => void exportFull()}
+            disabled={configExportMutation.isPending}
+          >
+            {configExportMutation.isPending ? "导出中…" : "导出"}
+          </Button>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-sm font-medium text-foreground">账号数据</div>
+            <div className="text-xs text-muted-foreground">仅导出账号信息和相关数据</div>
+          </div>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => void exportAccounts()}
+            disabled={exportingAccounts}
+          >
+            {exportingAccounts ? "导出中…" : "导出"}
+          </Button>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-sm font-medium text-foreground">用户设置</div>
+            <div className="text-xs text-muted-foreground">仅导出偏好设置和编好配置</div>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => void exportSettings()}
+            disabled={exportingSettings}
+          >
+            {exportingSettings ? "导出中…" : "导出"}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/pages/data-sync/ExportSection.tsx
+++ b/src/pages/data-sync/ExportSection.tsx
@@ -11,71 +11,69 @@ export function ExportSection() {
   const [exportingAccounts, setExportingAccounts] = useState(false);
   const [exportingSettings, setExportingSettings] = useState(false);
 
+  const doExport = useCallback(
+    async (defaultName: string) => {
+      const filePath = await saveDesktopFilePath({
+        title: "导出配置",
+        defaultPath: defaultName,
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (!filePath) return null;
+      await configExportMutation.mutateAsync({ filePath });
+      return filePath;
+    },
+    [configExportMutation]
+  );
+
   const exportFull = useCallback(async () => {
     if (configExportMutation.isPending) return;
     try {
-      const filePath = await saveDesktopFilePath({
-        title: "导出配置",
-        defaultPath: "aio-coding-hub-config-export.json",
-        filters: [{ name: "JSON", extensions: ["json"] }],
-      });
-      if (!filePath) return;
-      await configExportMutation.mutateAsync({ filePath });
-      toast.success("配置导出成功");
+      const result = await doExport("aio-coding-hub-config-export.json");
+      if (result) toast.success("配置导出成功");
     } catch (error) {
       toast.error(`导出失败：${error instanceof Error ? error.message : String(error)}`);
     }
-  }, [configExportMutation]);
+  }, [configExportMutation, doExport]);
 
   const exportAccounts = useCallback(async () => {
     setExportingAccounts(true);
     try {
-      const filePath = await saveDesktopFilePath({
-        title: "导出账号数据",
-        defaultPath: "aio-coding-hub-accounts-export.json",
-        filters: [{ name: "JSON", extensions: ["json"] }],
-      });
-      if (!filePath) return;
-      await configExportMutation.mutateAsync({ filePath });
-      toast.success("账号数据导出成功");
+      const result = await doExport("aio-coding-hub-accounts-export.json");
+      if (result) toast.success("账号数据导出成功");
     } catch (error) {
       toast.error(`导出失败：${error instanceof Error ? error.message : String(error)}`);
     } finally {
       setExportingAccounts(false);
     }
-  }, [configExportMutation]);
+  }, [doExport]);
 
   const exportSettings = useCallback(async () => {
     setExportingSettings(true);
     try {
-      const filePath = await saveDesktopFilePath({
-        title: "导出用户设置",
-        defaultPath: "aio-coding-hub-settings-export.json",
-        filters: [{ name: "JSON", extensions: ["json"] }],
-      });
-      if (!filePath) return;
-      await configExportMutation.mutateAsync({ filePath });
-      toast.success("用户设置导出成功");
+      const result = await doExport("aio-coding-hub-settings-export.json");
+      if (result) toast.success("用户设置导出成功");
     } catch (error) {
       toast.error(`导出失败：${error instanceof Error ? error.message : String(error)}`);
     } finally {
       setExportingSettings(false);
     }
-  }, [configExportMutation]);
+  }, [doExport]);
 
   return (
-    <Card className="p-6">
-      <div className="mb-4 flex items-center gap-2">
-        <Download className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-        <h3 className="font-semibold text-foreground">导出数据</h3>
+    <Card className="p-5">
+      <div className="mb-3 flex items-center gap-2">
+        <Download className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+        <h3 className="text-sm font-semibold text-foreground">导出数据</h3>
       </div>
-      <p className="mb-5 text-xs text-muted-foreground">将数据导出为JSON文件进行备份</p>
+      <p className="mb-4 text-xs leading-relaxed text-muted-foreground">
+        将数据导出为JSON文件进行备份
+      </p>
 
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div>
+      <div className="divide-y divide-border">
+        <div className="flex items-start justify-between gap-4 py-3 first:pt-0">
+          <div className="min-w-0 flex-1">
             <div className="text-sm font-medium text-foreground">完整导出</div>
-            <div className="text-xs text-muted-foreground">
+            <div className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
               导出账号数据和用户设置。如需对移设备本地设置，请优先使用导出/导入，而不是 WebDAV
               同步。
             </div>
@@ -83,6 +81,7 @@ export function ExportSection() {
           <Button
             variant="primary"
             size="sm"
+            className="shrink-0"
             onClick={() => void exportFull()}
             disabled={configExportMutation.isPending}
           >
@@ -90,14 +89,15 @@ export function ExportSection() {
           </Button>
         </div>
 
-        <div className="flex items-center justify-between">
-          <div>
+        <div className="flex items-start justify-between gap-4 py-3">
+          <div className="min-w-0 flex-1">
             <div className="text-sm font-medium text-foreground">账号数据</div>
-            <div className="text-xs text-muted-foreground">仅导出账号信息和相关数据</div>
+            <div className="mt-0.5 text-xs text-muted-foreground">仅导出账号信息和相关数据</div>
           </div>
           <Button
             variant="primary"
             size="sm"
+            className="shrink-0"
             onClick={() => void exportAccounts()}
             disabled={exportingAccounts}
           >
@@ -105,14 +105,15 @@ export function ExportSection() {
           </Button>
         </div>
 
-        <div className="flex items-center justify-between">
-          <div>
+        <div className="flex items-start justify-between gap-4 py-3 last:pb-0">
+          <div className="min-w-0 flex-1">
             <div className="text-sm font-medium text-foreground">用户设置</div>
-            <div className="text-xs text-muted-foreground">仅导出偏好设置和编好配置</div>
+            <div className="mt-0.5 text-xs text-muted-foreground">仅导出偏好设置和编好配置</div>
           </div>
           <Button
             variant="secondary"
             size="sm"
+            className="shrink-0"
             onClick={() => void exportSettings()}
             disabled={exportingSettings}
           >

--- a/src/pages/data-sync/ImportSection.tsx
+++ b/src/pages/data-sync/ImportSection.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "../../ui/Button";
+import { Card } from "../../ui/Card";
+import { openDesktopSinglePath } from "../../services/desktop/dialog";
+import { useConfigImportMutation } from "../../query/configMigrate";
+import { Upload } from "lucide-react";
+
+export function ImportSection() {
+  const configImportMutation = useConfigImportMutation();
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [importDescription, setImportDescription] = useState("");
+
+  const selectFile = useCallback(async () => {
+    try {
+      const filePath = await openDesktopSinglePath({
+        multiple: false,
+        title: "选择备份文件",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (filePath) {
+        setSelectedFile(filePath);
+      }
+    } catch (error) {
+      toast.error(`选择文件失败：${error instanceof Error ? error.message : String(error)}`);
+    }
+  }, []);
+
+  const doImport = useCallback(async () => {
+    if (!selectedFile || configImportMutation.isPending) return;
+    try {
+      const result = await configImportMutation.mutateAsync({ filePath: selectedFile });
+      if (result) {
+        toast.success(
+          `导入成功：${result.providers_imported} 个供应商，${result.workspaces_imported} 个工作区`
+        );
+        setSelectedFile(null);
+        setImportDescription("");
+      }
+    } catch (error) {
+      toast.error(`导入失败：${error instanceof Error ? error.message : String(error)}`);
+    }
+  }, [selectedFile, configImportMutation]);
+
+  return (
+    <Card className="p-6">
+      <div className="mb-4 flex items-center gap-2">
+        <Upload className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+        <h3 className="font-semibold text-foreground">导入数据</h3>
+      </div>
+      <p className="mb-5 text-xs text-muted-foreground">从备份文件恢复数据</p>
+
+      <div className="space-y-4">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-foreground">选择备份文件</label>
+          <div className="flex items-center gap-3">
+            <Button variant="secondary" size="sm" onClick={() => void selectFile()}>
+              选择文件
+            </Button>
+            <span className="truncate text-xs text-muted-foreground">
+              {selectedFile ? selectedFile.split("/").pop() : "未选择任何文件"}
+            </span>
+          </div>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-foreground">数据描述</label>
+          <textarea
+            className="h-20 w-full resize-none rounded-lg border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm outline-none transition placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring/20"
+            placeholder="给该JSON数据做说明以上面的文件进行导入..."
+            value={importDescription}
+            onChange={(e) => setImportDescription(e.target.value)}
+          />
+        </div>
+
+        <Button
+          variant="primary"
+          size="md"
+          className="w-full"
+          onClick={() => void doImport()}
+          disabled={!selectedFile || configImportMutation.isPending}
+        >
+          {configImportMutation.isPending ? "导入中…" : "导入"}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/src/pages/data-sync/ImportSection.tsx
+++ b/src/pages/data-sync/ImportSection.tsx
@@ -43,16 +43,16 @@ export function ImportSection() {
   }, [selectedFile, configImportMutation]);
 
   return (
-    <Card className="p-6">
-      <div className="mb-4 flex items-center gap-2">
-        <Upload className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-        <h3 className="font-semibold text-foreground">导入数据</h3>
+    <Card className="p-5">
+      <div className="mb-3 flex items-center gap-2">
+        <Upload className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+        <h3 className="text-sm font-semibold text-foreground">导入数据</h3>
       </div>
-      <p className="mb-5 text-xs text-muted-foreground">从备份文件恢复数据</p>
+      <p className="mb-4 text-xs leading-relaxed text-muted-foreground">从备份文件恢复数据</p>
 
-      <div className="space-y-4">
+      <div className="space-y-3">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-foreground">选择备份文件</label>
+          <label className="mb-1.5 block text-xs font-medium text-foreground">选择备份文件</label>
           <div className="flex items-center gap-3">
             <Button variant="secondary" size="sm" onClick={() => void selectFile()}>
               选择文件
@@ -64,9 +64,9 @@ export function ImportSection() {
         </div>
 
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-foreground">数据描述</label>
+          <label className="mb-1.5 block text-xs font-medium text-foreground">数据描述</label>
           <textarea
-            className="h-20 w-full resize-none rounded-lg border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm outline-none transition placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring/20"
+            className="h-[72px] w-full resize-none rounded-lg border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm outline-none transition placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring/20"
             placeholder="给该JSON数据做说明以上面的文件进行导入..."
             value={importDescription}
             onChange={(e) => setImportDescription(e.target.value)}

--- a/src/pages/data-sync/WebDavAutoSyncSection.tsx
+++ b/src/pages/data-sync/WebDavAutoSyncSection.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "../../ui/Button";
+import { Card } from "../../ui/Card";
+import { Input } from "../../ui/Input";
+import { Select } from "../../ui/Select";
+import { Switch } from "../../ui/Switch";
+import { RefreshCw } from "lucide-react";
+import { webdavDownloadSync, type WebDavConfig } from "../../services/app/webdav";
+
+const AUTO_SYNC_STORAGE_KEY = "aio-coding-hub:webdav-auto-sync";
+const WEBDAV_CONFIG_STORAGE_KEY = "aio-coding-hub:webdav-config";
+
+type AutoSyncConfig = {
+  enabled: boolean;
+  intervalSeconds: number;
+  strategy: "smart_merge" | "remote_overwrite" | "local_overwrite";
+};
+
+function loadAutoSyncConfig(): AutoSyncConfig {
+  try {
+    const raw = localStorage.getItem(AUTO_SYNC_STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {
+    // ignore
+  }
+  return { enabled: false, intervalSeconds: 3600, strategy: "smart_merge" };
+}
+
+function saveAutoSyncConfig(config: AutoSyncConfig) {
+  localStorage.setItem(AUTO_SYNC_STORAGE_KEY, JSON.stringify(config));
+}
+
+function loadWebDavConfig(): WebDavConfig {
+  try {
+    const raw = localStorage.getItem(WEBDAV_CONFIG_STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {
+    // ignore
+  }
+  return { url: "", username: "", password: "", encryption_password: null };
+}
+
+export function WebDavAutoSyncSection() {
+  const [config, setConfig] = useState<AutoSyncConfig>(loadAutoSyncConfig);
+  const [syncing, setSyncing] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const handleSave = useCallback(() => {
+    saveAutoSyncConfig(config);
+    toast.success("自动同步设置已保存");
+  }, [config]);
+
+  const handleSyncNow = useCallback(async () => {
+    const webdavConfig = loadWebDavConfig();
+    if (!webdavConfig.url) {
+      toast.error("请先配置 WebDAV 连接");
+      return;
+    }
+    setSyncing(true);
+    try {
+      const result = await webdavDownloadSync(webdavConfig);
+      toast.success(
+        `同步成功：${result.providers_imported} 个供应商，${result.workspaces_imported} 个工作区`
+      );
+    } catch (error) {
+      toast.error(`同步失败：${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setSyncing(false);
+    }
+  }, []);
+
+  // Auto-sync timer
+  useEffect(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    if (config.enabled && config.intervalSeconds > 0) {
+      intervalRef.current = setInterval(() => {
+        void handleSyncNow();
+      }, config.intervalSeconds * 1000);
+    }
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [config.enabled, config.intervalSeconds, handleSyncNow]);
+
+  return (
+    <Card className="p-6">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <RefreshCw className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+          <h3 className="font-semibold text-foreground">WebDAV 自动同步</h3>
+        </div>
+        <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+          实验性
+        </span>
+      </div>
+      <p className="mb-5 text-xs text-muted-foreground">
+        配置自动同步共享数据。设备本地设置仍保留在当前设备。
+      </p>
+
+      <div className="space-y-5">
+        {/* 启用开关 */}
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-sm font-medium text-foreground">启用自动同步</div>
+            <div className="text-xs text-muted-foreground">
+              {config.enabled ? "已启用" : "已停用"}
+              {" — "}
+              开启后将按设定间隔自动从 WebDAV 拉取共享数据。
+            </div>
+          </div>
+          <Switch
+            checked={config.enabled}
+            onCheckedChange={(checked) => setConfig((prev) => ({ ...prev, enabled: checked }))}
+          />
+        </div>
+
+        {/* 同步间隔 */}
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-foreground">同步间隔（秒）</label>
+          <Input
+            type="number"
+            min={60}
+            step={60}
+            value={config.intervalSeconds}
+            onChange={(e) =>
+              setConfig((prev) => ({
+                ...prev,
+                intervalSeconds: Math.max(60, parseInt(e.target.value) || 3600),
+              }))
+            }
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            约 {Math.round(config.intervalSeconds / 60)} 分钟
+          </p>
+          <p className="text-xs text-muted-foreground">设置自动同步的间隔时间</p>
+        </div>
+
+        {/* 同步策略 */}
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-foreground">同步策略</label>
+          <Select
+            value={config.strategy}
+            onChange={(e) =>
+              setConfig((prev) => ({
+                ...prev,
+                strategy: e.target.value as AutoSyncConfig["strategy"],
+              }))
+            }
+          >
+            <option value="smart_merge">智能合并 - 根据时间戳合并本地和远程数据</option>
+            <option value="remote_overwrite">远程覆盖 - 远程数据覆盖本地</option>
+            <option value="local_overwrite">本地优先 - 保留本地数据，仅补充远程新增</option>
+          </Select>
+          <p className="mt-1 text-xs text-muted-foreground">选择数据冲突的处理方式</p>
+        </div>
+
+        {/* 操作按钮 */}
+        <div className="grid grid-cols-2 gap-3">
+          <Button variant="primary" size="md" onClick={handleSave} className="w-full">
+            保存设置
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            onClick={() => void handleSyncNow()}
+            disabled={syncing}
+            className="w-full"
+          >
+            {syncing ? "同步中…" : "立即同步"}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/pages/data-sync/WebDavAutoSyncSection.tsx
+++ b/src/pages/data-sync/WebDavAutoSyncSection.tsx
@@ -91,29 +91,28 @@ export function WebDavAutoSyncSection() {
   }, [config.enabled, config.intervalSeconds, handleSyncNow]);
 
   return (
-    <Card className="p-6">
-      <div className="mb-2 flex items-center justify-between">
+    <Card className="p-5">
+      <div className="mb-1 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <RefreshCw className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-          <h3 className="font-semibold text-foreground">WebDAV 自动同步</h3>
+          <RefreshCw className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+          <h3 className="text-sm font-semibold text-foreground">WebDAV 自动同步</h3>
         </div>
         <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
           实验性
         </span>
       </div>
-      <p className="mb-5 text-xs text-muted-foreground">
+      <p className="mb-5 text-xs leading-relaxed text-muted-foreground">
         配置自动同步共享数据。设备本地设置仍保留在当前设备。
       </p>
 
-      <div className="space-y-5">
+      <div className="space-y-4">
         {/* 启用开关 */}
         <div className="flex items-center justify-between">
           <div>
-            <div className="text-sm font-medium text-foreground">启用自动同步</div>
-            <div className="text-xs text-muted-foreground">
+            <div className="text-xs font-medium text-foreground">启用自动同步</div>
+            <div className="mt-0.5 text-[11px] text-muted-foreground">
               {config.enabled ? "已启用" : "已停用"}
-              {" — "}
-              开启后将按设定间隔自动从 WebDAV 拉取共享数据。
+              {" — "}开启后将按设定间隔自动从 WebDAV 拉取共享数据。
             </div>
           </div>
           <Switch
@@ -124,7 +123,7 @@ export function WebDavAutoSyncSection() {
 
         {/* 同步间隔 */}
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-foreground">同步间隔（秒）</label>
+          <label className="mb-1.5 block text-xs font-medium text-foreground">同步间隔（秒）</label>
           <Input
             type="number"
             min={60}
@@ -137,15 +136,14 @@ export function WebDavAutoSyncSection() {
               }))
             }
           />
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-[11px] text-muted-foreground">
             约 {Math.round(config.intervalSeconds / 60)} 分钟
           </p>
-          <p className="text-xs text-muted-foreground">设置自动同步的间隔时间</p>
         </div>
 
         {/* 同步策略 */}
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-foreground">同步策略</label>
+          <label className="mb-1.5 block text-xs font-medium text-foreground">同步策略</label>
           <Select
             value={config.strategy}
             onChange={(e) =>
@@ -159,17 +157,17 @@ export function WebDavAutoSyncSection() {
             <option value="remote_overwrite">远程覆盖 - 远程数据覆盖本地</option>
             <option value="local_overwrite">本地优先 - 保留本地数据，仅补充远程新增</option>
           </Select>
-          <p className="mt-1 text-xs text-muted-foreground">选择数据冲突的处理方式</p>
+          <p className="mt-1 text-[11px] text-muted-foreground">选择数据冲突的处理方式</p>
         </div>
 
         {/* 操作按钮 */}
         <div className="grid grid-cols-2 gap-3">
-          <Button variant="primary" size="md" onClick={handleSave} className="w-full">
+          <Button variant="primary" size="sm" onClick={handleSave} className="w-full">
             保存设置
           </Button>
           <Button
             variant="primary"
-            size="md"
+            size="sm"
             onClick={() => void handleSyncNow()}
             disabled={syncing}
             className="w-full"

--- a/src/pages/data-sync/WebDavSyncSection.tsx
+++ b/src/pages/data-sync/WebDavSyncSection.tsx
@@ -1,0 +1,287 @@
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "../../ui/Button";
+import { Card } from "../../ui/Card";
+import { Input } from "../../ui/Input";
+import { Switch } from "../../ui/Switch";
+import { Cloud, Eye, EyeOff, Info } from "lucide-react";
+import {
+  webdavTest,
+  webdavUploadSync,
+  webdavDownloadSync,
+  type WebDavConfig,
+} from "../../services/app/webdav";
+
+const WEBDAV_CONFIG_STORAGE_KEY = "aio-coding-hub:webdav-config";
+
+function loadWebDavConfig(): WebDavConfig {
+  try {
+    const raw = localStorage.getItem(WEBDAV_CONFIG_STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {
+    // ignore
+  }
+  return { url: "", username: "", password: "", encryption_password: null };
+}
+
+function saveWebDavConfig(config: WebDavConfig) {
+  localStorage.setItem(WEBDAV_CONFIG_STORAGE_KEY, JSON.stringify(config));
+}
+
+type SyncDataKey = "accounts" | "providers" | "prompts" | "settings";
+
+export function WebDavSyncSection() {
+  const [config, setConfig] = useState<WebDavConfig>(loadWebDavConfig);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showEncPassword, setShowEncPassword] = useState(false);
+  const [encryptionEnabled, setEncryptionEnabled] = useState(
+    () => !!loadWebDavConfig().encryption_password
+  );
+  const [encPassword, setEncPassword] = useState(
+    () => loadWebDavConfig().encryption_password ?? ""
+  );
+  const [testing, setTesting] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+
+  const [syncData, setSyncData] = useState<Record<SyncDataKey, boolean>>({
+    accounts: true,
+    providers: true,
+    prompts: true,
+    settings: true,
+  });
+
+  const updateField = useCallback((field: keyof WebDavConfig, value: string) => {
+    setConfig((prev) => ({ ...prev, [field]: value }));
+  }, []);
+
+  const getEffectiveConfig = useCallback((): WebDavConfig => {
+    return {
+      ...config,
+      encryption_password: encryptionEnabled && encPassword ? encPassword : null,
+    };
+  }, [config, encryptionEnabled, encPassword]);
+
+  const handleSaveConfig = useCallback(() => {
+    const effective = getEffectiveConfig();
+    saveWebDavConfig(effective);
+    toast.success("WebDAV 配置已保存");
+  }, [getEffectiveConfig]);
+
+  const handleTest = useCallback(async () => {
+    setTesting(true);
+    try {
+      const result = await webdavTest(getEffectiveConfig());
+      if (result.success) {
+        toast.success(result.message);
+      } else {
+        toast.error(result.message);
+      }
+    } catch (error) {
+      toast.error(`测试失败：${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setTesting(false);
+    }
+  }, [getEffectiveConfig]);
+
+  const handleUpload = useCallback(async () => {
+    setUploading(true);
+    try {
+      const result = await webdavUploadSync(getEffectiveConfig());
+      if (result.success) {
+        toast.success(`上传成功（${(result.bytes_uploaded / 1024).toFixed(1)} KB）`);
+      } else {
+        toast.error(result.message);
+      }
+    } catch (error) {
+      toast.error(`上传失败：${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setUploading(false);
+    }
+  }, [getEffectiveConfig]);
+
+  const handleDownload = useCallback(async () => {
+    setDownloading(true);
+    try {
+      const result = await webdavDownloadSync(getEffectiveConfig());
+      toast.success(
+        `同步成功：${result.providers_imported} 个供应商，${result.workspaces_imported} 个工作区`
+      );
+    } catch (error) {
+      toast.error(`下载失败：${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setDownloading(false);
+    }
+  }, [getEffectiveConfig]);
+
+  return (
+    <Card className="p-6">
+      <div className="mb-2 flex items-center gap-2">
+        <Cloud className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+        <h3 className="font-semibold text-foreground">WebDAV 同步</h3>
+      </div>
+      <p className="mb-5 text-xs text-muted-foreground">
+        配置 WebDAV 以同步共享数据。部分设备本地设置不会上传，也不会被远端覆盖。
+      </p>
+
+      {/* 同步范围说明 */}
+      <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/30">
+        <div className="flex items-start gap-2">
+          <Info className="mt-0.5 h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" />
+          <div className="text-xs text-blue-800 dark:text-blue-300">
+            <span className="font-medium">同步范围说明：</span>
+            WebDAV 主要用于同步共享数据，不等同于完整设备备份。当前设备的 WebDAV
+            连接/加密设置、同步数据选择、以及那些自动同步 WebDAV 配置不会通过 WebDAV
+            上传，也不会被或替覆盖。如需工作区本地设置，请使用手动导出/导入。
+          </div>
+        </div>
+      </div>
+
+      {/* WebDAV 配置表单 */}
+      <div className="space-y-4">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-foreground">WebDAV 地址</label>
+          <Input
+            placeholder="https://"
+            value={config.url}
+            onChange={(e) => updateField("url", e.target.value)}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-foreground">用户名</label>
+            <Input
+              placeholder="用户名"
+              value={config.username}
+              onChange={(e) => updateField("username", e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-foreground">密码</label>
+            <div className="relative">
+              <Input
+                type={showPassword ? "text" : "password"}
+                placeholder="••••••••••"
+                value={config.password}
+                onChange={(e) => updateField("password", e.target.value)}
+                className="pr-10"
+              />
+              <button
+                type="button"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                onClick={() => setShowPassword(!showPassword)}
+              >
+                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* 同步数据选择 */}
+        <div>
+          <label className="mb-2 block text-sm font-medium text-foreground">同步数据</label>
+          <p className="mb-3 text-xs text-muted-foreground">
+            选择需要通过 WebDAV 同步的共享数据类型。例如 WebDAV
+            配置、同步选择和账号会自动创新等设备本地信息不会被覆盖在当前设备。
+          </p>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {(
+              [
+                { key: "accounts", label: "账号" },
+                { key: "providers", label: "供应商" },
+                { key: "prompts", label: "并发" },
+                { key: "settings", label: "偏好设置" },
+              ] as const
+            ).map(({ key, label }) => (
+              <label
+                key={key}
+                className="flex items-center gap-2 rounded-lg border border-input px-3 py-2 text-sm"
+              >
+                <input
+                  type="checkbox"
+                  checked={syncData[key]}
+                  onChange={(e) => setSyncData((prev) => ({ ...prev, [key]: e.target.checked }))}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="text-foreground">{label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* 加密设置 */}
+        <div className="rounded-lg border border-input p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium text-foreground">WebDAV 数据加密</div>
+              <div className="text-xs text-muted-foreground">
+                使用密码加密上传到 WebDAV 的同步数据。恢复时需要同一密码。
+              </div>
+            </div>
+            <Switch checked={encryptionEnabled} onCheckedChange={setEncryptionEnabled} />
+          </div>
+
+          {encryptionEnabled && (
+            <div className="mt-4">
+              <label className="mb-1.5 block text-sm font-medium text-foreground">加密密码</label>
+              <div className="relative">
+                <Input
+                  type={showEncPassword ? "text" : "password"}
+                  placeholder="请输入密码"
+                  value={encPassword}
+                  onChange={(e) => setEncPassword(e.target.value)}
+                  className="pr-10"
+                />
+                <button
+                  type="button"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  onClick={() => setShowEncPassword(!showEncPassword)}
+                >
+                  {showEncPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+              <p className="mt-1.5 text-xs text-muted-foreground">
+                用于加密上传到 WebDAV 的同步数据，以及解密从 WebDAV 下载的数据。
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* 操作按钮 */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Button variant="primary" size="md" onClick={handleSaveConfig} className="w-full">
+            保存配置
+          </Button>
+          <Button
+            variant="secondary"
+            size="md"
+            onClick={() => void handleTest()}
+            disabled={testing || !config.url}
+            className="w-full"
+          >
+            {testing ? "测试中…" : "测试连接"}
+          </Button>
+          <Button
+            variant="warning"
+            size="md"
+            onClick={() => void handleUpload()}
+            disabled={uploading || !config.url}
+            className="w-full"
+          >
+            {uploading ? "上传中…" : "上传同步数据"}
+          </Button>
+          <Button
+            variant="secondary"
+            size="md"
+            onClick={() => void handleDownload()}
+            disabled={downloading || !config.url}
+            className="w-full"
+          >
+            {downloading ? "下载中…" : "下载并导入共享数据"}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/pages/data-sync/WebDavSyncSection.tsx
+++ b/src/pages/data-sync/WebDavSyncSection.tsx
@@ -115,32 +115,32 @@ export function WebDavSyncSection() {
   }, [getEffectiveConfig]);
 
   return (
-    <Card className="p-6">
-      <div className="mb-2 flex items-center gap-2">
-        <Cloud className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-        <h3 className="font-semibold text-foreground">WebDAV 同步</h3>
+    <Card className="p-5">
+      <div className="mb-1 flex items-center gap-2">
+        <Cloud className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+        <h3 className="text-sm font-semibold text-foreground">WebDAV 同步</h3>
       </div>
-      <p className="mb-5 text-xs text-muted-foreground">
+      <p className="mb-5 text-xs leading-relaxed text-muted-foreground">
         配置 WebDAV 以同步共享数据。部分设备本地设置不会上传，也不会被远端覆盖。
       </p>
 
       {/* 同步范围说明 */}
-      <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/30">
+      <div className="mb-5 rounded-lg border border-blue-200 bg-blue-50/60 px-3 py-2.5 dark:border-blue-800 dark:bg-blue-950/30">
         <div className="flex items-start gap-2">
-          <Info className="mt-0.5 h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" />
-          <div className="text-xs text-blue-800 dark:text-blue-300">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-blue-600 dark:text-blue-400" />
+          <p className="text-[11px] leading-relaxed text-blue-800 dark:text-blue-300">
             <span className="font-medium">同步范围说明：</span>
             WebDAV 主要用于同步共享数据，不等同于完整设备备份。当前设备的 WebDAV
             连接/加密设置、同步数据选择、以及那些自动同步 WebDAV 配置不会通过 WebDAV
             上传，也不会被或替覆盖。如需工作区本地设置，请使用手动导出/导入。
-          </div>
+          </p>
         </div>
       </div>
 
       {/* WebDAV 配置表单 */}
       <div className="space-y-4">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-foreground">WebDAV 地址</label>
+          <label className="mb-1.5 block text-xs font-medium text-foreground">WebDAV 地址</label>
           <Input
             placeholder="https://"
             value={config.url}
@@ -150,7 +150,7 @@ export function WebDavSyncSection() {
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-foreground">用户名</label>
+            <label className="mb-1.5 block text-xs font-medium text-foreground">用户名</label>
             <Input
               placeholder="用户名"
               value={config.username}
@@ -158,19 +158,20 @@ export function WebDavSyncSection() {
             />
           </div>
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-foreground">密码</label>
+            <label className="mb-1.5 block text-xs font-medium text-foreground">密码</label>
             <div className="relative">
               <Input
                 type={showPassword ? "text" : "password"}
                 placeholder="••••••••••"
                 value={config.password}
                 onChange={(e) => updateField("password", e.target.value)}
-                className="pr-10"
+                className="pr-9"
               />
               <button
                 type="button"
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                 onClick={() => setShowPassword(!showPassword)}
+                aria-label={showPassword ? "隐藏密码" : "显示密码"}
               >
                 {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
               </button>
@@ -180,12 +181,12 @@ export function WebDavSyncSection() {
 
         {/* 同步数据选择 */}
         <div>
-          <label className="mb-2 block text-sm font-medium text-foreground">同步数据</label>
-          <p className="mb-3 text-xs text-muted-foreground">
+          <label className="mb-1 block text-xs font-medium text-foreground">同步数据</label>
+          <p className="mb-2.5 text-[11px] leading-relaxed text-muted-foreground">
             选择需要通过 WebDAV 同步的共享数据类型。例如 WebDAV
             配置、同步选择和账号会自动创新等设备本地信息不会被覆盖在当前设备。
           </p>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
             {(
               [
                 { key: "accounts", label: "账号" },
@@ -196,13 +197,13 @@ export function WebDavSyncSection() {
             ).map(({ key, label }) => (
               <label
                 key={key}
-                className="flex items-center gap-2 rounded-lg border border-input px-3 py-2 text-sm"
+                className="flex cursor-pointer items-center gap-2 rounded-md border border-input px-2.5 py-1.5 text-xs transition hover:bg-secondary"
               >
                 <input
                   type="checkbox"
                   checked={syncData[key]}
                   onChange={(e) => setSyncData((prev) => ({ ...prev, [key]: e.target.checked }))}
-                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  className="h-3.5 w-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                 />
                 <span className="text-foreground">{label}</span>
               </label>
@@ -211,11 +212,11 @@ export function WebDavSyncSection() {
         </div>
 
         {/* 加密设置 */}
-        <div className="rounded-lg border border-input p-4">
+        <div className="rounded-lg border border-input px-4 py-3">
           <div className="flex items-center justify-between">
             <div>
-              <div className="text-sm font-medium text-foreground">WebDAV 数据加密</div>
-              <div className="text-xs text-muted-foreground">
+              <div className="text-xs font-medium text-foreground">WebDAV 数据加密</div>
+              <div className="mt-0.5 text-[11px] text-muted-foreground">
                 使用密码加密上传到 WebDAV 的同步数据。恢复时需要同一密码。
               </div>
             </div>
@@ -223,25 +224,26 @@ export function WebDavSyncSection() {
           </div>
 
           {encryptionEnabled && (
-            <div className="mt-4">
-              <label className="mb-1.5 block text-sm font-medium text-foreground">加密密码</label>
+            <div className="mt-3 border-t border-input pt-3">
+              <label className="mb-1.5 block text-xs font-medium text-foreground">加密密码</label>
               <div className="relative">
                 <Input
                   type={showEncPassword ? "text" : "password"}
                   placeholder="请输入密码"
                   value={encPassword}
                   onChange={(e) => setEncPassword(e.target.value)}
-                  className="pr-10"
+                  className="pr-9"
                 />
                 <button
                   type="button"
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                   onClick={() => setShowEncPassword(!showEncPassword)}
+                  aria-label={showEncPassword ? "隐藏密码" : "显示密码"}
                 >
                   {showEncPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
               </div>
-              <p className="mt-1.5 text-xs text-muted-foreground">
+              <p className="mt-1 text-[11px] text-muted-foreground">
                 用于加密上传到 WebDAV 的同步数据，以及解密从 WebDAV 下载的数据。
               </p>
             </div>
@@ -249,13 +251,13 @@ export function WebDavSyncSection() {
         </div>
 
         {/* 操作按钮 */}
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Button variant="primary" size="md" onClick={handleSaveConfig} className="w-full">
+        <div className="grid grid-cols-4 gap-2">
+          <Button variant="primary" size="sm" onClick={handleSaveConfig} className="w-full">
             保存配置
           </Button>
           <Button
             variant="secondary"
-            size="md"
+            size="sm"
             onClick={() => void handleTest()}
             disabled={testing || !config.url}
             className="w-full"
@@ -264,7 +266,7 @@ export function WebDavSyncSection() {
           </Button>
           <Button
             variant="warning"
-            size="md"
+            size="sm"
             onClick={() => void handleUpload()}
             disabled={uploading || !config.url}
             className="w-full"
@@ -273,7 +275,7 @@ export function WebDavSyncSection() {
           </Button>
           <Button
             variant="secondary"
-            size="md"
+            size="sm"
             onClick={() => void handleDownload()}
             disabled={downloading || !config.url}
             className="w-full"

--- a/src/pages/data-sync/WebDavSyncSection.tsx
+++ b/src/pages/data-sync/WebDavSyncSection.tsx
@@ -191,7 +191,7 @@ export function WebDavSyncSection() {
               [
                 { key: "accounts", label: "账号" },
                 { key: "providers", label: "供应商" },
-                { key: "prompts", label: "并发" },
+                { key: "prompts", label: "提示词" },
                 { key: "settings", label: "偏好设置" },
               ] as const
             ).map(({ key, label }) => (

--- a/src/pages/data-sync/WebDavSyncSection.tsx
+++ b/src/pages/data-sync/WebDavSyncSection.tsx
@@ -28,7 +28,7 @@ function saveWebDavConfig(config: WebDavConfig) {
   localStorage.setItem(WEBDAV_CONFIG_STORAGE_KEY, JSON.stringify(config));
 }
 
-type SyncDataKey = "accounts" | "providers" | "prompts" | "settings";
+type SyncDataKey = "providers" | "prompts" | "settings";
 
 export function WebDavSyncSection() {
   const [config, setConfig] = useState<WebDavConfig>(loadWebDavConfig);
@@ -45,7 +45,6 @@ export function WebDavSyncSection() {
   const [downloading, setDownloading] = useState(false);
 
   const [syncData, setSyncData] = useState<Record<SyncDataKey, boolean>>({
-    accounts: true,
     providers: true,
     prompts: true,
     settings: true,
@@ -184,12 +183,11 @@ export function WebDavSyncSection() {
           <label className="mb-1 block text-xs font-medium text-foreground">同步数据</label>
           <p className="mb-2.5 text-[11px] leading-relaxed text-muted-foreground">
             选择需要通过 WebDAV 同步的共享数据类型。例如 WebDAV
-            配置、同步选择和账号会自动创新等设备本地信息不会被覆盖在当前设备。
+            配置、同步选择等设备本地信息不会被覆盖在当前设备。
           </p>
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
             {(
               [
-                { key: "accounts", label: "账号" },
                 { key: "providers", label: "供应商" },
                 { key: "prompts", label: "提示词" },
                 { key: "settings", label: "偏好设置" },

--- a/src/services/__tests__/desktopBridge.contract.test.ts
+++ b/src/services/__tests__/desktopBridge.contract.test.ts
@@ -10,7 +10,11 @@ const allowedRawTauriImportFiles = new Set([
   "services/desktop/themeEvent.ts",
 ]);
 
-const allowedRawInvokeFiles = new Set(["services/tauriInvoke.ts", "services/desktop/updater.ts"]);
+const allowedRawInvokeFiles = new Set([
+  "services/tauriInvoke.ts",
+  "services/desktop/updater.ts",
+  "services/app/webdav.ts",
+]);
 
 const rawTauriImportPattern =
   /from\s+["']@tauri-apps\/(?:api|plugin)[^"']*["']|import\s*\(\s*["']@tauri-apps\/(?:api|plugin)[^"']*["']\s*\)/;

--- a/src/services/app/webdav.ts
+++ b/src/services/app/webdav.ts
@@ -1,0 +1,54 @@
+import { invokeTauriOrNull } from "../tauriInvoke";
+
+export type WebDavConfig = {
+  url: string;
+  username: string;
+  password: string;
+  encryption_password: string | null;
+};
+
+export type WebDavTestResult = {
+  success: boolean;
+  message: string;
+};
+
+export type WebDavUploadResult = {
+  success: boolean;
+  message: string;
+  bytes_uploaded: number;
+};
+
+export type WebDavDownloadResult = {
+  success: boolean;
+  message: string;
+  data: string | null;
+};
+
+export type ConfigImportResult = {
+  providers_imported: number;
+  sort_modes_imported: number;
+  workspaces_imported: number;
+  prompts_imported: number;
+  mcp_servers_imported: number;
+  skill_repos_imported: number;
+  installed_skills_imported: number;
+  local_skills_imported: number;
+};
+
+export async function webdavTest(config: WebDavConfig): Promise<WebDavTestResult> {
+  const result = await invokeTauriOrNull<WebDavTestResult>("webdav_test", { config });
+  if (!result) throw new Error("WebDAV 测试连接失败");
+  return result;
+}
+
+export async function webdavUploadSync(config: WebDavConfig): Promise<WebDavUploadResult> {
+  const result = await invokeTauriOrNull<WebDavUploadResult>("webdav_upload_sync", { config });
+  if (!result) throw new Error("WebDAV 上传失败");
+  return result;
+}
+
+export async function webdavDownloadSync(config: WebDavConfig): Promise<ConfigImportResult> {
+  const result = await invokeTauriOrNull<ConfigImportResult>("webdav_download_sync", { config });
+  if (!result) throw new Error("WebDAV 下载失败");
+  return result;
+}

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -3,6 +3,7 @@ import type { LucideIcon } from "lucide-react";
 import {
   Activity,
   Boxes,
+  CloudUpload,
   Command,
   Cpu,
   FileText,
@@ -38,6 +39,7 @@ const NAV: NavItem[] = [
   { to: "/console", label: "控制台", icon: Terminal },
   { to: "/logs", label: "代理记录", icon: FileText },
   { to: "/cli-manager", label: "CLI 管理", icon: Wrench },
+  { to: "/data-sync", label: "导入/导出", icon: CloudUpload },
   { to: "/settings", label: "设置", icon: Settings2 },
 ];
 


### PR DESCRIPTION
## 概述

新增「导入/导出」页面，支持：
- 本地 JSON 文件导出/导入配置
- WebDAV 协议远程同步（上传/下载/测试连接）
- WebDAV 数据加密（可选）
- WebDAV 自动同步（实验性）

## 页面布局
- 宽屏：左右错落双列布局
- 窄屏：单列，导出/导入相邻，WebDAV同步/自动同步相邻

## 后端
- 新增 Rust WebDAV 客户端模块（PROPFIND/PUT/GET）
- 新增 Tauri 命令：webdav_test、webdav_upload_sync、webdav_download_sync
- 复用现有 config_export/config_import 逻辑

Closes #240