### PR TITLE
feat(providers): 整个排序卡片可拖拽，不再限制为手柄图标

### DIFF
--- a/src/pages/providers/SortableProviderOrderItem.tsx
+++ b/src/pages/providers/SortableProviderOrderItem.tsx
@@ -95,7 +95,12 @@ export const SortableProviderOrderItem = memo(function SortableProviderOrderItem
   };
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn("cursor-grab active:cursor-grabbing", disabled && "cursor-default")}
+      {...(disabled ? {} : { ...attributes, ...listeners })}
+    >
       <ProviderOrderItem
         provider={provider}
         providerId={providerId}
@@ -106,7 +111,6 @@ export const SortableProviderOrderItem = memo(function SortableProviderOrderItem
           isDragging && "z-10 scale-[1.02] opacity-95 shadow-lg ring-2 ring-ring/30",
           disabled && "opacity-70"
         )}
-        dragHandleProps={disabled ? undefined : { ...attributes, ...listeners }}
       />
     </div>
   );


### PR DESCRIPTION
## 概述

将供应商排序面板的拖拽区域从小图标（GripVertical）扩展到整个卡片，操作更直观。

## 实现
- 将 `useSortable` 的 `attributes` 和 `listeners` 绑定到整个卡片容器
- 保留 GripVertical 图标作为视觉提示
- 禁用状态的 provider 不可拖拽

## 注意
卡片内的交互元素（Switch、Button）通过 `onPointerDown stopPropagation` 防止拖拽冲突，`PointerSensor` 的 `distance: 8` 激活约束确保普通点击不会误触拖拽。