### PR TITLE
feat: support codex websocket proxy

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "chrono",
  "flate2",
  "futures-core",
+ "futures-util",
  "hostname",
  "if-addrs",
  "junction",
@@ -75,6 +76,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "toml 0.8.2",
  "tower",
  "tracing",
@@ -356,6 +358,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http",
@@ -374,8 +377,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -903,6 +908,12 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deranged"
@@ -4273,6 +4284,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5315,6 +5337,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5581,6 +5619,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ sha2 = "0.10"
 base64 = "0.22"
 rand = "0.8"
 bytes = "1"
-axum = "0.7"
+axum = { version = "0.7", features = ["ws"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "process", "sync", "time", "io-util"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
 r2d2 = "0.8"
@@ -43,8 +43,10 @@ reqwest = { version = "0.12.28", default-features = false, features = ["rustls-t
 if-addrs = "0.13"
 hostname = "0.4"
 futures-core = "0.3"
+futures-util = "0.3"
 flate2 = "1.1.5"
 zip = { version = "4.6", default-features = false, features = ["deflate"] }
+tokio-tungstenite = { version = "0.24.0", features = ["rustls-tls-native-roots"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/src-tauri/src/app/gateway_control.rs
+++ b/src-tauri/src/app/gateway_control.rs
@@ -101,6 +101,10 @@ pub(crate) fn app_gateway_clear_cli_route_runtime_state<R: tauri::Runtime>(
     })
 }
 
+pub(crate) fn app_gateway_close_provider_websockets(provider_id: i64) -> usize {
+    gateway::close_active_provider_websockets(provider_id)
+}
+
 pub(crate) fn try_app_gateway_update_circuit_config<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     failure_threshold: u32,

--- a/src-tauri/src/app/provider_service.rs
+++ b/src-tauri/src/app/provider_service.rs
@@ -30,6 +30,7 @@ pub(crate) struct ProviderUpsertInput {
     pub source_provider_id: Option<i64>,
     pub bridge_type: Option<String>,
     pub stream_idle_timeout_seconds: Option<u32>,
+    pub supports_websockets: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -100,7 +101,8 @@ fn provider_runtime_reset_decision(
         || previous.auth_mode != next.auth_mode
         || submitted_api_key_changed(previous_api_key, submitted_api_key)
         || previous.source_provider_id != next.source_provider_id
-        || previous.bridge_type != next.bridge_type;
+        || previous.bridge_type != next.bridge_type
+        || previous.supports_websockets != next.supports_websockets;
 
     ProviderRuntimeResetDecision {
         clear_route_runtime_state: sensitive_config_changed,
@@ -149,6 +151,7 @@ pub(crate) async fn provider_upsert(
         source_provider_id,
         bridge_type,
         stream_idle_timeout_seconds,
+        supports_websockets,
     } = input;
 
     let is_create = provider_id.is_none();
@@ -195,6 +198,7 @@ pub(crate) async fn provider_upsert(
                 source_provider_id,
                 bridge_type,
                 stream_idle_timeout_seconds,
+                supports_websockets,
             },
         )?;
 
@@ -287,6 +291,7 @@ pub(crate) async fn provider_duplicate(
                 source_provider_id: source.source_provider_id,
                 bridge_type: source.bridge_type.clone(),
                 stream_idle_timeout_seconds: source.stream_idle_timeout_seconds,
+                supports_websockets: Some(source.supports_websockets),
             },
         )
     })
@@ -432,7 +437,8 @@ mod tests {
             "limitTotalUsd": null,
             "tags": ["x"],
             "note": "n",
-            "streamIdleTimeoutSeconds": 90
+            "streamIdleTimeoutSeconds": 90,
+            "supportsWebsockets": true
         }))
         .expect("deserialize provider input");
 
@@ -444,6 +450,7 @@ mod tests {
             Some(providers::DailyResetMode::Fixed)
         );
         assert_eq!(input.stream_idle_timeout_seconds, Some(90));
+        assert_eq!(input.supports_websockets, Some(true));
     }
 
     #[test]
@@ -505,6 +512,7 @@ mod tests {
             source_provider_id: None,
             bridge_type: None,
             stream_idle_timeout_seconds: None,
+            supports_websockets: false,
             api_key_configured: true,
         };
 
@@ -589,6 +597,7 @@ mod tests {
             source_provider_id: None,
             bridge_type: None,
             stream_idle_timeout_seconds: None,
+            supports_websockets: false,
             api_key_configured: true,
         };
 

--- a/src-tauri/src/app/provider_service.rs
+++ b/src-tauri/src/app/provider_service.rs
@@ -1,5 +1,7 @@
 use crate::app_state::{ensure_db_ready, DbInitState};
-use crate::gateway_control::app_gateway_clear_cli_route_runtime_state;
+use crate::gateway_control::{
+    app_gateway_clear_cli_route_runtime_state, app_gateway_close_provider_websockets,
+};
 use crate::{blocking, providers};
 
 #[derive(serde::Deserialize, specta::Type)]
@@ -36,6 +38,7 @@ pub(crate) struct ProviderUpsertInput {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct ProviderRuntimeResetDecision {
     clear_route_runtime_state: bool,
+    close_provider_websockets: bool,
 }
 
 fn normalize_provider_name(name: &str) -> String {
@@ -92,9 +95,11 @@ fn provider_runtime_reset_decision(
     let Some(previous) = previous else {
         return ProviderRuntimeResetDecision {
             clear_route_runtime_state: next.enabled,
+            close_provider_websockets: false,
         };
     };
 
+    let websocket_support_changed = previous.supports_websockets != next.supports_websockets;
     let sensitive_config_changed = previous.base_urls != next.base_urls
         || previous.base_url_mode != next.base_url_mode
         || previous.enabled != next.enabled
@@ -102,10 +107,11 @@ fn provider_runtime_reset_decision(
         || submitted_api_key_changed(previous_api_key, submitted_api_key)
         || previous.source_provider_id != next.source_provider_id
         || previous.bridge_type != next.bridge_type
-        || previous.supports_websockets != next.supports_websockets;
+        || websocket_support_changed;
 
     ProviderRuntimeResetDecision {
         clear_route_runtime_state: sensitive_config_changed,
+        close_provider_websockets: websocket_support_changed,
     }
 }
 
@@ -239,6 +245,16 @@ pub(crate) async fn provider_upsert(
                 cleared_sessions = cleared.cleared_sessions,
                 cleared_recent_errors = cleared.cleared_recent_errors,
                 "provider route runtime state cleared after provider save"
+            );
+        }
+
+        if decision.close_provider_websockets {
+            let closed_websockets = app_gateway_close_provider_websockets(provider.id);
+            tracing::info!(
+                provider_id = provider.id,
+                cli_key = %provider.cli_key,
+                closed_websockets,
+                "provider websocket connections closed after websocket support changed"
             );
         }
     }
@@ -520,6 +536,7 @@ mod tests {
             provider_runtime_reset_decision(None, None, &next, None),
             ProviderRuntimeResetDecision {
                 clear_route_runtime_state: true,
+                close_provider_websockets: false,
             }
         );
 
@@ -562,6 +579,7 @@ mod tests {
             provider_runtime_reset_decision(Some(&next), Some("sk-existing"), &disabled, None),
             ProviderRuntimeResetDecision {
                 clear_route_runtime_state: true,
+                close_provider_websockets: false,
             }
         );
     }
@@ -608,6 +626,7 @@ mod tests {
             provider_runtime_reset_decision(Some(&previous), Some("sk-old"), &next, None),
             ProviderRuntimeResetDecision {
                 clear_route_runtime_state: true,
+                close_provider_websockets: false,
             }
         );
 
@@ -623,6 +642,18 @@ mod tests {
             ),
             ProviderRuntimeResetDecision {
                 clear_route_runtime_state: true,
+                close_provider_websockets: false,
+            }
+        );
+
+        let mut next_websocket = previous.clone();
+        next_websocket.supports_websockets = true;
+
+        assert_eq!(
+            provider_runtime_reset_decision(Some(&previous), Some("sk-old"), &next_websocket, None),
+            ProviderRuntimeResetDecision {
+                clear_route_runtime_state: true,
+                close_provider_websockets: true,
             }
         );
     }

--- a/src-tauri/src/domain/cli_sessions/codex.rs
+++ b/src-tauri/src/domain/cli_sessions/codex.rs
@@ -649,8 +649,8 @@ fn folder_lookup_in_files(
 
         let folder_path = meta
             .as_ref()
-            .and_then(|value| value.cwd.clone())
-            .or_else(|| meta.as_ref().and_then(|value| value.project_path.clone()))
+            .and_then(|value| value.project_path.clone())
+            .or_else(|| meta.as_ref().and_then(|value| value.cwd.clone()))
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
         let Some(folder_path) = folder_path else {
@@ -946,7 +946,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn folder_lookup_prefers_cwd_and_falls_back_to_project_path() {
+    fn folder_lookup_prefers_project_path_and_falls_back_to_cwd() {
         let dir = tempdir().unwrap();
         let sessions_dir = dir.path();
         let day_dir = sessions_dir.join("2026").join("04").join("06");
@@ -979,12 +979,12 @@ mod tests {
 
         assert_eq!(out.len(), 2);
 
-        let cwd_entry = out
+        let project_entry = out
             .iter()
             .find(|item| item.session_id == "codex-cwd")
             .unwrap();
-        assert_eq!(cwd_entry.folder_name, "current");
-        assert_eq!(cwd_entry.folder_path, "/Users/demo/worktrees/current");
+        assert_eq!(project_entry.folder_name, "fallback");
+        assert_eq!(project_entry.folder_path, "/Users/demo/worktrees/fallback");
 
         let fallback_entry = out
             .iter()

--- a/src-tauri/src/domain/provider_limit_usage.rs
+++ b/src-tauri/src/domain/provider_limit_usage.rs
@@ -544,6 +544,7 @@ mod tests {
                 source_provider_id: None,
                 bridge_type: None,
                 stream_idle_timeout_seconds: None,
+                supports_websockets: None,
             },
         )
         .expect("create provider")

--- a/src-tauri/src/domain/provider_oauth_limits.rs
+++ b/src-tauri/src/domain/provider_oauth_limits.rs
@@ -371,6 +371,7 @@ INSERT INTO provider_oauth_limit_snapshots(
                 source_provider_id: None,
                 bridge_type: None,
                 stream_idle_timeout_seconds: None,
+                supports_websockets: None,
             },
         )
         .expect("insert provider")

--- a/src-tauri/src/domain/providers/queries.rs
+++ b/src-tauri/src/domain/providers/queries.rs
@@ -45,6 +45,11 @@ fn decode_provider_row(
         oauth_provider_type: row.get("oauth_provider_type")?,
         source_provider_id: row.get("source_provider_id")?,
         bridge_type: row.get("bridge_type").unwrap_or(None),
+        supports_websockets: row
+            .get::<_, Option<i64>>("supports_websockets")
+            .unwrap_or(None)
+            .unwrap_or(0)
+            != 0,
     })
 }
 
@@ -84,6 +89,7 @@ fn row_to_summary(row: &rusqlite::Row<'_>) -> Result<ProviderSummary, rusqlite::
         stream_idle_timeout_seconds: parse_positive_optional_u32(
             row.get("stream_idle_timeout_seconds").unwrap_or(None),
         ),
+        supports_websockets: decoded.supports_websockets,
         api_key_configured: row
             .get::<_, Option<i64>>("api_key_configured")
             .unwrap_or(None)
@@ -128,6 +134,7 @@ SELECT
   source_provider_id,
   bridge_type,
   stream_idle_timeout_seconds,
+  supports_websockets,
   CASE WHEN COALESCE(api_key_plaintext, '') = '' THEN 0 ELSE 1 END AS api_key_configured
 FROM providers
 WHERE id = ?1
@@ -385,6 +392,7 @@ SELECT
   source_provider_id,
   bridge_type,
   stream_idle_timeout_seconds,
+  supports_websockets,
   CASE WHEN COALESCE(api_key_plaintext, '') = '' THEN 0 ELSE 1 END AS api_key_configured
 FROM providers
 WHERE cli_key = ?1
@@ -434,6 +442,7 @@ fn map_gateway_provider_row(
         stream_idle_timeout_seconds: parse_positive_optional_u32(
             row.get("stream_idle_timeout_seconds").unwrap_or(None),
         ),
+        supports_websockets: decoded.supports_websockets,
     })
 }
 
@@ -465,7 +474,8 @@ SELECT
   p.oauth_provider_type,
   p.source_provider_id,
   p.bridge_type,
-  p.stream_idle_timeout_seconds
+  p.stream_idle_timeout_seconds,
+  p.supports_websockets
 FROM sort_mode_providers mp
 JOIN providers p ON p.id = mp.provider_id
 WHERE mp.mode_id = ?1
@@ -517,7 +527,8 @@ SELECT
   oauth_provider_type,
   source_provider_id,
   bridge_type,
-  stream_idle_timeout_seconds
+  stream_idle_timeout_seconds,
+  supports_websockets
 FROM providers
 WHERE cli_key = ?1
   AND enabled = 1
@@ -644,7 +655,8 @@ SELECT
   oauth_provider_type,
   source_provider_id,
   bridge_type,
-  stream_idle_timeout_seconds
+  stream_idle_timeout_seconds,
+  supports_websockets
 FROM providers
 WHERE id = ?1 AND enabled = 1 AND source_provider_id IS NULL AND cli_key = 'codex'
 "#,
@@ -696,6 +708,7 @@ pub fn upsert(
         source_provider_id,
         bridge_type,
         stream_idle_timeout_seconds,
+        supports_websockets,
     } = input;
     let cli_key = cli_key.trim();
     validate_cli_key(cli_key)?;
@@ -798,6 +811,8 @@ pub fn upsert(
     let stream_idle_timeout_seconds_specified = stream_idle_timeout_seconds.is_some();
     let stream_idle_timeout_seconds =
         normalize_stream_idle_timeout_seconds(stream_idle_timeout_seconds)?;
+    let supports_websockets_specified = supports_websockets.is_some();
+    let supports_websockets = supports_websockets.unwrap_or(false);
 
     let api_key = api_key.as_deref().map(str::trim).filter(|v| !v.is_empty());
 
@@ -884,9 +899,10 @@ INSERT INTO providers(
   source_provider_id,
   bridge_type,
   stream_idle_timeout_seconds,
+  supports_websockets,
   created_at,
   updated_at
-) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, '{}', '{}', ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, '{}', '{}', ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)
 "#,
                 params![
                     cli_key,
@@ -913,6 +929,7 @@ INSERT INTO providers(
                     source_provider_id,
                     bridge_type,
                     stream_idle_timeout_seconds,
+                    enabled_to_int(supports_websockets),
                     now,
                     now
                 ],
@@ -947,12 +964,13 @@ INSERT INTO providers(
                 String,
                 String,
                 Option<i64>,
+                i64,
             );
             let existing: Option<ExistingProviderRow> = tx
                 .query_row(
-                    "SELECT cli_key, api_key_plaintext, priority, claude_models_json, auth_mode, daily_reset_mode, daily_reset_time, tags_json, note, stream_idle_timeout_seconds FROM providers WHERE id = ?1",
+                    "SELECT cli_key, api_key_plaintext, priority, claude_models_json, auth_mode, daily_reset_mode, daily_reset_time, tags_json, note, stream_idle_timeout_seconds, supports_websockets FROM providers WHERE id = ?1",
                     params![id],
-                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?, row.get(7)?, row.get(8)?, row.get(9)?)),
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?, row.get(7)?, row.get(8)?, row.get(9)?, row.get(10)?)),
                 )
                 .optional()
                 .map_err(|e| db_err!("failed to query provider: {e}"))?;
@@ -968,6 +986,7 @@ INSERT INTO providers(
                 existing_tags_json,
                 existing_note,
                 existing_stream_idle_timeout_seconds,
+                existing_supports_websockets,
             )) = existing
             else {
                 return Err("DB_NOT_FOUND: provider not found".to_string().into());
@@ -1045,6 +1064,11 @@ INSERT INTO providers(
             } else {
                 parse_positive_optional_u32(existing_stream_idle_timeout_seconds)
             };
+            let next_supports_websockets = if supports_websockets_specified {
+                supports_websockets
+            } else {
+                existing_supports_websockets != 0
+            };
 
             tx.execute(
                 r#"
@@ -1074,8 +1098,9 @@ SET
   source_provider_id = ?20,
   bridge_type = ?21,
   stream_idle_timeout_seconds = ?22,
-  updated_at = ?23
-WHERE id = ?24
+  supports_websockets = ?23,
+  updated_at = ?24
+WHERE id = ?25
 "#,
                 params![
                     name,
@@ -1100,6 +1125,7 @@ WHERE id = ?24
                     source_provider_id,
                     bridge_type,
                     next_stream_idle_timeout_seconds,
+                    enabled_to_int(next_supports_websockets),
                     now,
                     id
                 ],

--- a/src-tauri/src/domain/providers/tests.rs
+++ b/src-tauri/src/domain/providers/tests.rs
@@ -416,6 +416,7 @@ fn default_provider_params(name: &str) -> ProviderUpsertParams {
         source_provider_id: None,
         bridge_type: None,
         stream_idle_timeout_seconds: None,
+        supports_websockets: None,
     }
 }
 
@@ -458,6 +459,30 @@ fn upsert_oauth_provider_drops_submitted_base_urls() {
 
     let saved = upsert(&db, params).expect("save oauth provider");
     assert!(saved.base_urls.is_empty());
+}
+
+#[test]
+fn upsert_defaults_and_persists_websocket_support_flag() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("providers_websocket_flag.db");
+    let db = crate::db::init_for_tests(&db_path).expect("init db");
+
+    let saved_default =
+        upsert(&db, default_provider_params("websocket-flag-default")).expect("save provider");
+    assert!(!saved_default.supports_websockets);
+
+    let mut params = default_provider_params("websocket-flag-enabled");
+    params.supports_websockets = Some(true);
+    let saved_enabled = upsert(&db, params).expect("save websocket provider");
+    assert!(saved_enabled.supports_websockets);
+
+    let gateway_provider =
+        list_enabled_for_gateway_in_mode(&db, "claude", None).expect("list gateway providers");
+    let from_gateway = gateway_provider
+        .into_iter()
+        .find(|provider| provider.id == saved_enabled.id)
+        .expect("gateway provider");
+    assert!(from_gateway.supports_websockets);
 }
 
 #[test]
@@ -509,6 +534,7 @@ fn create_oauth_provider_for_cas_test(db: &crate::db::Db, name: &str) -> i64 {
             source_provider_id: None,
             bridge_type: None,
             stream_idle_timeout_seconds: None,
+            supports_websockets: None,
         },
     )
     .expect("create oauth provider")

--- a/src-tauri/src/domain/providers/types.rs
+++ b/src-tauri/src/domain/providers/types.rs
@@ -83,6 +83,7 @@ pub struct ProviderUpsertParams {
     pub source_provider_id: Option<i64>,
     pub bridge_type: Option<String>,
     pub stream_idle_timeout_seconds: Option<u32>,
+    pub supports_websockets: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, specta::Type)]
@@ -226,6 +227,7 @@ pub struct ProviderSummary {
     pub source_provider_id: Option<i64>,
     pub bridge_type: Option<String>,
     pub stream_idle_timeout_seconds: Option<u32>,
+    pub supports_websockets: bool,
     pub api_key_configured: bool,
 }
 
@@ -250,6 +252,7 @@ pub(crate) struct ProviderForGateway {
     #[allow(dead_code)] // Will be read when failover_loop uses bridge_type for dispatch.
     pub bridge_type: Option<String>,
     pub stream_idle_timeout_seconds: Option<u32>,
+    pub supports_websockets: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -297,6 +300,7 @@ pub(super) struct DecodedProviderRow {
     pub oauth_provider_type: Option<String>,
     pub source_provider_id: Option<i64>,
     pub bridge_type: Option<String>,
+    pub supports_websockets: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/domain/usage.rs
+++ b/src-tauri/src/domain/usage.rs
@@ -105,6 +105,26 @@ fn extract_model_from_json_value(value: &Value) -> Option<String> {
     None
 }
 
+fn extract_model_recursive(value: &Value, depth: usize) -> Option<String> {
+    if depth > 8 {
+        return None;
+    }
+
+    if let Some(model) = extract_model_from_json_value(value) {
+        return Some(model);
+    }
+
+    match value {
+        Value::Object(obj) => obj
+            .values()
+            .find_map(|item| extract_model_recursive(item, depth + 1)),
+        Value::Array(items) => items
+            .iter()
+            .find_map(|item| extract_model_recursive(item, depth + 1)),
+        _ => None,
+    }
+}
+
 pub fn parse_model_from_json_bytes(body: &[u8]) -> Option<String> {
     let value: Value = serde_json::from_slice(body).ok()?;
 
@@ -123,7 +143,7 @@ pub fn parse_model_from_json_bytes(body: &[u8]) -> Option<String> {
         }
     }
 
-    None
+    extract_model_recursive(&value, 0)
 }
 
 fn extract_usage_metrics(value: &Value) -> Option<UsageMetrics> {
@@ -156,6 +176,11 @@ fn extract_usage_metrics(value: &Value) -> Option<UsageMetrics> {
     // OpenAI detail: input_tokens_details.cached_tokens OR prompt_tokens_details.cached_tokens
     metrics.cache_read_input_tokens = metrics.cache_read_input_tokens.or_else(|| {
         obj.get("input_tokens_details")
+            .and_then(|v| v.as_object())
+            .and_then(|m| as_i64(m.get("cached_tokens")))
+    });
+    metrics.cache_read_input_tokens = metrics.cache_read_input_tokens.or_else(|| {
+        obj.get("input_token_details")
             .and_then(|v| v.as_object())
             .and_then(|m| as_i64(m.get("cached_tokens")))
     });
@@ -280,9 +305,29 @@ fn extract_from_json_value(value: &Value) -> Option<UsageMetrics> {
     None
 }
 
+fn extract_from_json_value_recursive(value: &Value, depth: usize) -> Option<UsageMetrics> {
+    if depth > 8 {
+        return None;
+    }
+
+    if let Some(metrics) = extract_from_json_value(value) {
+        return Some(metrics);
+    }
+
+    match value {
+        Value::Object(obj) => obj
+            .values()
+            .find_map(|item| extract_from_json_value_recursive(item, depth + 1)),
+        Value::Array(items) => items
+            .iter()
+            .find_map(|item| extract_from_json_value_recursive(item, depth + 1)),
+        _ => None,
+    }
+}
+
 pub fn parse_usage_from_json_bytes(body: &[u8]) -> Option<UsageExtract> {
     let value: Value = serde_json::from_slice(body).ok()?;
-    let metrics = extract_from_json_value(&value)?;
+    let metrics = extract_from_json_value_recursive(&value, 0)?;
     Some(UsageExtract {
         usage_json: normalize_usage_json(&metrics),
         metrics,

--- a/src-tauri/src/domain/usage/tests.rs
+++ b/src-tauri/src/domain/usage/tests.rs
@@ -22,6 +22,30 @@ fn parse_openai_responses_usage_with_cached_tokens() {
 }
 
 #[test]
+fn parse_openai_realtime_usage_with_singular_cached_token_details() {
+    let body = br#"{"type":"response.done","response":{"model":"gpt-realtime","usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18,"input_token_details":{"cached_tokens":3}}}}"#;
+    let extract = parse_usage_from_json_bytes(body).expect("should parse usage");
+    assert_eq!(extract.metrics.input_tokens, Some(11));
+    assert_eq!(extract.metrics.output_tokens, Some(7));
+    assert_eq!(extract.metrics.total_tokens, Some(18));
+    assert_eq!(extract.metrics.cache_read_input_tokens, Some(3));
+}
+
+#[test]
+fn parse_usage_and_model_from_nested_realtime_payload() {
+    let body = br#"{"event":{"payload":{"type":"response.done","response":{"model":"gpt-realtime","usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18}}}}}"#;
+    let extract = parse_usage_from_json_bytes(body).expect("should parse usage");
+
+    assert_eq!(
+        parse_model_from_json_bytes(body).as_deref(),
+        Some("gpt-realtime")
+    );
+    assert_eq!(extract.metrics.input_tokens, Some(11));
+    assert_eq!(extract.metrics.output_tokens, Some(7));
+    assert_eq!(extract.metrics.total_tokens, Some(18));
+}
+
+#[test]
 fn parse_gemini_usage_metadata() {
     let body = br#"{"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":9,"thoughtsTokenCount":2,"totalTokenCount":19,"cachedContentTokenCount":4}}"#;
     let extract = parse_usage_from_json_bytes(body).expect("should parse usage");

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -54,3 +54,7 @@ pub(crate) fn listen_rebind_required(
 ) -> bool {
     binder::listen_rebind_required(previous, next)
 }
+
+pub(crate) fn close_active_provider_websockets(provider_id: i64) -> usize {
+    proxy::close_active_provider_websockets(provider_id)
+}

--- a/src-tauri/src/gateway/manager.rs
+++ b/src-tauri/src/gateway/manager.rs
@@ -248,6 +248,7 @@ mod tests {
                 source_provider_id: None,
                 bridge_type: None,
                 stream_idle_timeout_seconds: None,
+                supports_websockets: None,
             },
         )
         .expect("insert provider")

--- a/src-tauri/src/gateway/proxy/failover/tests.rs
+++ b/src-tauri/src/gateway/proxy/failover/tests.rs
@@ -35,6 +35,7 @@ fn provider_for_base_url_test(
         source_provider_id: None,
         bridge_type: None,
         stream_idle_timeout_seconds: None,
+        supports_websockets: false,
     }
 }
 

--- a/src-tauri/src/gateway/proxy/handler/mod.rs
+++ b/src-tauri/src/gateway/proxy/handler/mod.rs
@@ -296,6 +296,7 @@ mod tests {
             source_provider_id: None,
             bridge_type: None,
             stream_idle_timeout_seconds: None,
+            supports_websockets: false,
         }
     }
 

--- a/src-tauri/src/gateway/proxy/handler/provider_order.rs
+++ b/src-tauri/src/gateway/proxy/handler/provider_order.rs
@@ -92,6 +92,7 @@ mod tests {
             source_provider_id: None,
             bridge_type: None,
             stream_idle_timeout_seconds: None,
+            supports_websockets: false,
         }
     }
 

--- a/src-tauri/src/gateway/proxy/handler/provider_selection/tests.rs
+++ b/src-tauri/src/gateway/proxy/handler/provider_selection/tests.rs
@@ -34,6 +34,7 @@ fn insert_provider(db: &crate::db::Db, name: &str, enabled: bool) -> providers::
             source_provider_id: None,
             bridge_type: None,
             stream_idle_timeout_seconds: None,
+            supports_websockets: None,
         },
     )
     .expect("insert provider")

--- a/src-tauri/src/gateway/proxy/mod.rs
+++ b/src-tauri/src/gateway/proxy/mod.rs
@@ -32,6 +32,7 @@ pub(in crate::gateway) use logging::spawn_enqueue_request_log_with_backpressure;
 pub(super) use types::ErrorCategory;
 
 pub(super) use handler::proxy_impl;
+pub(in crate::gateway) use websocket::close_active_provider_websockets;
 pub(super) use websocket::proxy_websocket_impl;
 
 const CLAUDE_COUNT_TOKENS_PATH: &str = "/v1/messages/count_tokens";

--- a/src-tauri/src/gateway/proxy/mod.rs
+++ b/src-tauri/src/gateway/proxy/mod.rs
@@ -23,6 +23,7 @@ mod request_end;
 pub(in crate::gateway) mod status_override;
 mod types;
 pub(in crate::gateway) mod upstream_client_error_rules;
+mod websocket;
 
 pub(super) use caches::{ProviderBaseUrlPingCache, RecentErrorCache};
 pub(super) use error_code::GatewayErrorCode;
@@ -31,6 +32,7 @@ pub(in crate::gateway) use logging::spawn_enqueue_request_log_with_backpressure;
 pub(super) use types::ErrorCategory;
 
 pub(super) use handler::proxy_impl;
+pub(super) use websocket::proxy_websocket_impl;
 
 const CLAUDE_COUNT_TOKENS_PATH: &str = "/v1/messages/count_tokens";
 const CLAUDE_LOGGED_MESSAGES_PATH: &str = "/v1/messages";

--- a/src-tauri/src/gateway/proxy/mod.rs
+++ b/src-tauri/src/gateway/proxy/mod.rs
@@ -99,7 +99,7 @@ pub(super) fn mark_internal_forwarded_request(headers: &mut HeaderMap) {
     );
 }
 
-fn compute_observe_request(
+pub(super) fn compute_observe_request(
     cli_key: &str,
     forwarded_path: &str,
     headers: &HeaderMap,

--- a/src-tauri/src/gateway/proxy/websocket.rs
+++ b/src-tauri/src/gateway/proxy/websocket.rs
@@ -3,18 +3,92 @@
 use super::cli_proxy_guard::cli_proxy_enabled_cached;
 use super::errors::error_response;
 use super::failover::select_provider_base_url_for_request;
-use super::{mark_internal_forwarded_request, GatewayErrorCode};
+use super::{
+    compute_observe_request, mark_internal_forwarded_request,
+    spawn_enqueue_request_log_with_backpressure, ErrorCategory, GatewayErrorCode,
+    RequestLogEnqueueArgs,
+};
+use crate::gateway::events::{
+    decision_chain as dc, emit_attempt_event, emit_request_start_event, FailoverAttempt,
+    GatewayAttemptEvent,
+};
 use crate::gateway::runtime::GatewayAppState;
-use crate::gateway::util::{build_target_url, clear_all_auth_headers, ensure_cli_required_headers};
+use crate::gateway::util::{
+    build_target_url, clear_all_auth_headers, ensure_cli_required_headers,
+    infer_requested_model_info, now_unix_millis,
+};
 use axum::extract::ws::{Message as AxumWsMessage, WebSocket, WebSocketUpgrade};
 use axum::http::{header, HeaderMap, Request, StatusCode};
 use axum::response::Response;
 use futures_util::{SinkExt, StreamExt};
 use std::borrow::Cow;
+use std::time::Instant;
 use tokio_tungstenite::tungstenite::{self, client::IntoClientRequest};
 
 type UpstreamWsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+struct WebsocketObservation<R: tauri::Runtime = tauri::Wry> {
+    state: GatewayAppState<R>,
+    trace_id: String,
+    cli_key: String,
+    method: String,
+    path: String,
+    query: Option<String>,
+    session_id: Option<String>,
+    requested_model: Option<String>,
+    observe_request: bool,
+    created_at_ms: i64,
+    created_at: i64,
+    started: Instant,
+    provider_id: i64,
+    provider_name: String,
+    provider_base_url: String,
+}
+
+struct WebsocketCompletion {
+    outcome: &'static str,
+    status: Option<u16>,
+    error_category: Option<&'static str>,
+    error_code: Option<&'static str>,
+    reason: Option<String>,
+    ttfb_ms: Option<u128>,
+}
+
+impl WebsocketCompletion {
+    fn success(ttfb_ms: Option<u128>) -> Self {
+        Self {
+            outcome: "success",
+            status: Some(StatusCode::SWITCHING_PROTOCOLS.as_u16()),
+            error_category: None,
+            error_code: None,
+            reason: None,
+            ttfb_ms,
+        }
+    }
+
+    fn internal_error(reason: String) -> Self {
+        Self {
+            outcome: "failed",
+            status: Some(StatusCode::INTERNAL_SERVER_ERROR.as_u16()),
+            error_category: Some(ErrorCategory::SystemError.as_str()),
+            error_code: Some(GatewayErrorCode::InternalError.as_str()),
+            reason: Some(reason),
+            ttfb_ms: None,
+        }
+    }
+
+    fn upstream_connect_failed(reason: String) -> Self {
+        Self {
+            outcome: "failed",
+            status: Some(StatusCode::BAD_GATEWAY.as_u16()),
+            error_category: Some(ErrorCategory::ProviderError.as_str()),
+            error_code: Some(GatewayErrorCode::UpstreamConnectFailed.as_str()),
+            reason: Some(reason),
+            ttfb_ms: None,
+        }
+    }
+}
 
 pub(in crate::gateway) async fn proxy_websocket_impl<R>(
     state: GatewayAppState<R>,
@@ -27,8 +101,15 @@ where
     R: tauri::Runtime + 'static,
     R::Handle: Unpin,
 {
+    let started = Instant::now();
+    let created_at_ms = now_unix_millis() as i64;
+    let created_at = (created_at_ms / 1000).max(0);
+    let method = req.method().to_string();
     let query = req.uri().query().map(str::to_string);
     let headers = req.headers().clone();
+    let session_id = extract_websocket_session_id(&headers);
+    let requested_model = infer_requested_model_info(&forwarded_path, query.as_deref(), None).model;
+    let observe_request = compute_observe_request(&cli_key, &forwarded_path, &headers, None);
     let forced_provider_id = headers
         .get("x-aio-provider-id")
         .and_then(|value| value.to_str().ok())
@@ -53,6 +134,8 @@ where
             return error_response(err.0, trace_id, err.1.as_str(), err.2, vec![]);
         }
     };
+    let provider_id = provider.id;
+    let provider_name = provider.name.clone();
 
     let base_url = match select_provider_base_url_for_request(&state, &provider, &cli_key, 1).await
     {
@@ -67,6 +150,7 @@ where
             );
         }
     };
+    let provider_base_url = base_url.clone();
 
     let target_url = match build_websocket_url(&base_url, &forwarded_path, query.as_deref()) {
         Ok(value) => value,
@@ -94,9 +178,38 @@ where
                 );
             }
         };
+    let observation = WebsocketObservation {
+        state,
+        trace_id,
+        cli_key,
+        method,
+        path: forwarded_path,
+        query,
+        session_id,
+        requested_model,
+        observe_request,
+        created_at_ms,
+        created_at,
+        started,
+        provider_id,
+        provider_name,
+        provider_base_url,
+    };
+    emit_websocket_request_start(&observation);
+
     ws.on_upgrade(move |socket| async move {
-        relay_websocket(socket, target_url, upstream_headers, trace_id).await;
+        relay_websocket(socket, target_url, upstream_headers, observation).await;
     })
+}
+
+fn extract_websocket_session_id(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("session_id")
+        .or_else(|| headers.get("x-session-id"))
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn resolve_websocket_provider<R: tauri::Runtime>(
@@ -230,17 +343,18 @@ async fn inject_websocket_provider_auth<R: tauri::Runtime>(
     Ok(())
 }
 
-async fn relay_websocket(
+async fn relay_websocket<R: tauri::Runtime>(
     client_socket: WebSocket,
     target_url: reqwest::Url,
     headers: HeaderMap,
-    trace_id: String,
+    observation: WebsocketObservation<R>,
 ) {
     let request = match build_tungstenite_request(target_url, headers) {
         Ok(request) => request,
         Err(err) => {
-            tracing::warn!(trace_id = %trace_id, "websocket request build failed: {err}");
-            close_client_socket(client_socket, err).await;
+            tracing::warn!(trace_id = %observation.trace_id, "websocket request build failed: {err}");
+            close_client_socket(client_socket, err.clone()).await;
+            record_websocket_request_end(observation, WebsocketCompletion::internal_error(err));
             return;
         }
     };
@@ -248,13 +362,178 @@ async fn relay_websocket(
     let (upstream_socket, _response) = match tokio_tungstenite::connect_async(request).await {
         Ok(value) => value,
         Err(err) => {
-            tracing::warn!(trace_id = %trace_id, "websocket upstream connect failed: {err}");
-            close_client_socket(client_socket, err.to_string()).await;
+            let reason = err.to_string();
+            tracing::warn!(trace_id = %observation.trace_id, "websocket upstream connect failed: {reason}");
+            close_client_socket(client_socket, reason.clone()).await;
+            record_websocket_request_end(
+                observation,
+                WebsocketCompletion::upstream_connect_failed(reason),
+            );
             return;
         }
     };
+    let ttfb_ms = observation.started.elapsed().as_millis();
 
-    relay_websocket_messages(client_socket, upstream_socket, trace_id).await;
+    relay_websocket_messages(client_socket, upstream_socket, observation.trace_id.clone()).await;
+    record_websocket_request_end(observation, WebsocketCompletion::success(Some(ttfb_ms)));
+}
+
+fn emit_websocket_request_start<R: tauri::Runtime>(observation: &WebsocketObservation<R>) {
+    if !observation.observe_request {
+        return;
+    }
+
+    emit_request_start_event(
+        &observation.state.app,
+        observation.trace_id.clone(),
+        observation.cli_key.clone(),
+        observation.session_id.clone(),
+        observation.method.clone(),
+        observation.path.clone(),
+        observation.query.clone(),
+        observation.requested_model.clone(),
+        observation.created_at,
+    );
+
+    let attempt = build_websocket_attempt(observation, "started", None, None, None, None, 0);
+    emit_websocket_attempt_event(observation, &attempt, 0);
+}
+
+fn record_websocket_request_end<R: tauri::Runtime>(
+    observation: WebsocketObservation<R>,
+    completion: WebsocketCompletion,
+) {
+    if !observation.observe_request {
+        return;
+    }
+
+    let duration_ms = observation.started.elapsed().as_millis();
+    let attempt = build_websocket_attempt(
+        &observation,
+        completion.outcome,
+        completion.status,
+        completion.error_category,
+        completion.error_code,
+        completion.reason,
+        duration_ms,
+    );
+    emit_websocket_attempt_event(&observation, &attempt, duration_ms);
+
+    let (log_args, attempts) = RequestLogEnqueueArgs::from_proxy_request_end_parts(
+        &observation.trace_id,
+        &observation.cli_key,
+        observation.session_id,
+        &observation.method,
+        &observation.path,
+        observation.query.as_deref(),
+        false,
+        None,
+        completion.status,
+        completion.error_code,
+        duration_ms,
+        completion.ttfb_ms,
+        &[attempt],
+        observation.requested_model,
+        observation.created_at_ms,
+        observation.created_at,
+        None,
+        None,
+    );
+
+    log_args.emit_gateway_request_event(
+        &observation.state.app,
+        completion.error_category,
+        completion.ttfb_ms,
+        attempts,
+        None,
+    );
+
+    spawn_enqueue_request_log_with_backpressure(
+        observation.state.app,
+        observation.state.db,
+        observation.state.log_tx,
+        log_args,
+    );
+}
+
+fn build_websocket_attempt<R: tauri::Runtime>(
+    observation: &WebsocketObservation<R>,
+    outcome: &'static str,
+    status: Option<u16>,
+    error_category: Option<&'static str>,
+    error_code: Option<&'static str>,
+    reason: Option<String>,
+    duration_ms: u128,
+) -> FailoverAttempt {
+    let reason_code = if outcome == "success" {
+        Some(dc::success_reason_code(1, 1))
+    } else {
+        error_category.and_then(|_| {
+            error_code.map(|_| {
+                if error_category == Some(ErrorCategory::ProviderError.as_str()) {
+                    ErrorCategory::ProviderError.reason_code()
+                } else {
+                    ErrorCategory::SystemError.reason_code()
+                }
+            })
+        })
+    };
+
+    FailoverAttempt {
+        provider_id: observation.provider_id,
+        provider_name: observation.provider_name.clone(),
+        base_url: observation.provider_base_url.clone(),
+        outcome: outcome.to_string(),
+        status,
+        provider_index: Some(1),
+        retry_index: Some(1),
+        session_reuse: Some(false),
+        error_category,
+        error_code,
+        decision: None,
+        reason,
+        selection_method: dc::selection_method(1, 1, Some(false)),
+        reason_code,
+        attempt_started_ms: Some(0),
+        attempt_duration_ms: Some(duration_ms),
+        circuit_state_before: None,
+        circuit_state_after: None,
+        circuit_failure_count: None,
+        circuit_failure_threshold: None,
+    }
+}
+
+fn emit_websocket_attempt_event<R: tauri::Runtime>(
+    observation: &WebsocketObservation<R>,
+    attempt: &FailoverAttempt,
+    duration_ms: u128,
+) {
+    emit_attempt_event(
+        &observation.state.app,
+        GatewayAttemptEvent {
+            trace_id: observation.trace_id.clone(),
+            cli_key: observation.cli_key.clone(),
+            session_id: observation.session_id.clone(),
+            method: observation.method.clone(),
+            path: observation.path.clone(),
+            query: observation.query.clone(),
+            requested_model: observation.requested_model.clone(),
+            attempt_index: 1,
+            provider_id: attempt.provider_id,
+            session_reuse: attempt.session_reuse,
+            provider_name: attempt.provider_name.clone(),
+            base_url: attempt.base_url.clone(),
+            outcome: attempt.outcome.clone(),
+            status: attempt.status,
+            attempt_started_ms: 0,
+            attempt_duration_ms: duration_ms,
+            circuit_state_before: None,
+            circuit_state_after: None,
+            circuit_failure_count: None,
+            circuit_failure_threshold: None,
+            claude_model_mapping: None,
+        },
+    );
 }
 
 fn build_tungstenite_request(
@@ -389,6 +668,18 @@ mod tests {
         .expect("websocket url");
 
         assert_eq!(url.as_str(), "wss://api.example.com/v1/realtime?model=x");
+    }
+
+    #[test]
+    fn extract_websocket_session_id_prefers_primary_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("session_id", HeaderValue::from_static(" sess-primary "));
+        headers.insert("x-session-id", HeaderValue::from_static("sess-fallback"));
+
+        assert_eq!(
+            extract_websocket_session_id(&headers).as_deref(),
+            Some("sess-primary")
+        );
     }
 
     #[test]

--- a/src-tauri/src/gateway/proxy/websocket.rs
+++ b/src-tauri/src/gateway/proxy/websocket.rs
@@ -1,0 +1,468 @@
+//! Usage: WebSocket upgrade proxy path for gateway requests.
+
+use super::cli_proxy_guard::cli_proxy_enabled_cached;
+use super::errors::error_response;
+use super::failover::select_provider_base_url_for_request;
+use super::{mark_internal_forwarded_request, GatewayErrorCode};
+use crate::gateway::runtime::GatewayAppState;
+use crate::gateway::util::{build_target_url, clear_all_auth_headers, ensure_cli_required_headers};
+use axum::extract::ws::{Message as AxumWsMessage, WebSocket, WebSocketUpgrade};
+use axum::http::{header, HeaderMap, Request, StatusCode};
+use axum::response::Response;
+use futures_util::{SinkExt, StreamExt};
+use std::borrow::Cow;
+use tokio_tungstenite::tungstenite::{self, client::IntoClientRequest};
+
+type UpstreamWsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+pub(in crate::gateway) async fn proxy_websocket_impl<R>(
+    state: GatewayAppState<R>,
+    cli_key: String,
+    forwarded_path: String,
+    ws: WebSocketUpgrade,
+    req: Request<axum::body::Body>,
+) -> Response
+where
+    R: tauri::Runtime + 'static,
+    R::Handle: Unpin,
+{
+    let query = req.uri().query().map(str::to_string);
+    let headers = req.headers().clone();
+    let forced_provider_id = headers
+        .get("x-aio-provider-id")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<i64>().ok())
+        .filter(|value| *value > 0);
+    let trace_id = crate::gateway::util::new_trace_id();
+
+    let cli_proxy = cli_proxy_enabled_cached(&state.app, &cli_key);
+    if !cli_proxy.enabled {
+        return error_response(
+            StatusCode::FORBIDDEN,
+            trace_id,
+            GatewayErrorCode::CliProxyDisabled.as_str(),
+            format!("CLI proxy is disabled for cli_key={cli_key}"),
+            vec![],
+        );
+    }
+
+    let provider = match resolve_websocket_provider(&state, &cli_key, forced_provider_id) {
+        Ok(provider) => provider,
+        Err(err) => {
+            return error_response(err.0, trace_id, err.1.as_str(), err.2, vec![]);
+        }
+    };
+
+    let base_url = match select_provider_base_url_for_request(&state, &provider, &cli_key, 1).await
+    {
+        Ok(value) => value,
+        Err(err) => {
+            return error_response(
+                StatusCode::BAD_GATEWAY,
+                trace_id,
+                GatewayErrorCode::InvalidBaseUrl.as_str(),
+                err,
+                vec![],
+            );
+        }
+    };
+
+    let target_url = match build_websocket_url(&base_url, &forwarded_path, query.as_deref()) {
+        Ok(value) => value,
+        Err(err) => {
+            return error_response(
+                StatusCode::BAD_GATEWAY,
+                trace_id,
+                GatewayErrorCode::InvalidBaseUrl.as_str(),
+                err,
+                vec![],
+            );
+        }
+    };
+
+    let upstream_headers =
+        match build_upstream_websocket_headers(&state, &cli_key, &headers, &provider).await {
+            Ok(headers) => headers,
+            Err(err) => {
+                return error_response(
+                    StatusCode::BAD_GATEWAY,
+                    trace_id,
+                    GatewayErrorCode::InternalError.as_str(),
+                    err,
+                    vec![],
+                );
+            }
+        };
+    ws.on_upgrade(move |socket| async move {
+        relay_websocket(socket, target_url, upstream_headers, trace_id).await;
+    })
+}
+
+fn resolve_websocket_provider<R: tauri::Runtime>(
+    state: &GatewayAppState<R>,
+    cli_key: &str,
+    forced_provider_id: Option<i64>,
+) -> Result<crate::providers::ProviderForGateway, (StatusCode, GatewayErrorCode, String)> {
+    let mut providers =
+        crate::providers::list_enabled_for_gateway_using_active_mode(&state.db, cli_key)
+            .map(|selection| selection.providers)
+            .map_err(|err| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    GatewayErrorCode::InvalidCliKey,
+                    err.to_string(),
+                )
+            })?;
+    if providers.is_empty() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            GatewayErrorCode::NoEnabledProvider,
+            format!("no enabled provider for cli_key={cli_key}"),
+        ));
+    }
+    if let Some(provider_id) = forced_provider_id {
+        return providers
+            .into_iter()
+            .find(|provider| provider.id == provider_id)
+            .ok_or_else(|| {
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    GatewayErrorCode::NoEnabledProvider,
+                    format!("no enabled provider for cli_key={cli_key}, provider_id={provider_id}"),
+                )
+            });
+    }
+    Ok(providers.remove(0))
+}
+
+fn build_websocket_url(
+    base_url: &str,
+    forwarded_path: &str,
+    query: Option<&str>,
+) -> Result<reqwest::Url, String> {
+    let mut url = build_target_url(base_url, forwarded_path, query)?;
+    let scheme = match url.scheme() {
+        "http" => "ws",
+        "https" => "wss",
+        "ws" => "ws",
+        "wss" => "wss",
+        other => return Err(format!("unsupported websocket base_url scheme: {other}")),
+    };
+    url.set_scheme(scheme)
+        .map_err(|_| format!("failed to set websocket URL scheme: {scheme}"))?;
+    Ok(url)
+}
+
+async fn build_upstream_websocket_headers<R: tauri::Runtime>(
+    state: &GatewayAppState<R>,
+    cli_key: &str,
+    inbound: &HeaderMap,
+    provider: &crate::providers::ProviderForGateway,
+) -> Result<HeaderMap, String> {
+    let mut headers = build_base_upstream_websocket_headers(cli_key, inbound);
+    inject_websocket_provider_auth(state, cli_key, provider, &mut headers).await?;
+    Ok(headers)
+}
+
+fn build_base_upstream_websocket_headers(cli_key: &str, inbound: &HeaderMap) -> HeaderMap {
+    let mut headers = inbound.clone();
+    clear_hop_and_websocket_handshake_headers(&mut headers);
+    headers.remove(header::HOST);
+    headers.remove(header::CONTENT_LENGTH);
+    clear_all_auth_headers(&mut headers);
+    ensure_cli_required_headers(cli_key, &mut headers);
+    if cli_key == "claude" {
+        mark_internal_forwarded_request(&mut headers);
+    }
+    headers
+}
+
+fn clear_hop_and_websocket_handshake_headers(headers: &mut HeaderMap) {
+    headers.remove(header::CONNECTION);
+    headers.remove(header::UPGRADE);
+    headers.remove(header::SEC_WEBSOCKET_ACCEPT);
+    headers.remove(header::SEC_WEBSOCKET_KEY);
+    headers.remove(header::SEC_WEBSOCKET_VERSION);
+    headers.remove("sec-websocket-extensions");
+    headers.remove("proxy-connection");
+    headers.remove(header::PROXY_AUTHENTICATE);
+    headers.remove(header::PROXY_AUTHORIZATION);
+    headers.remove(header::TE);
+    headers.remove(header::TRAILER);
+    headers.remove(header::TRANSFER_ENCODING);
+}
+
+async fn inject_websocket_provider_auth<R: tauri::Runtime>(
+    state: &GatewayAppState<R>,
+    cli_key: &str,
+    provider: &crate::providers::ProviderForGateway,
+    headers: &mut HeaderMap,
+) -> Result<(), String> {
+    if provider.auth_mode == "oauth" {
+        let details = crate::providers::get_oauth_details(&state.db, provider.id)
+            .map_err(|err| err.to_string())?;
+        if details.cli_key != cli_key {
+            return Err(format!(
+                "SEC_INVALID_STATE: oauth details cli_key mismatch for provider_id={} (expected={cli_key}, actual={})",
+                provider.id, details.cli_key
+            ));
+        }
+
+        let adapter = crate::gateway::oauth::registry::resolve_oauth_adapter(
+            cli_key,
+            provider.id,
+            Some(details.oauth_provider_type.as_str()),
+        )?;
+        let token = details.oauth_access_token.trim();
+        if token.is_empty() {
+            return Err("SEC_INVALID_INPUT: oauth access_token is empty".to_string());
+        }
+        adapter.inject_upstream_headers(headers, token)?;
+        return Ok(());
+    }
+
+    if provider.api_key_plaintext.trim().is_empty() {
+        return Err("SEC_INVALID_INPUT: provider api_key is empty".to_string());
+    }
+
+    crate::gateway::util::inject_provider_auth(cli_key, &provider.api_key_plaintext, headers);
+    Ok(())
+}
+
+async fn relay_websocket(
+    client_socket: WebSocket,
+    target_url: reqwest::Url,
+    headers: HeaderMap,
+    trace_id: String,
+) {
+    let request = match build_tungstenite_request(target_url, headers) {
+        Ok(request) => request,
+        Err(err) => {
+            tracing::warn!(trace_id = %trace_id, "websocket request build failed: {err}");
+            close_client_socket(client_socket, err).await;
+            return;
+        }
+    };
+
+    let (upstream_socket, _response) = match tokio_tungstenite::connect_async(request).await {
+        Ok(value) => value,
+        Err(err) => {
+            tracing::warn!(trace_id = %trace_id, "websocket upstream connect failed: {err}");
+            close_client_socket(client_socket, err.to_string()).await;
+            return;
+        }
+    };
+
+    relay_websocket_messages(client_socket, upstream_socket, trace_id).await;
+}
+
+fn build_tungstenite_request(
+    target_url: reqwest::Url,
+    headers: HeaderMap,
+) -> Result<tungstenite::handshake::client::Request, String> {
+    let mut request = target_url
+        .as_str()
+        .into_client_request()
+        .map_err(|err| err.to_string())?;
+
+    for (name, value) in headers.iter() {
+        request.headers_mut().insert(name.clone(), value.clone());
+    }
+
+    Ok(request)
+}
+
+async fn close_client_socket(mut socket: WebSocket, reason: String) {
+    let _ = socket
+        .send(AxumWsMessage::Close(Some(axum::extract::ws::CloseFrame {
+            code: axum::extract::ws::close_code::ERROR,
+            reason: Cow::Owned(reason),
+        })))
+        .await;
+}
+
+async fn relay_websocket_messages(
+    client_socket: WebSocket,
+    upstream_socket: UpstreamWsStream,
+    trace_id: String,
+) {
+    let (mut client_tx, mut client_rx) = client_socket.split();
+    let (mut upstream_tx, mut upstream_rx) = upstream_socket.split();
+
+    loop {
+        tokio::select! {
+            msg = client_rx.next() => {
+                let Some(msg) = msg else {
+                    let _ = upstream_tx.close().await;
+                    break;
+                };
+                match msg {
+                    Ok(message) => {
+                        let is_close = matches!(message, AxumWsMessage::Close(_));
+                        if let Err(err) = upstream_tx.send(axum_to_tungstenite(message)).await {
+                            tracing::debug!(trace_id = %trace_id, "websocket client-to-upstream send failed: {err}");
+                            break;
+                        }
+                        if is_close {
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        tracing::debug!(trace_id = %trace_id, "websocket client receive failed: {err}");
+                        break;
+                    }
+                }
+            }
+            msg = upstream_rx.next() => {
+                let Some(msg) = msg else {
+                    let _ = client_tx.close().await;
+                    break;
+                };
+                match msg {
+                    Ok(message) => {
+                        let Some(message) = tungstenite_to_axum(message) else {
+                            continue;
+                        };
+                        let is_close = matches!(message, AxumWsMessage::Close(_));
+                        if let Err(err) = client_tx.send(message).await {
+                            tracing::debug!(trace_id = %trace_id, "websocket upstream-to-client send failed: {err}");
+                            break;
+                        }
+                        if is_close {
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        tracing::debug!(trace_id = %trace_id, "websocket upstream receive failed: {err}");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn axum_to_tungstenite(message: AxumWsMessage) -> tungstenite::Message {
+    match message {
+        AxumWsMessage::Text(value) => tungstenite::Message::Text(value),
+        AxumWsMessage::Binary(value) => tungstenite::Message::Binary(value),
+        AxumWsMessage::Ping(value) => tungstenite::Message::Ping(value),
+        AxumWsMessage::Pong(value) => tungstenite::Message::Pong(value),
+        AxumWsMessage::Close(value) => {
+            tungstenite::Message::Close(value.map(|frame| tungstenite::protocol::CloseFrame {
+                code: frame.code.into(),
+                reason: frame.reason,
+            }))
+        }
+    }
+}
+
+fn tungstenite_to_axum(message: tungstenite::Message) -> Option<AxumWsMessage> {
+    match message {
+        tungstenite::Message::Text(value) => Some(AxumWsMessage::Text(value)),
+        tungstenite::Message::Binary(value) => Some(AxumWsMessage::Binary(value)),
+        tungstenite::Message::Ping(value) => Some(AxumWsMessage::Ping(value)),
+        tungstenite::Message::Pong(value) => Some(AxumWsMessage::Pong(value)),
+        tungstenite::Message::Close(value) => Some(AxumWsMessage::Close(value.map(|frame| {
+            axum::extract::ws::CloseFrame {
+                code: frame.code.into(),
+                reason: frame.reason,
+            }
+        }))),
+        tungstenite::Message::Frame(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn build_websocket_url_rewrites_http_scheme() {
+        let url = build_websocket_url(
+            "https://api.example.com/v1",
+            "/v1/realtime",
+            Some("model=x"),
+        )
+        .expect("websocket url");
+
+        assert_eq!(url.as_str(), "wss://api.example.com/v1/realtime?model=x");
+    }
+
+    #[test]
+    fn upstream_headers_remove_client_handshake_and_keep_protocol() {
+        let mut inbound = HeaderMap::new();
+        inbound.insert(header::CONNECTION, HeaderValue::from_static("Upgrade"));
+        inbound.insert(header::UPGRADE, HeaderValue::from_static("websocket"));
+        inbound.insert(
+            header::SEC_WEBSOCKET_PROTOCOL,
+            HeaderValue::from_static("realtime"),
+        );
+        inbound.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer old"),
+        );
+
+        let provider = crate::providers::ProviderForGateway {
+            id: 1,
+            name: "p1".to_string(),
+            base_urls: vec!["https://api.example.com".to_string()],
+            base_url_mode: crate::providers::ProviderBaseUrlMode::Order,
+            api_key_plaintext: "sk-test".to_string(),
+            claude_models: crate::providers::ClaudeModels::default(),
+            limit_5h_usd: None,
+            limit_daily_usd: None,
+            daily_reset_mode: crate::providers::DailyResetMode::Fixed,
+            daily_reset_time: "00:00:00".to_string(),
+            limit_weekly_usd: None,
+            limit_monthly_usd: None,
+            limit_total_usd: None,
+            auth_mode: "api_key".to_string(),
+            oauth_provider_type: None,
+            source_provider_id: None,
+            bridge_type: None,
+            stream_idle_timeout_seconds: None,
+        };
+
+        let mut headers = build_base_upstream_websocket_headers("codex", &inbound);
+        crate::gateway::util::inject_provider_auth(
+            "codex",
+            &provider.api_key_plaintext,
+            &mut headers,
+        );
+
+        assert!(!headers.contains_key(header::CONNECTION));
+        assert!(!headers.contains_key(header::UPGRADE));
+        assert!(!headers.contains_key(header::SEC_WEBSOCKET_KEY));
+        assert_eq!(
+            headers
+                .get(header::SEC_WEBSOCKET_PROTOCOL)
+                .and_then(|v| v.to_str().ok()),
+            Some("realtime")
+        );
+        assert!(headers
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .starts_with("Bearer sk-test"));
+    }
+
+    #[test]
+    fn message_conversion_preserves_close_frame() {
+        let input = AxumWsMessage::Close(Some(axum::extract::ws::CloseFrame {
+            code: axum::extract::ws::close_code::NORMAL,
+            reason: Cow::Borrowed("done"),
+        }));
+
+        let output = tungstenite_to_axum(axum_to_tungstenite(input)).expect("converted message");
+
+        assert!(matches!(
+            output,
+            AxumWsMessage::Close(Some(frame))
+                if frame.code == axum::extract::ws::close_code::NORMAL
+                    && frame.reason == "done"
+        ));
+    }
+}

--- a/src-tauri/src/gateway/proxy/websocket.rs
+++ b/src-tauri/src/gateway/proxy/websocket.rs
@@ -3,30 +3,49 @@
 use super::cli_proxy_guard::cli_proxy_enabled_cached;
 use super::errors::error_response;
 use super::failover::select_provider_base_url_for_request;
+use super::logging::enqueue_request_log_placeholder;
+use super::provider_router;
 use super::{
     compute_observe_request, mark_internal_forwarded_request,
     spawn_enqueue_request_log_with_backpressure, ErrorCategory, GatewayErrorCode,
     RequestLogEnqueueArgs,
 };
 use crate::gateway::events::{
-    decision_chain as dc, emit_attempt_event, emit_request_start_event, FailoverAttempt,
-    GatewayAttemptEvent,
+    decision_chain as dc, emit_attempt_event, emit_gateway_debug_log_lazy,
+    emit_request_start_event, FailoverAttempt, GatewayAttemptEvent,
 };
 use crate::gateway::runtime::GatewayAppState;
 use crate::gateway::util::{
     build_target_url, clear_all_auth_headers, ensure_cli_required_headers,
-    infer_requested_model_info, now_unix_millis,
+    infer_requested_model_info, now_unix_millis, now_unix_seconds, redacted_headers_for_debug,
 };
 use axum::extract::ws::{Message as AxumWsMessage, WebSocket, WebSocketUpgrade};
 use axum::http::{header, HeaderMap, Request, StatusCode};
 use axum::response::Response;
 use futures_util::{SinkExt, StreamExt};
-use std::borrow::Cow;
-use std::time::Instant;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 use tokio_tungstenite::tungstenite::{self, client::IntoClientRequest};
 
 type UpstreamWsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+const WEBSOCKET_TRACE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+const WEBSOCKET_UPSTREAM_DRAIN_TIMEOUT: Duration = Duration::from_millis(1200);
+const WEBSOCKET_SPECIAL_SETTINGS_JSON: &str = r#"[{"type":"websocket_proxy"}]"#;
+const WEBSOCKET_RECONNECT_WINDOW_MS: i64 = 15 * 60 * 1000;
+const WEBSOCKET_UNSUPPORTED_CACHE_SECS: i64 = 10 * 60;
+
+static WEBSOCKET_CONNECTION_REGISTRY: OnceLock<Mutex<HashMap<String, WebsocketConnectionStats>>> =
+    OnceLock::new();
+static WEBSOCKET_UNSUPPORTED_CACHE: OnceLock<Mutex<HashMap<String, i64>>> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy)]
+struct WebsocketConnectionStats {
+    count: usize,
+    last_seen_ms: i64,
+}
 
 struct WebsocketObservation<R: tauri::Runtime = tauri::Wry> {
     state: GatewayAppState<R>,
@@ -46,6 +65,13 @@ struct WebsocketObservation<R: tauri::Runtime = tauri::Wry> {
     provider_base_url: String,
 }
 
+struct PreparedWebsocketUpstream {
+    provider_id: i64,
+    provider_name: String,
+    provider_base_url: String,
+    upstream_socket: UpstreamWsStream,
+}
+
 struct WebsocketCompletion {
     outcome: &'static str,
     status: Option<u16>,
@@ -53,6 +79,37 @@ struct WebsocketCompletion {
     error_code: Option<&'static str>,
     reason: Option<String>,
     ttfb_ms: Option<u128>,
+}
+
+#[derive(Default)]
+struct WebsocketRelayMetadata {
+    requested_model: Option<String>,
+    usage: Option<crate::usage::UsageExtract>,
+    first_token_ms: Option<u128>,
+    completed_turns: usize,
+}
+
+#[derive(Default)]
+struct WebsocketRelayState {
+    metadata: WebsocketRelayMetadata,
+    turn_timings: HashMap<String, WebsocketTurnTiming>,
+    active_response_id: Option<String>,
+}
+
+struct WebsocketTurnTiming {
+    started_ms: u128,
+    first_token_ms: Option<u128>,
+}
+
+struct WebsocketTurnCompletion {
+    response_id: Option<String>,
+    terminal_event: String,
+    turn_index: usize,
+    started_ms: u128,
+    duration_ms: u128,
+    ttfb_ms: Option<u128>,
+    requested_model: Option<String>,
+    usage: Option<crate::usage::UsageExtract>,
 }
 
 impl WebsocketCompletion {
@@ -64,28 +121,6 @@ impl WebsocketCompletion {
             error_code: None,
             reason: None,
             ttfb_ms,
-        }
-    }
-
-    fn internal_error(reason: String) -> Self {
-        Self {
-            outcome: "failed",
-            status: Some(StatusCode::INTERNAL_SERVER_ERROR.as_u16()),
-            error_category: Some(ErrorCategory::SystemError.as_str()),
-            error_code: Some(GatewayErrorCode::InternalError.as_str()),
-            reason: Some(reason),
-            ttfb_ms: None,
-        }
-    }
-
-    fn upstream_connect_failed(reason: String) -> Self {
-        Self {
-            outcome: "failed",
-            status: Some(StatusCode::BAD_GATEWAY.as_u16()),
-            error_category: Some(ErrorCategory::ProviderError.as_str()),
-            error_code: Some(GatewayErrorCode::UpstreamConnectFailed.as_str()),
-            reason: Some(reason),
-            ttfb_ms: None,
         }
     }
 }
@@ -117,6 +152,18 @@ where
         .filter(|value| *value > 0);
     let trace_id = crate::gateway::util::new_trace_id();
 
+    emit_gateway_debug_log_lazy(&state.app, || {
+        format!(
+            "[WS_REQ] trace_id={} cli_key={} method={} path={} model={}\n  headers={}",
+            trace_id,
+            cli_key,
+            method,
+            forwarded_path,
+            requested_model.as_deref().unwrap_or("-"),
+            redacted_headers_for_debug(&headers),
+        )
+    });
+
     let cli_proxy = cli_proxy_enabled_cached(&state.app, &cli_key);
     if !cli_proxy.enabled {
         return error_response(
@@ -128,56 +175,22 @@ where
         );
     }
 
-    let provider = match resolve_websocket_provider(&state, &cli_key, forced_provider_id) {
-        Ok(provider) => provider,
+    let prepared = match prepare_websocket_upstream(
+        &state,
+        &cli_key,
+        forced_provider_id,
+        &forwarded_path,
+        query.as_deref(),
+        &headers,
+        &trace_id,
+    )
+    .await
+    {
+        Ok(prepared) => prepared,
         Err(err) => {
             return error_response(err.0, trace_id, err.1.as_str(), err.2, vec![]);
         }
     };
-    let provider_id = provider.id;
-    let provider_name = provider.name.clone();
-
-    let base_url = match select_provider_base_url_for_request(&state, &provider, &cli_key, 1).await
-    {
-        Ok(value) => value,
-        Err(err) => {
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                trace_id,
-                GatewayErrorCode::InvalidBaseUrl.as_str(),
-                err,
-                vec![],
-            );
-        }
-    };
-    let provider_base_url = base_url.clone();
-
-    let target_url = match build_websocket_url(&base_url, &forwarded_path, query.as_deref()) {
-        Ok(value) => value,
-        Err(err) => {
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                trace_id,
-                GatewayErrorCode::InvalidBaseUrl.as_str(),
-                err,
-                vec![],
-            );
-        }
-    };
-
-    let upstream_headers =
-        match build_upstream_websocket_headers(&state, &cli_key, &headers, &provider).await {
-            Ok(headers) => headers,
-            Err(err) => {
-                return error_response(
-                    StatusCode::BAD_GATEWAY,
-                    trace_id,
-                    GatewayErrorCode::InternalError.as_str(),
-                    err,
-                    vec![],
-                );
-            }
-        };
     let observation = WebsocketObservation {
         state,
         trace_id,
@@ -191,14 +204,16 @@ where
         created_at_ms,
         created_at,
         started,
-        provider_id,
-        provider_name,
-        provider_base_url,
+        provider_id: prepared.provider_id,
+        provider_name: prepared.provider_name,
+        provider_base_url: prepared.provider_base_url,
     };
+    log_websocket_connection_start(&observation);
     emit_websocket_request_start(&observation);
+    enqueue_websocket_request_placeholder(&observation).await;
 
     ws.on_upgrade(move |socket| async move {
-        relay_websocket(socket, target_url, upstream_headers, observation).await;
+        relay_websocket(socket, prepared.upstream_socket, observation).await;
     })
 }
 
@@ -247,6 +262,249 @@ fn resolve_websocket_provider<R: tauri::Runtime>(
             });
     }
     Ok(providers.remove(0))
+}
+
+async fn prepare_websocket_upstream<R: tauri::Runtime>(
+    state: &GatewayAppState<R>,
+    cli_key: &str,
+    forced_provider_id: Option<i64>,
+    forwarded_path: &str,
+    query: Option<&str>,
+    inbound_headers: &HeaderMap,
+    trace_id: &str,
+) -> Result<PreparedWebsocketUpstream, (StatusCode, GatewayErrorCode, String)> {
+    let providers = match forced_provider_id {
+        Some(_) => vec![resolve_websocket_provider(
+            state,
+            cli_key,
+            forced_provider_id,
+        )?],
+        None => crate::providers::list_enabled_for_gateway_using_active_mode(&state.db, cli_key)
+            .map(|selection| selection.providers)
+            .map_err(|err| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    GatewayErrorCode::InvalidCliKey,
+                    err.to_string(),
+                )
+            })?,
+    };
+    if providers.is_empty() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            GatewayErrorCode::NoEnabledProvider,
+            format!("no enabled provider for cli_key={cli_key}"),
+        ));
+    }
+
+    let mut earliest_available_unix = None;
+    let mut skipped_open = 0usize;
+    let mut skipped_cooldown = 0usize;
+    let mut skipped_websocket_disabled = 0usize;
+    let mut attempted_websocket_provider = false;
+    let mut last_error = None;
+
+    for provider in providers {
+        if !provider.supports_websockets {
+            skipped_websocket_disabled += 1;
+            let reason = format!(
+                "websocket disabled for provider={} (id={})",
+                provider.name, provider.id
+            );
+            tracing::info!(
+                target: "gateway_debug",
+                trace_id = %trace_id,
+                provider_id = provider.id,
+                provider = %provider.name,
+                "[WS_PROVIDER_SKIP] provider websocket disabled"
+            );
+            emit_gateway_debug_log_lazy(&state.app, || {
+                format!(
+                    "[WS_PROVIDER_SKIP] trace_id={} provider={} (id={}) reason=websocket_disabled",
+                    trace_id, provider.name, provider.id,
+                )
+            });
+            last_error = Some((GatewayErrorCode::NoEnabledProvider, reason));
+            continue;
+        }
+        attempted_websocket_provider = true;
+
+        let base_url =
+            match select_provider_base_url_for_request(state, &provider, cli_key, 1).await {
+                Ok(value) => value,
+                Err(err) => {
+                    last_error = Some((GatewayErrorCode::InvalidBaseUrl, err));
+                    continue;
+                }
+            };
+        let now_unix = now_unix_seconds() as i64;
+        if websocket_unsupported_cache_hit(provider.id, &base_url, now_unix) {
+            let reason = format!(
+                "websocket unsupported by upstream cache provider={} (id={}) base_url={}",
+                provider.name, provider.id, base_url
+            );
+            tracing::info!(
+                target: "gateway_debug",
+                trace_id = %trace_id,
+                provider_id = provider.id,
+                provider = %provider.name,
+                base_url = %base_url,
+                "[WS_UNSUPPORTED] cached websocket unsupported provider skipped"
+            );
+            last_error = Some((GatewayErrorCode::UpstreamConnectFailed, reason));
+            continue;
+        }
+        let gate = provider_router::gate_provider(provider_router::GateProviderArgs {
+            app: Some(&state.app),
+            circuit: state.circuit.as_ref(),
+            trace_id,
+            cli_key,
+            provider_id: provider.id,
+            provider_name: provider.name.as_str(),
+            provider_base_url_display: base_url.as_str(),
+            now_unix,
+            earliest_available_unix: &mut earliest_available_unix,
+            skipped_open: &mut skipped_open,
+            skipped_cooldown: &mut skipped_cooldown,
+        });
+        if gate.is_none() {
+            continue;
+        }
+
+        let target_url = match build_websocket_url(&base_url, forwarded_path, query) {
+            Ok(value) => value,
+            Err(err) => {
+                last_error = Some((GatewayErrorCode::InvalidBaseUrl, err));
+                continue;
+            }
+        };
+        let upstream_headers = match build_upstream_websocket_headers(
+            state,
+            cli_key,
+            inbound_headers,
+            &provider,
+        )
+        .await
+        {
+            Ok(headers) => headers,
+            Err(err) => {
+                last_error = Some((GatewayErrorCode::InternalError, err));
+                continue;
+            }
+        };
+        let request = match build_tungstenite_request(target_url, upstream_headers) {
+            Ok(request) => request,
+            Err(err) => {
+                last_error = Some((GatewayErrorCode::InternalError, err));
+                continue;
+            }
+        };
+
+        match tokio_tungstenite::connect_async(request).await {
+            Ok((upstream_socket, response)) => {
+                emit_gateway_debug_log_lazy(&state.app, || {
+                    format!(
+                        "[WS_UPSTREAM_RESP] trace_id={} status={} provider={} (id={})\n  headers={}",
+                        trace_id,
+                        response.status().as_u16(),
+                        provider.name,
+                        provider.id,
+                        redacted_headers_for_debug(response.headers()),
+                    )
+                });
+                provider_router::record_success_and_emit_transition(
+                    provider_router::RecordCircuitArgs::from_state(
+                        state,
+                        trace_id,
+                        cli_key,
+                        provider.id,
+                        provider.name.as_str(),
+                        base_url.as_str(),
+                        now_unix_seconds() as i64,
+                    ),
+                );
+                return Ok(PreparedWebsocketUpstream {
+                    provider_id: provider.id,
+                    provider_name: provider.name,
+                    provider_base_url: base_url,
+                    upstream_socket,
+                });
+            }
+            Err(err) => {
+                let reason = err.to_string();
+                if let Some(status) = websocket_unsupported_status_from_error(&err) {
+                    remember_websocket_unsupported(provider.id, &base_url, now_unix);
+                    tracing::info!(
+                        target: "gateway_debug",
+                        trace_id = %trace_id,
+                        provider_id = provider.id,
+                        provider = %provider.name,
+                        base_url = %base_url,
+                        status,
+                        "[WS_UNSUPPORTED] upstream does not support websocket"
+                    );
+                }
+                emit_gateway_debug_log_lazy(&state.app, || {
+                    format!(
+                        "[WS_UPSTREAM_FAIL] trace_id={} provider={} (id={}) reason={}",
+                        trace_id, provider.name, provider.id, reason,
+                    )
+                });
+                tracing::warn!(
+                    trace_id = %trace_id,
+                    provider_id = provider.id,
+                    provider_name = %provider.name,
+                    "websocket upstream connect failed without circuit failure, trying next provider: {reason}"
+                );
+                last_error = Some((GatewayErrorCode::UpstreamConnectFailed, reason));
+            }
+        }
+    }
+
+    let no_websocket_provider_enabled =
+        skipped_websocket_disabled > 0 && !attempted_websocket_provider;
+    let message = if skipped_open > 0 || skipped_cooldown > 0 {
+        match earliest_available_unix {
+            Some(until) => format!(
+                "no websocket provider available for cli_key={cli_key}; skipped_open={skipped_open}, skipped_cooldown={skipped_cooldown}, earliest_available_unix={until}"
+            ),
+            None => format!(
+                "no websocket provider available for cli_key={cli_key}; skipped_open={skipped_open}, skipped_cooldown={skipped_cooldown}"
+            ),
+        }
+    } else if no_websocket_provider_enabled {
+        match forced_provider_id {
+            Some(provider_id) => format!(
+                "no websocket-enabled provider for cli_key={cli_key}, provider_id={provider_id}; skipped_websocket_disabled={skipped_websocket_disabled}"
+            ),
+            None => format!(
+                "no websocket-enabled provider for cli_key={cli_key}; skipped_websocket_disabled={skipped_websocket_disabled}"
+            ),
+        }
+    } else {
+        last_error
+            .as_ref()
+            .map(|(_, err)| err.clone())
+            .unwrap_or_else(|| format!("no websocket provider available for cli_key={cli_key}"))
+    };
+    let code = last_error
+        .map(|(code, _)| code)
+        .unwrap_or(GatewayErrorCode::NoEnabledProvider);
+    let status = if no_websocket_provider_enabled {
+        StatusCode::UPGRADE_REQUIRED
+    } else {
+        StatusCode::BAD_GATEWAY
+    };
+    emit_gateway_debug_log_lazy(&state.app, || {
+        format!(
+            "[WS_RESP] trace_id={} status={} error_code={} message={}",
+            trace_id,
+            status.as_u16(),
+            code.as_str(),
+            message,
+        )
+    });
+    Err((status, code, message))
 }
 
 fn build_websocket_url(
@@ -345,37 +603,17 @@ async fn inject_websocket_provider_auth<R: tauri::Runtime>(
 
 async fn relay_websocket<R: tauri::Runtime>(
     client_socket: WebSocket,
-    target_url: reqwest::Url,
-    headers: HeaderMap,
+    upstream_socket: UpstreamWsStream,
     observation: WebsocketObservation<R>,
 ) {
-    let request = match build_tungstenite_request(target_url, headers) {
-        Ok(request) => request,
-        Err(err) => {
-            tracing::warn!(trace_id = %observation.trace_id, "websocket request build failed: {err}");
-            close_client_socket(client_socket, err.clone()).await;
-            record_websocket_request_end(observation, WebsocketCompletion::internal_error(err));
-            return;
-        }
-    };
-
-    let (upstream_socket, _response) = match tokio_tungstenite::connect_async(request).await {
-        Ok(value) => value,
-        Err(err) => {
-            let reason = err.to_string();
-            tracing::warn!(trace_id = %observation.trace_id, "websocket upstream connect failed: {reason}");
-            close_client_socket(client_socket, reason.clone()).await;
-            record_websocket_request_end(
-                observation,
-                WebsocketCompletion::upstream_connect_failed(reason),
-            );
-            return;
-        }
-    };
-    let ttfb_ms = observation.started.elapsed().as_millis();
-
-    relay_websocket_messages(client_socket, upstream_socket, observation.trace_id.clone()).await;
-    record_websocket_request_end(observation, WebsocketCompletion::success(Some(ttfb_ms)));
+    let relay_metadata =
+        relay_websocket_messages(client_socket, upstream_socket, &observation).await;
+    let ttfb_ms = relay_metadata.first_token_ms;
+    record_websocket_request_end(
+        observation,
+        WebsocketCompletion::success(ttfb_ms),
+        relay_metadata,
+    );
 }
 
 fn emit_websocket_request_start<R: tauri::Runtime>(observation: &WebsocketObservation<R>) {
@@ -399,15 +637,187 @@ fn emit_websocket_request_start<R: tauri::Runtime>(observation: &WebsocketObserv
     emit_websocket_attempt_event(observation, &attempt, 0);
 }
 
-fn record_websocket_request_end<R: tauri::Runtime>(
-    observation: WebsocketObservation<R>,
-    completion: WebsocketCompletion,
+async fn enqueue_websocket_request_placeholder<R: tauri::Runtime>(
+    observation: &WebsocketObservation<R>,
 ) {
     if !observation.observe_request {
         return;
     }
 
+    let attempt = build_websocket_attempt(observation, "started", None, None, None, None, 0);
+    let attempts_json = serde_json::to_string(&[attempt]).unwrap_or_else(|_| "[]".to_string());
+    let args = RequestLogEnqueueArgs {
+        trace_id: observation.trace_id.clone(),
+        cli_key: observation.cli_key.clone(),
+        session_id: observation.session_id.clone(),
+        method: observation.method.clone(),
+        path: observation.path.clone(),
+        query: observation.query.clone(),
+        excluded_from_stats: true,
+        special_settings_json: Some(WEBSOCKET_SPECIAL_SETTINGS_JSON.to_string()),
+        status: None,
+        error_code: None,
+        duration_ms: 0,
+        ttfb_ms: None,
+        attempts_json,
+        requested_model: observation.requested_model.clone(),
+        created_at_ms: observation.created_at_ms,
+        created_at: observation.created_at,
+        usage_metrics: None,
+        usage: None,
+        provider_chain_json: None,
+        error_details_json: None,
+    };
+
+    enqueue_request_log_placeholder(&observation.state.app, &observation.state.log_tx, args).await;
+}
+
+fn log_websocket_connection_start<R: tauri::Runtime>(observation: &WebsocketObservation<R>) {
+    let reconnect_count = register_websocket_connection(
+        &observation.cli_key,
+        observation.session_id.as_deref(),
+        observation.created_at_ms,
+    );
+    tracing::info!(
+        target: "gateway_debug",
+        trace_id = %observation.trace_id,
+        cli_key = %observation.cli_key,
+        session_id = observation.session_id.as_deref().unwrap_or("-"),
+        provider_id = observation.provider_id,
+        provider = %observation.provider_name,
+        reconnect_count = reconnect_count.unwrap_or(0),
+        "[WS_CONN] websocket connection started"
+    );
+    if let Some(reconnect_count) = reconnect_count.filter(|value| *value > 0) {
+        tracing::info!(
+            target: "gateway_debug",
+            trace_id = %observation.trace_id,
+            cli_key = %observation.cli_key,
+            session_id = observation.session_id.as_deref().unwrap_or("-"),
+            provider_id = observation.provider_id,
+            provider = %observation.provider_name,
+            reconnect_count,
+            "[WS_RECONNECT] websocket reconnect detected"
+        );
+    }
+}
+
+fn register_websocket_connection(
+    cli_key: &str,
+    session_id: Option<&str>,
+    now_ms: i64,
+) -> Option<usize> {
+    let session_id = session_id?.trim();
+    if session_id.is_empty() {
+        return None;
+    }
+    let key = format!("{cli_key}:{session_id}");
+    let registry = WEBSOCKET_CONNECTION_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
+    let Ok(mut registry) = registry.lock() else {
+        return None;
+    };
+    registry.retain(|_, stats| {
+        now_ms.saturating_sub(stats.last_seen_ms) <= WEBSOCKET_RECONNECT_WINDOW_MS
+    });
+    let entry = registry.entry(key).or_insert(WebsocketConnectionStats {
+        count: 0,
+        last_seen_ms: now_ms,
+    });
+    let reconnect_count = entry.count;
+    entry.count = entry.count.saturating_add(1);
+    entry.last_seen_ms = now_ms;
+    Some(reconnect_count)
+}
+
+fn websocket_unsupported_status_from_error(err: &tungstenite::Error) -> Option<u16> {
+    let status = match err {
+        tungstenite::Error::Http(response) => response.status(),
+        _ => return None,
+    };
+    matches!(
+        status,
+        StatusCode::BAD_REQUEST
+            | StatusCode::NOT_FOUND
+            | StatusCode::METHOD_NOT_ALLOWED
+            | StatusCode::UPGRADE_REQUIRED
+            | StatusCode::NOT_IMPLEMENTED
+    )
+    .then_some(status.as_u16())
+}
+
+fn websocket_unsupported_cache_key(provider_id: i64, base_url: &str) -> String {
+    format!("{provider_id}:{}", base_url.trim_end_matches('/'))
+}
+
+fn websocket_unsupported_cache_hit(provider_id: i64, base_url: &str, now_unix: i64) -> bool {
+    let cache = WEBSOCKET_UNSUPPORTED_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let Ok(mut cache) = cache.lock() else {
+        return false;
+    };
+    cache.retain(|_, expires_at| *expires_at > now_unix);
+    cache.contains_key(&websocket_unsupported_cache_key(provider_id, base_url))
+}
+
+fn remember_websocket_unsupported(provider_id: i64, base_url: &str, now_unix: i64) {
+    let cache = WEBSOCKET_UNSUPPORTED_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(mut cache) = cache.lock() {
+        cache.insert(
+            websocket_unsupported_cache_key(provider_id, base_url),
+            now_unix.saturating_add(WEBSOCKET_UNSUPPORTED_CACHE_SECS),
+        );
+    }
+}
+
+fn record_websocket_request_end<R: tauri::Runtime>(
+    observation: WebsocketObservation<R>,
+    completion: WebsocketCompletion,
+    relay_metadata: WebsocketRelayMetadata,
+) {
     let duration_ms = observation.started.elapsed().as_millis();
+    tracing::info!(
+        target: "gateway_debug",
+        trace_id = %observation.trace_id,
+        cli_key = %observation.cli_key,
+        session_id = observation.session_id.as_deref().unwrap_or("-"),
+        provider_id = observation.provider_id,
+        provider = %observation.provider_name,
+        status = completion
+            .status
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        outcome = completion.outcome,
+        duration_ms,
+        ttfb_ms = completion
+            .ttfb_ms
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        completed_turns = relay_metadata.completed_turns,
+        "[WS_CONN] websocket connection ended"
+    );
+    emit_gateway_debug_log_lazy(&observation.state.app, || {
+        format!(
+            "[WS_RESP] trace_id={} status={} outcome={} duration_ms={} ttfb_ms={} completed_turns={} provider={} (id={})",
+            observation.trace_id,
+            completion
+                .status
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            completion.outcome,
+            duration_ms,
+            completion
+                .ttfb_ms
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            relay_metadata.completed_turns,
+            observation.provider_name,
+            observation.provider_id,
+        )
+    });
+
+    if !observation.observe_request {
+        return;
+    }
+
     let attempt = build_websocket_attempt(
         &observation,
         completion.outcome,
@@ -419,6 +829,17 @@ fn record_websocket_request_end<R: tauri::Runtime>(
     );
     emit_websocket_attempt_event(&observation, &attempt, duration_ms);
 
+    let requested_model = relay_metadata
+        .requested_model
+        .or(observation.requested_model.clone());
+    let usage = if relay_metadata.completed_turns > 0 {
+        None
+    } else {
+        relay_metadata.usage
+    };
+    let usage_metrics = usage.as_ref().map(|extract| extract.metrics.clone());
+
+    let excluded_from_stats = completion.status == Some(StatusCode::SWITCHING_PROTOCOLS.as_u16());
     let (log_args, attempts) = RequestLogEnqueueArgs::from_proxy_request_end_parts(
         &observation.trace_id,
         &observation.cli_key,
@@ -426,18 +847,18 @@ fn record_websocket_request_end<R: tauri::Runtime>(
         &observation.method,
         &observation.path,
         observation.query.as_deref(),
-        false,
-        None,
+        excluded_from_stats,
+        Some(WEBSOCKET_SPECIAL_SETTINGS_JSON.to_string()),
         completion.status,
         completion.error_code,
         duration_ms,
         completion.ttfb_ms,
         &[attempt],
-        observation.requested_model,
+        requested_model,
         observation.created_at_ms,
         observation.created_at,
-        None,
-        None,
+        usage_metrics.clone(),
+        usage,
     );
 
     log_args.emit_gateway_request_event(
@@ -445,7 +866,7 @@ fn record_websocket_request_end<R: tauri::Runtime>(
         completion.error_category,
         completion.ttfb_ms,
         attempts,
-        None,
+        usage_metrics,
     );
 
     spawn_enqueue_request_log_with_backpressure(
@@ -552,44 +973,76 @@ fn build_tungstenite_request(
     Ok(request)
 }
 
-async fn close_client_socket(mut socket: WebSocket, reason: String) {
-    let _ = socket
-        .send(AxumWsMessage::Close(Some(axum::extract::ws::CloseFrame {
-            code: axum::extract::ws::close_code::ERROR,
-            reason: Cow::Owned(reason),
-        })))
-        .await;
-}
-
-async fn relay_websocket_messages(
+async fn relay_websocket_messages<R: tauri::Runtime>(
     client_socket: WebSocket,
     upstream_socket: UpstreamWsStream,
-    trace_id: String,
-) {
+    observation: &WebsocketObservation<R>,
+) -> WebsocketRelayMetadata {
     let (mut client_tx, mut client_rx) = client_socket.split();
     let (mut upstream_tx, mut upstream_rx) = upstream_socket.split();
+    let mut relay_state = WebsocketRelayState::default();
+    let mut heartbeat = tokio::time::interval_at(
+        tokio::time::Instant::now() + WEBSOCKET_TRACE_HEARTBEAT_INTERVAL,
+        WEBSOCKET_TRACE_HEARTBEAT_INTERVAL,
+    );
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut drop_downstream = false;
+    let mut drain_deadline: Option<tokio::time::Instant> = None;
 
     loop {
         tokio::select! {
-            msg = client_rx.next() => {
+            _ = heartbeat.tick() => {
+                emit_websocket_progress_event(observation);
+            }
+            _ = wait_websocket_drain_deadline(drain_deadline), if drain_deadline.is_some() => {
+                emit_websocket_relay_debug(
+                    observation,
+                    "websocket upstream drain timeout after client disconnect",
+                );
+                break;
+            }
+            msg = client_rx.next(), if !drop_downstream => {
                 let Some(msg) = msg else {
-                    let _ = upstream_tx.close().await;
-                    break;
+                    start_websocket_upstream_drain(
+                        observation,
+                        "client stream ended",
+                        &mut drop_downstream,
+                        &mut drain_deadline,
+                    );
+                    continue;
                 };
                 match msg {
                     Ok(message) => {
                         let is_close = matches!(message, AxumWsMessage::Close(_));
-                        if let Err(err) = upstream_tx.send(axum_to_tungstenite(message)).await {
-                            tracing::debug!(trace_id = %trace_id, "websocket client-to-upstream send failed: {err}");
-                            break;
-                        }
                         if is_close {
+                            start_websocket_upstream_drain(
+                                observation,
+                                "client close frame",
+                                &mut drop_downstream,
+                                &mut drain_deadline,
+                            );
+                            continue;
+                        }
+                        if let Err(err) = upstream_tx.send(axum_to_tungstenite(message)).await {
+                            emit_websocket_relay_debug(
+                                observation,
+                                format!("websocket client-to-upstream send failed: {err}"),
+                            );
                             break;
                         }
                     }
                     Err(err) => {
-                        tracing::debug!(trace_id = %trace_id, "websocket client receive failed: {err}");
-                        break;
+                        emit_websocket_relay_debug(
+                            observation,
+                            format!("websocket client receive failed: {err}"),
+                        );
+                        start_websocket_upstream_drain(
+                            observation,
+                            "client receive failed",
+                            &mut drop_downstream,
+                            &mut drain_deadline,
+                        );
+                        continue;
                     }
                 }
             }
@@ -603,23 +1056,481 @@ async fn relay_websocket_messages(
                         let Some(message) = tungstenite_to_axum(message) else {
                             continue;
                         };
+                        let turn_completion = capture_websocket_upstream_metadata(
+                            &message,
+                            &observation.cli_key,
+                            observation.started.elapsed().as_millis(),
+                            &mut relay_state,
+                        );
+                        if let Some(turn_completion) = turn_completion {
+                            record_websocket_turn_end(observation, turn_completion);
+                            if drop_downstream {
+                                emit_websocket_relay_debug(
+                                    observation,
+                                    "websocket upstream drain captured terminal event",
+                                );
+                                break;
+                            }
+                        }
+                        if drop_downstream {
+                            continue;
+                        }
                         let is_close = matches!(message, AxumWsMessage::Close(_));
                         if let Err(err) = client_tx.send(message).await {
-                            tracing::debug!(trace_id = %trace_id, "websocket upstream-to-client send failed: {err}");
-                            break;
+                            emit_websocket_relay_debug(
+                                observation,
+                                format!("websocket upstream-to-client send failed: {err}"),
+                            );
+                            start_websocket_upstream_drain(
+                                observation,
+                                "client send failed",
+                                &mut drop_downstream,
+                                &mut drain_deadline,
+                            );
+                            continue;
                         }
                         if is_close {
                             break;
                         }
                     }
                     Err(err) => {
-                        tracing::debug!(trace_id = %trace_id, "websocket upstream receive failed: {err}");
+                        emit_websocket_relay_debug(
+                            observation,
+                            format!("websocket upstream receive failed: {err}"),
+                        );
                         break;
                     }
                 }
             }
         }
     }
+
+    relay_state.metadata
+}
+
+async fn wait_websocket_drain_deadline(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+fn start_websocket_upstream_drain<R: tauri::Runtime>(
+    observation: &WebsocketObservation<R>,
+    reason: &str,
+    drop_downstream: &mut bool,
+    drain_deadline: &mut Option<tokio::time::Instant>,
+) {
+    if *drop_downstream {
+        return;
+    }
+
+    *drop_downstream = true;
+    *drain_deadline = Some(tokio::time::Instant::now() + WEBSOCKET_UPSTREAM_DRAIN_TIMEOUT);
+    emit_websocket_relay_debug(
+        observation,
+        format!("websocket client disconnected, draining upstream: {reason}"),
+    );
+}
+
+fn emit_websocket_relay_debug<R: tauri::Runtime>(
+    observation: &WebsocketObservation<R>,
+    message: impl Into<String>,
+) {
+    let message = message.into();
+    emit_gateway_debug_log_lazy(&observation.state.app, || {
+        format!("[WS_RELAY] trace_id={} {}", observation.trace_id, message)
+    });
+}
+
+fn capture_websocket_upstream_metadata(
+    message: &AxumWsMessage,
+    cli_key: &str,
+    elapsed_ms: u128,
+    state: &mut WebsocketRelayState,
+) -> Option<WebsocketTurnCompletion> {
+    let bytes = match message {
+        AxumWsMessage::Text(value) => value.as_bytes(),
+        AxumWsMessage::Binary(value) => value.as_slice(),
+        _ => return None,
+    };
+
+    if let Some(model) = crate::usage::parse_model_from_json_bytes(bytes) {
+        state.metadata.requested_model = Some(model);
+    }
+
+    let Some(event_type) = parse_websocket_event_type(bytes) else {
+        return None;
+    };
+
+    let response_id = parse_websocket_response_id(bytes, &event_type);
+    if event_type == "response.created" {
+        if let Some(response_id) = response_id.as_deref() {
+            init_websocket_turn_timing(state, response_id, elapsed_ms);
+        }
+    }
+
+    if is_websocket_token_event(&event_type) {
+        if state.metadata.first_token_ms.is_none() {
+            state.metadata.first_token_ms = Some(elapsed_ms);
+        }
+        mark_websocket_turn_first_token(state, response_id.as_deref(), elapsed_ms);
+    }
+
+    let usage = if should_parse_websocket_usage(&event_type) {
+        crate::usage::parse_usage_from_json_or_sse_bytes(cli_key, bytes)
+    } else {
+        None
+    };
+    if let Some(usage) = usage.as_ref() {
+        accumulate_websocket_usage(&mut state.metadata.usage, usage);
+    }
+
+    if !is_websocket_terminal_event(&event_type) {
+        return None;
+    }
+
+    state.metadata.completed_turns = state.metadata.completed_turns.saturating_add(1);
+    let turn_index = state.metadata.completed_turns;
+    let timing = response_id
+        .as_deref()
+        .and_then(|id| state.turn_timings.remove(id))
+        .unwrap_or(WebsocketTurnTiming {
+            started_ms: elapsed_ms,
+            first_token_ms: None,
+        });
+    if response_id
+        .as_deref()
+        .is_some_and(|id| state.active_response_id.as_deref() == Some(id))
+    {
+        state.active_response_id = None;
+    }
+
+    let duration_ms = elapsed_ms.saturating_sub(timing.started_ms);
+    Some(WebsocketTurnCompletion {
+        response_id,
+        terminal_event: event_type,
+        turn_index,
+        started_ms: timing.started_ms,
+        duration_ms,
+        ttfb_ms: timing.first_token_ms,
+        requested_model: state.metadata.requested_model.clone(),
+        usage,
+    })
+}
+
+fn record_websocket_turn_end<R: tauri::Runtime>(
+    observation: &WebsocketObservation<R>,
+    turn: WebsocketTurnCompletion,
+) {
+    if !observation.observe_request {
+        return;
+    }
+
+    let trace_id = format!("{}-ws-{}", observation.trace_id, turn.turn_index);
+    let mut attempt = build_websocket_attempt(
+        observation,
+        "success",
+        Some(StatusCode::SWITCHING_PROTOCOLS.as_u16()),
+        None,
+        None,
+        None,
+        turn.duration_ms,
+    );
+    attempt.attempt_started_ms = Some(turn.started_ms);
+    attempt.attempt_duration_ms = Some(turn.duration_ms);
+
+    let special_settings_json = websocket_special_settings_json(&turn);
+    let created_at_ms = observation
+        .created_at_ms
+        .saturating_add(turn.started_ms.min(i64::MAX as u128) as i64);
+    let created_at = (created_at_ms / 1000).max(0);
+    let usage_metrics = turn.usage.as_ref().map(|extract| extract.metrics.clone());
+    let excluded_from_stats = websocket_turn_excluded_from_stats(&turn);
+    let input_tokens = usage_metrics
+        .as_ref()
+        .and_then(|metrics| metrics.input_tokens);
+    let output_tokens = usage_metrics
+        .as_ref()
+        .and_then(|metrics| metrics.output_tokens);
+    let total_tokens = usage_metrics
+        .as_ref()
+        .and_then(|metrics| metrics.total_tokens);
+    let requested_model = turn.requested_model.or(observation.requested_model.clone());
+    tracing::info!(
+        target: "gateway_debug",
+        trace_id = %trace_id,
+        parent_trace_id = %observation.trace_id,
+        cli_key = %observation.cli_key,
+        session_id = observation.session_id.as_deref().unwrap_or("-"),
+        provider_id = observation.provider_id,
+        provider = %observation.provider_name,
+        model = requested_model.as_deref().unwrap_or("-"),
+        terminal_event = %turn.terminal_event,
+        response_id = turn.response_id.as_deref().unwrap_or("-"),
+        duration_ms = turn.duration_ms,
+        ttfb_ms = turn.ttfb_ms.map(|value| value.to_string()).unwrap_or_else(|| "-".to_string()),
+        input_tokens = input_tokens.map(|value| value.to_string()).unwrap_or_else(|| "-".to_string()),
+        output_tokens = output_tokens.map(|value| value.to_string()).unwrap_or_else(|| "-".to_string()),
+        total_tokens = total_tokens.map(|value| value.to_string()).unwrap_or_else(|| "-".to_string()),
+        excluded_from_stats,
+        "[WS_TURN] websocket request log recorded"
+    );
+    let (log_args, attempts) = RequestLogEnqueueArgs::from_proxy_request_end_parts(
+        &trace_id,
+        &observation.cli_key,
+        observation.session_id.clone(),
+        &observation.method,
+        &observation.path,
+        observation.query.as_deref(),
+        excluded_from_stats,
+        Some(special_settings_json),
+        Some(StatusCode::SWITCHING_PROTOCOLS.as_u16()),
+        None,
+        turn.duration_ms,
+        turn.ttfb_ms,
+        &[attempt],
+        requested_model,
+        created_at_ms,
+        created_at,
+        usage_metrics.clone(),
+        turn.usage,
+    );
+
+    log_args.emit_gateway_request_event(
+        &observation.state.app,
+        None,
+        turn.ttfb_ms,
+        attempts,
+        usage_metrics,
+    );
+
+    spawn_enqueue_request_log_with_backpressure(
+        observation.state.app.clone(),
+        observation.state.db.clone(),
+        observation.state.log_tx.clone(),
+        log_args,
+    );
+}
+
+fn websocket_turn_excluded_from_stats(turn: &WebsocketTurnCompletion) -> bool {
+    let Some(usage) = turn.usage.as_ref() else {
+        return true;
+    };
+    usage.metrics.output_tokens.unwrap_or(0) <= 0
+}
+
+fn websocket_special_settings_json(turn: &WebsocketTurnCompletion) -> String {
+    let mut turn_obj = serde_json::json!({
+        "type": "websocket_turn",
+        "turn_index": turn.turn_index,
+        "terminal_event": turn.terminal_event,
+    });
+    if let Some(response_id) = turn.response_id.as_deref() {
+        if let Some(obj) = turn_obj.as_object_mut() {
+            obj.insert("response_id".to_string(), serde_json::json!(response_id));
+        }
+    }
+    serde_json::json!([
+        {"type": "websocket_proxy"},
+        turn_obj
+    ])
+    .to_string()
+}
+
+fn init_websocket_turn_timing(
+    state: &mut WebsocketRelayState,
+    response_id: &str,
+    elapsed_ms: u128,
+) {
+    state
+        .turn_timings
+        .entry(response_id.to_string())
+        .or_insert(WebsocketTurnTiming {
+            started_ms: elapsed_ms,
+            first_token_ms: None,
+        });
+    state.active_response_id = Some(response_id.to_string());
+}
+
+fn mark_websocket_turn_first_token(
+    state: &mut WebsocketRelayState,
+    response_id: Option<&str>,
+    elapsed_ms: u128,
+) {
+    let timing = response_id
+        .map(str::to_string)
+        .or_else(|| state.active_response_id.clone())
+        .map(|id| {
+            state
+                .turn_timings
+                .entry(id.clone())
+                .or_insert(WebsocketTurnTiming {
+                    started_ms: 0,
+                    first_token_ms: None,
+                })
+        });
+
+    if let Some(timing) = timing {
+        if timing.first_token_ms.is_none() {
+            timing.first_token_ms = Some(elapsed_ms.saturating_sub(timing.started_ms));
+        }
+    }
+}
+
+fn parse_websocket_event_type(bytes: &[u8]) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    value
+        .get("type")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn parse_websocket_response_id(bytes: &[u8], event_type: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let response_id = value
+        .get("response")
+        .and_then(|response| response.get("id"))
+        .and_then(|value| value.as_str())
+        .or_else(|| value.get("response_id").and_then(|value| value.as_str()))
+        .or_else(|| {
+            is_websocket_terminal_event(event_type)
+                .then(|| value.get("id").and_then(|value| value.as_str()))
+                .flatten()
+        })?;
+
+    let response_id = response_id.trim();
+    (!response_id.is_empty()).then(|| response_id.to_string())
+}
+
+fn is_websocket_terminal_event(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        "response.completed"
+            | "response.done"
+            | "response.failed"
+            | "response.incomplete"
+            | "response.cancelled"
+            | "response.canceled"
+    )
+}
+
+fn should_parse_websocket_usage(event_type: &str) -> bool {
+    is_websocket_terminal_event(event_type)
+}
+
+fn is_websocket_token_event(event_type: &str) -> bool {
+    if matches!(
+        event_type,
+        "" | "response.created"
+            | "response.in_progress"
+            | "response.output_item.added"
+            | "response.output_item.done"
+    ) {
+        return false;
+    }
+
+    event_type.contains(".delta")
+        || event_type.starts_with("response.output_text")
+        || event_type.starts_with("response.output")
+        || matches!(event_type, "response.completed" | "response.done")
+}
+
+fn accumulate_websocket_usage(
+    aggregate: &mut Option<crate::usage::UsageExtract>,
+    usage: &crate::usage::UsageExtract,
+) {
+    let Some(existing) = aggregate else {
+        *aggregate = Some(usage.clone());
+        return;
+    };
+
+    add_metric(
+        &mut existing.metrics.input_tokens,
+        usage.metrics.input_tokens,
+    );
+    add_metric(
+        &mut existing.metrics.output_tokens,
+        usage.metrics.output_tokens,
+    );
+    add_metric(
+        &mut existing.metrics.total_tokens,
+        usage.metrics.total_tokens,
+    );
+    add_metric(
+        &mut existing.metrics.cache_read_input_tokens,
+        usage.metrics.cache_read_input_tokens,
+    );
+    add_metric(
+        &mut existing.metrics.cache_creation_input_tokens,
+        usage.metrics.cache_creation_input_tokens,
+    );
+    add_metric(
+        &mut existing.metrics.cache_creation_5m_input_tokens,
+        usage.metrics.cache_creation_5m_input_tokens,
+    );
+    add_metric(
+        &mut existing.metrics.cache_creation_1h_input_tokens,
+        usage.metrics.cache_creation_1h_input_tokens,
+    );
+    existing.usage_json = websocket_usage_json(&existing.metrics);
+}
+
+fn add_metric(base: &mut Option<i64>, patch: Option<i64>) {
+    if let Some(patch) = patch {
+        *base = Some(base.unwrap_or(0).saturating_add(patch));
+    }
+}
+
+fn websocket_usage_json(metrics: &crate::usage::UsageMetrics) -> String {
+    let mut obj = serde_json::Map::new();
+    if let Some(value) = metrics.input_tokens {
+        obj.insert("input_tokens".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = metrics.output_tokens {
+        obj.insert("output_tokens".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = metrics.total_tokens {
+        obj.insert("total_tokens".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = metrics.cache_read_input_tokens {
+        obj.insert(
+            "cache_read_input_tokens".to_string(),
+            serde_json::json!(value),
+        );
+    }
+    if let Some(value) = metrics.cache_creation_input_tokens {
+        obj.insert(
+            "cache_creation_input_tokens".to_string(),
+            serde_json::json!(value),
+        );
+    }
+    if let Some(value) = metrics.cache_creation_5m_input_tokens {
+        obj.insert(
+            "cache_creation_5m_input_tokens".to_string(),
+            serde_json::json!(value),
+        );
+    }
+    if let Some(value) = metrics.cache_creation_1h_input_tokens {
+        obj.insert(
+            "cache_creation_1h_input_tokens".to_string(),
+            serde_json::json!(value),
+        );
+    }
+    serde_json::Value::Object(obj).to_string()
+}
+
+fn emit_websocket_progress_event<R: tauri::Runtime>(observation: &WebsocketObservation<R>) {
+    if !observation.observe_request {
+        return;
+    }
+
+    let duration_ms = observation.started.elapsed().as_millis();
+    let attempt =
+        build_websocket_attempt(observation, "started", None, None, None, None, duration_ms);
+    emit_websocket_attempt_event(observation, &attempt, duration_ms);
 }
 
 fn axum_to_tungstenite(message: AxumWsMessage) -> tungstenite::Message {
@@ -656,7 +1567,116 @@ fn tungstenite_to_axum(message: tungstenite::Message) -> Option<AxumWsMessage> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gateway::proxy::{ProviderBaseUrlPingCache, RecentErrorCache};
     use axum::http::HeaderValue;
+    use axum::routing::get;
+    use axum::Router;
+    use std::borrow::Cow;
+    use std::sync::{Arc, Mutex};
+
+    fn websocket_test_state(
+        app: tauri::AppHandle<tauri::test::MockRuntime>,
+        db: crate::db::Db,
+    ) -> GatewayAppState<tauri::test::MockRuntime> {
+        let (log_tx, _log_rx) =
+            tokio::sync::mpsc::channel::<crate::request_logs::RequestLogInsert>(8);
+        GatewayAppState {
+            app,
+            db,
+            log_tx,
+            circuit: Arc::new(crate::circuit_breaker::CircuitBreaker::new(
+                crate::circuit_breaker::CircuitBreakerConfig {
+                    failure_threshold: 1,
+                    open_duration_secs: 60,
+                },
+                HashMap::new(),
+                None,
+            )),
+            session: Arc::new(crate::session_manager::SessionManager::new()),
+            codex_session_cache: Arc::new(Mutex::new(
+                crate::gateway::codex_session_id::CodexSessionIdCache::default(),
+            )),
+            recent_errors: Arc::new(Mutex::new(RecentErrorCache::default())),
+            latency_cache: Arc::new(Mutex::new(ProviderBaseUrlPingCache::default())),
+        }
+    }
+
+    fn insert_codex_provider(
+        db: &crate::db::Db,
+        name: &str,
+        base_url: String,
+        priority: i64,
+    ) -> i64 {
+        insert_codex_provider_with_websockets(db, name, base_url, priority, true)
+    }
+
+    fn insert_codex_provider_with_websockets(
+        db: &crate::db::Db,
+        name: &str,
+        base_url: String,
+        priority: i64,
+        supports_websockets: bool,
+    ) -> i64 {
+        crate::providers::upsert(
+            db,
+            crate::providers::ProviderUpsertParams {
+                provider_id: None,
+                cli_key: "codex".to_string(),
+                name: name.to_string(),
+                base_urls: vec![base_url],
+                base_url_mode: crate::providers::ProviderBaseUrlMode::Order,
+                auth_mode: None,
+                api_key: Some("sk-test".to_string()),
+                enabled: true,
+                cost_multiplier: 1.0,
+                priority: Some(priority),
+                claude_models: None,
+                limit_5h_usd: None,
+                limit_daily_usd: None,
+                daily_reset_mode: None,
+                daily_reset_time: None,
+                limit_weekly_usd: None,
+                limit_monthly_usd: None,
+                limit_total_usd: None,
+                tags: None,
+                note: None,
+                source_provider_id: None,
+                bridge_type: None,
+                stream_idle_timeout_seconds: None,
+                supports_websockets: Some(supports_websockets),
+            },
+        )
+        .expect("insert provider")
+        .id
+    }
+
+    async fn spawn_websocket_upstream() -> (String, tokio::task::JoinHandle<()>) {
+        async fn handler(ws: WebSocketUpgrade) -> Response {
+            ws.on_upgrade(|mut socket| async move { while socket.recv().await.is_some() {} })
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind websocket upstream");
+        let addr = listener.local_addr().expect("local addr");
+        let app = Router::new().route("/v1/realtime", get(handler));
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://{addr}"), task)
+    }
+
+    async fn spawn_plain_http_upstream() -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind plain upstream");
+        let addr = listener.local_addr().expect("local addr");
+        let app = Router::new().fallback(|| async { "not websocket" });
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://{addr}"), task)
+    }
 
     #[test]
     fn build_websocket_url_rewrites_http_scheme() {
@@ -668,6 +1688,344 @@ mod tests {
         .expect("websocket url");
 
         assert_eq!(url.as_str(), "wss://api.example.com/v1/realtime?model=x");
+    }
+
+    #[test]
+    fn websocket_success_completion_uses_switching_protocols_status() {
+        let completion = WebsocketCompletion::success(Some(12));
+
+        assert_eq!(completion.outcome, "success");
+        assert_eq!(
+            completion.status,
+            Some(StatusCode::SWITCHING_PROTOCOLS.as_u16())
+        );
+        assert_eq!(completion.ttfb_ms, Some(12));
+    }
+
+    #[test]
+    fn captures_realtime_response_done_usage_from_upstream_text_frame() {
+        let mut state = WebsocketRelayState::default();
+        let message = AxumWsMessage::Text(
+            r#"{"type":"response.done","response":{"model":"gpt-realtime","usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18,"input_token_details":{"cached_tokens":3}}}}"#
+                .to_string(),
+        );
+
+        let turn = capture_websocket_upstream_metadata(&message, "codex", 42, &mut state)
+            .expect("turn captured");
+
+        let usage = state.metadata.usage.expect("usage captured");
+        assert_eq!(
+            state.metadata.requested_model.as_deref(),
+            Some("gpt-realtime")
+        );
+        assert_eq!(usage.metrics.input_tokens, Some(11));
+        assert_eq!(usage.metrics.output_tokens, Some(7));
+        assert_eq!(usage.metrics.total_tokens, Some(18));
+        assert_eq!(usage.metrics.cache_read_input_tokens, Some(3));
+        assert_eq!(turn.turn_index, 1);
+        assert_eq!(turn.terminal_event, "response.done");
+        assert_eq!(turn.duration_ms, 0);
+    }
+
+    #[test]
+    fn websocket_turn_timing_uses_first_token_event_not_terminal_event() {
+        let mut state = WebsocketRelayState::default();
+        let created = AxumWsMessage::Text(
+            r#"{"type":"response.created","response":{"id":"resp_1","model":"gpt-realtime"}}"#
+                .to_string(),
+        );
+        let delta = AxumWsMessage::Text(
+            r#"{"type":"response.output_text.delta","delta":"hi"}"#.to_string(),
+        );
+        let done = AxumWsMessage::Text(
+            r#"{"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":2,"output_tokens":3,"total_tokens":5}}}"#
+                .to_string(),
+        );
+
+        assert!(capture_websocket_upstream_metadata(&created, "codex", 10, &mut state).is_none());
+        assert!(capture_websocket_upstream_metadata(&delta, "codex", 25, &mut state).is_none());
+        let turn = capture_websocket_upstream_metadata(&done, "codex", 70, &mut state)
+            .expect("turn captured");
+
+        assert_eq!(state.metadata.first_token_ms, Some(25));
+        assert_eq!(turn.started_ms, 10);
+        assert_eq!(turn.duration_ms, 60);
+        assert_eq!(turn.ttfb_ms, Some(15));
+        assert_eq!(
+            turn.usage
+                .as_ref()
+                .and_then(|usage| usage.metrics.output_tokens),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn websocket_usage_accumulates_multiple_terminal_turns() {
+        let mut state = WebsocketRelayState::default();
+        let first = AxumWsMessage::Text(
+            r#"{"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}"#
+                .to_string(),
+        );
+        let second = AxumWsMessage::Text(
+            r#"{"type":"response.failed","response":{"id":"resp_2","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7}}}"#
+                .to_string(),
+        );
+
+        let turn1 = capture_websocket_upstream_metadata(&first, "codex", 100, &mut state)
+            .expect("first turn");
+        let turn2 = capture_websocket_upstream_metadata(&second, "codex", 200, &mut state)
+            .expect("second turn");
+
+        let usage = state.metadata.usage.expect("aggregate usage");
+        assert_eq!(turn1.turn_index, 1);
+        assert_eq!(turn2.turn_index, 2);
+        assert_eq!(usage.metrics.input_tokens, Some(5));
+        assert_eq!(usage.metrics.output_tokens, Some(5));
+        assert_eq!(usage.metrics.total_tokens, Some(10));
+    }
+
+    #[test]
+    fn websocket_turn_stats_require_output_tokens() {
+        let mut state = WebsocketRelayState::default();
+        let input_only = AxumWsMessage::Text(
+            r#"{"type":"response.completed","response":{"id":"resp_input_only","usage":{"input_tokens":12828,"output_tokens":0,"total_tokens":12828}}}"#
+                .to_string(),
+        );
+        let answered = AxumWsMessage::Text(
+            r#"{"type":"response.completed","response":{"id":"resp_answered","usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}"#
+                .to_string(),
+        );
+
+        let input_only_turn =
+            capture_websocket_upstream_metadata(&input_only, "codex", 100, &mut state)
+                .expect("input-only turn");
+        let answered_turn =
+            capture_websocket_upstream_metadata(&answered, "codex", 200, &mut state)
+                .expect("answered turn");
+
+        assert!(websocket_turn_excluded_from_stats(&input_only_turn));
+        assert!(!websocket_turn_excluded_from_stats(&answered_turn));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn websocket_upstream_selection_skips_open_circuit_provider() {
+        let app = tauri::test::mock_app();
+        let db_dir = tempfile::tempdir().expect("db dir");
+        let db = crate::db::init_for_tests(&db_dir.path().join("ws-open-circuit.sqlite"))
+            .expect("init db");
+        let state = websocket_test_state(app.handle().clone(), db.clone());
+        let (plain_base_url, plain_task) = spawn_plain_http_upstream().await;
+        let (ws_base_url, ws_task) = spawn_websocket_upstream().await;
+        let first_provider_id = insert_codex_provider(&db, "open circuit", plain_base_url, 0);
+        let second_provider_id = insert_codex_provider(&db, "ws ok", ws_base_url, 1);
+        state
+            .circuit
+            .record_failure(first_provider_id, now_unix_seconds() as i64);
+
+        let prepared = prepare_websocket_upstream(
+            &state,
+            "codex",
+            None,
+            "/v1/realtime",
+            None,
+            &HeaderMap::new(),
+            "trace-ws-open-circuit",
+        )
+        .await
+        .expect("prepared websocket upstream");
+
+        assert_eq!(prepared.provider_id, second_provider_id);
+        assert_eq!(
+            state
+                .circuit
+                .snapshot(first_provider_id, now_unix_seconds() as i64)
+                .state,
+            crate::circuit_breaker::CircuitState::Open
+        );
+
+        drop(prepared);
+        plain_task.abort();
+        ws_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn websocket_upstream_selection_tries_next_when_provider_rejects_ws() {
+        let app = tauri::test::mock_app();
+        let db_dir = tempfile::tempdir().expect("db dir");
+        let db = crate::db::init_for_tests(&db_dir.path().join("ws-provider-failover.sqlite"))
+            .expect("init db");
+        let state = websocket_test_state(app.handle().clone(), db.clone());
+        let (plain_one_base_url, plain_one_task) = spawn_plain_http_upstream().await;
+        let (plain_two_base_url, plain_two_task) = spawn_plain_http_upstream().await;
+        let (ws_base_url, ws_task) = spawn_websocket_upstream().await;
+        let first_provider_id = insert_codex_provider(&db, "plain one", plain_one_base_url, 0);
+        let second_provider_id = insert_codex_provider(&db, "plain two", plain_two_base_url, 1);
+        let third_provider_id = insert_codex_provider(&db, "ws ok", ws_base_url, 2);
+
+        let prepared = prepare_websocket_upstream(
+            &state,
+            "codex",
+            None,
+            "/v1/realtime",
+            None,
+            &HeaderMap::new(),
+            "trace-ws-failover",
+        )
+        .await
+        .expect("prepared websocket upstream");
+
+        assert_eq!(prepared.provider_id, third_provider_id);
+        let now = now_unix_seconds() as i64;
+        assert_eq!(
+            state.circuit.snapshot(first_provider_id, now).state,
+            crate::circuit_breaker::CircuitState::Closed
+        );
+        assert_eq!(
+            state.circuit.snapshot(second_provider_id, now).state,
+            crate::circuit_breaker::CircuitState::Closed
+        );
+
+        drop(prepared);
+        plain_one_task.abort();
+        plain_two_task.abort();
+        ws_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn websocket_upstream_selection_skips_provider_without_websocket_flag() {
+        let app = tauri::test::mock_app();
+        let db_dir = tempfile::tempdir().expect("db dir");
+        let db = crate::db::init_for_tests(&db_dir.path().join("ws-provider-flag.sqlite"))
+            .expect("init db");
+        let state = websocket_test_state(app.handle().clone(), db.clone());
+        let (plain_base_url, plain_task) = spawn_plain_http_upstream().await;
+        let (ws_base_url, ws_task) = spawn_websocket_upstream().await;
+        let first_provider_id =
+            insert_codex_provider_with_websockets(&db, "ws disabled", plain_base_url, 0, false);
+        let second_provider_id =
+            insert_codex_provider_with_websockets(&db, "ws enabled", ws_base_url, 1, true);
+
+        let prepared = prepare_websocket_upstream(
+            &state,
+            "codex",
+            None,
+            "/v1/realtime",
+            None,
+            &HeaderMap::new(),
+            "trace-ws-provider-flag",
+        )
+        .await
+        .expect("prepared websocket upstream");
+
+        assert_eq!(prepared.provider_id, second_provider_id);
+        assert_eq!(
+            state
+                .circuit
+                .snapshot(first_provider_id, now_unix_seconds() as i64)
+                .state,
+            crate::circuit_breaker::CircuitState::Closed
+        );
+
+        drop(prepared);
+        plain_task.abort();
+        ws_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn websocket_forced_provider_without_websocket_flag_fails_without_circuit() {
+        let app = tauri::test::mock_app();
+        let db_dir = tempfile::tempdir().expect("db dir");
+        let db = crate::db::init_for_tests(&db_dir.path().join("ws-forced-provider-flag.sqlite"))
+            .expect("init db");
+        let state = websocket_test_state(app.handle().clone(), db.clone());
+        let (plain_base_url, plain_task) = spawn_plain_http_upstream().await;
+        let provider_id =
+            insert_codex_provider_with_websockets(&db, "ws disabled", plain_base_url, 0, false);
+
+        let err = match prepare_websocket_upstream(
+            &state,
+            "codex",
+            Some(provider_id),
+            "/v1/realtime",
+            None,
+            &HeaderMap::new(),
+            "trace-ws-forced-provider-flag",
+        )
+        .await
+        {
+            Ok(_) => panic!("forced provider should not be attempted"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.0, StatusCode::UPGRADE_REQUIRED);
+        assert_eq!(err.1, GatewayErrorCode::NoEnabledProvider);
+        assert!(err.2.contains("no websocket-enabled provider"));
+        assert_eq!(
+            state
+                .circuit
+                .snapshot(provider_id, now_unix_seconds() as i64)
+                .state,
+            crate::circuit_breaker::CircuitState::Closed
+        );
+
+        plain_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn websocket_all_providers_without_websocket_flag_fail_fast() {
+        let app = tauri::test::mock_app();
+        let db_dir = tempfile::tempdir().expect("db dir");
+        let db = crate::db::init_for_tests(&db_dir.path().join("ws-all-provider-flag.sqlite"))
+            .expect("init db");
+        let state = websocket_test_state(app.handle().clone(), db.clone());
+        let (plain_one_base_url, plain_one_task) = spawn_plain_http_upstream().await;
+        let (plain_two_base_url, plain_two_task) = spawn_plain_http_upstream().await;
+        let first_provider_id = insert_codex_provider_with_websockets(
+            &db,
+            "ws disabled one",
+            plain_one_base_url,
+            0,
+            false,
+        );
+        let second_provider_id = insert_codex_provider_with_websockets(
+            &db,
+            "ws disabled two",
+            plain_two_base_url,
+            1,
+            false,
+        );
+
+        let err = match prepare_websocket_upstream(
+            &state,
+            "codex",
+            None,
+            "/v1/realtime",
+            None,
+            &HeaderMap::new(),
+            "trace-ws-all-provider-flag",
+        )
+        .await
+        {
+            Ok(_) => panic!("websocket preparation should fail fast"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.0, StatusCode::UPGRADE_REQUIRED);
+        assert_eq!(err.1, GatewayErrorCode::NoEnabledProvider);
+        assert!(err.2.contains("no websocket-enabled provider"));
+
+        let now = now_unix_seconds() as i64;
+        assert_eq!(
+            state.circuit.snapshot(first_provider_id, now).state,
+            crate::circuit_breaker::CircuitState::Closed
+        );
+        assert_eq!(
+            state.circuit.snapshot(second_provider_id, now).state,
+            crate::circuit_breaker::CircuitState::Closed
+        );
+
+        plain_one_task.abort();
+        plain_two_task.abort();
     }
 
     #[test]
@@ -715,6 +2073,7 @@ mod tests {
             source_provider_id: None,
             bridge_type: None,
             stream_idle_timeout_seconds: None,
+            supports_websockets: true,
         };
 
         let mut headers = build_base_upstream_websocket_headers("codex", &inbound);

--- a/src-tauri/src/gateway/proxy/websocket.rs
+++ b/src-tauri/src/gateway/proxy/websocket.rs
@@ -26,6 +26,7 @@ use futures_util::{SinkExt, StreamExt};
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
+use tokio::sync::watch;
 use tokio_tungstenite::tungstenite::{self, client::IntoClientRequest};
 
 type UpstreamWsStream =
@@ -40,6 +41,9 @@ const WEBSOCKET_UNSUPPORTED_CACHE_SECS: i64 = 10 * 60;
 static WEBSOCKET_CONNECTION_REGISTRY: OnceLock<Mutex<HashMap<String, WebsocketConnectionStats>>> =
     OnceLock::new();
 static WEBSOCKET_UNSUPPORTED_CACHE: OnceLock<Mutex<HashMap<String, i64>>> = OnceLock::new();
+static WEBSOCKET_ACTIVE_CONNECTIONS: OnceLock<
+    Mutex<HashMap<i64, HashMap<String, watch::Sender<u64>>>>,
+> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy)]
 struct WebsocketConnectionStats {
@@ -606,14 +610,65 @@ async fn relay_websocket<R: tauri::Runtime>(
     upstream_socket: UpstreamWsStream,
     observation: WebsocketObservation<R>,
 ) {
-    let relay_metadata =
-        relay_websocket_messages(client_socket, upstream_socket, &observation).await;
+    let mut provider_close_rx =
+        register_active_websocket_connection(observation.provider_id, &observation.trace_id);
+    let relay_metadata = relay_websocket_messages(
+        client_socket,
+        upstream_socket,
+        &observation,
+        &mut provider_close_rx,
+    )
+    .await;
+    unregister_active_websocket_connection(observation.provider_id, &observation.trace_id);
     let ttfb_ms = relay_metadata.first_token_ms;
     record_websocket_request_end(
         observation,
         WebsocketCompletion::success(ttfb_ms),
         relay_metadata,
     );
+}
+
+pub(in crate::gateway) fn close_active_provider_websockets(provider_id: i64) -> usize {
+    let registry = WEBSOCKET_ACTIVE_CONNECTIONS.get_or_init(|| Mutex::new(HashMap::new()));
+    let Ok(mut registry) = registry.lock() else {
+        return 0;
+    };
+    let Some(connections) = registry.remove(&provider_id) else {
+        return 0;
+    };
+    let count = connections.len();
+    for tx in connections.into_values() {
+        let _ = tx.send(1);
+    }
+    count
+}
+
+fn register_active_websocket_connection(provider_id: i64, trace_id: &str) -> watch::Receiver<u64> {
+    let (tx, rx) = watch::channel(0);
+    let registry = WEBSOCKET_ACTIVE_CONNECTIONS.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(mut registry) = registry.lock() {
+        registry
+            .entry(provider_id)
+            .or_default()
+            .insert(trace_id.to_string(), tx);
+    }
+    rx
+}
+
+fn unregister_active_websocket_connection(provider_id: i64, trace_id: &str) {
+    let Some(registry) = WEBSOCKET_ACTIVE_CONNECTIONS.get() else {
+        return;
+    };
+    let Ok(mut registry) = registry.lock() else {
+        return;
+    };
+    let Some(connections) = registry.get_mut(&provider_id) else {
+        return;
+    };
+    connections.remove(trace_id);
+    if connections.is_empty() {
+        registry.remove(&provider_id);
+    }
 }
 
 fn emit_websocket_request_start<R: tauri::Runtime>(observation: &WebsocketObservation<R>) {
@@ -977,6 +1032,7 @@ async fn relay_websocket_messages<R: tauri::Runtime>(
     client_socket: WebSocket,
     upstream_socket: UpstreamWsStream,
     observation: &WebsocketObservation<R>,
+    provider_close_rx: &mut watch::Receiver<u64>,
 ) -> WebsocketRelayMetadata {
     let (mut client_tx, mut client_rx) = client_socket.split();
     let (mut upstream_tx, mut upstream_rx) = upstream_socket.split();
@@ -991,6 +1047,15 @@ async fn relay_websocket_messages<R: tauri::Runtime>(
 
     loop {
         tokio::select! {
+            changed = provider_close_rx.changed() => {
+                if changed.is_ok() {
+                    emit_websocket_relay_debug(
+                        observation,
+                        "websocket provider config changed, closing active connection",
+                    );
+                }
+                break;
+            }
             _ = heartbeat.tick() => {
                 emit_websocket_progress_event(observation);
             }
@@ -1805,6 +1870,27 @@ mod tests {
 
         assert!(websocket_turn_excluded_from_stats(&input_only_turn));
         assert!(!websocket_turn_excluded_from_stats(&answered_turn));
+    }
+
+    #[test]
+    fn active_provider_websocket_registry_closes_registered_connections() {
+        let provider_id = 9_001_001;
+        let mut close_rx = register_active_websocket_connection(provider_id, "trace-close");
+
+        assert_eq!(close_active_provider_websockets(provider_id), 1);
+        assert!(close_rx.has_changed().expect("close signal available"));
+        assert_eq!(*close_rx.borrow_and_update(), 1);
+        assert_eq!(close_active_provider_websockets(provider_id), 0);
+    }
+
+    #[test]
+    fn active_provider_websocket_registry_unregisters_finished_connections() {
+        let provider_id = 9_001_002;
+        let close_rx = register_active_websocket_connection(provider_id, "trace-finished");
+        unregister_active_websocket_connection(provider_id, "trace-finished");
+
+        assert_eq!(close_active_provider_websockets(provider_id), 0);
+        assert!(close_rx.has_changed().is_err());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src-tauri/src/gateway/routes.rs
+++ b/src-tauri/src/gateway/routes.rs
@@ -1,6 +1,9 @@
 use axum::{
     body::Body,
-    extract::{Path, State},
+    extract::{
+        ws::{rejection::WebSocketUpgradeRejection, WebSocketUpgrade},
+        Path, State,
+    },
     http::Request,
     response::Response,
     routing::{any, get},
@@ -8,7 +11,7 @@ use axum::{
 };
 use serde::Serialize;
 
-use super::proxy::proxy_impl;
+use super::proxy::{proxy_impl, proxy_websocket_impl};
 use super::runtime::GatewayAppState;
 use super::util::now_unix_seconds;
 
@@ -36,6 +39,7 @@ async fn root() -> &'static str {
 async fn proxy_cli_any<R>(
     State(state): State<GatewayAppState<R>>,
     Path((cli_key, path)): Path<(String, String)>,
+    ws: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
     req: Request<Body>,
 ) -> Response
 where
@@ -47,12 +51,16 @@ where
     } else {
         format!("/{path}")
     };
-    proxy_impl(state, cli_key, forwarded_path, req).await
+    match ws {
+        Ok(ws) => proxy_websocket_impl(state, cli_key, forwarded_path, ws, req).await,
+        Err(_) => proxy_impl(state, cli_key, forwarded_path, req).await,
+    }
 }
 
 async fn proxy_cli_with_provider_any<R>(
     State(state): State<GatewayAppState<R>>,
     Path((cli_key, provider_id, path)): Path<(String, i64, String)>,
+    ws: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
     mut req: Request<Body>,
 ) -> Response
 where
@@ -69,12 +77,16 @@ where
         format!("/{path}")
     };
 
-    proxy_impl(state, cli_key, forwarded_path, req).await
+    match ws {
+        Ok(ws) => proxy_websocket_impl(state, cli_key, forwarded_path, ws, req).await,
+        Err(_) => proxy_impl(state, cli_key, forwarded_path, req).await,
+    }
 }
 
 async fn proxy_openai_v1_any<R>(
     State(state): State<GatewayAppState<R>>,
     Path(path): Path<String>,
+    ws: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
     req: Request<Body>,
 ) -> Response
 where
@@ -86,18 +98,27 @@ where
     } else {
         format!("/v1/{path}")
     };
-    proxy_impl(state, "codex".to_string(), forwarded_path, req).await
+    match ws {
+        Ok(ws) => proxy_websocket_impl(state, "codex".to_string(), forwarded_path, ws, req).await,
+        Err(_) => proxy_impl(state, "codex".to_string(), forwarded_path, req).await,
+    }
 }
 
 async fn proxy_openai_v1_root<R>(
     State(state): State<GatewayAppState<R>>,
+    ws: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
     req: Request<Body>,
 ) -> Response
 where
     R: tauri::Runtime + 'static,
     R::Handle: Unpin,
 {
-    proxy_impl(state, "codex".to_string(), "/v1".to_string(), req).await
+    match ws {
+        Ok(ws) => {
+            proxy_websocket_impl(state, "codex".to_string(), "/v1".to_string(), ws, req).await
+        }
+        Err(_) => proxy_impl(state, "codex".to_string(), "/v1".to_string(), req).await,
+    }
 }
 
 pub(super) fn build_router<R>(state: GatewayAppState<R>) -> Router

--- a/src-tauri/src/gateway/routes.rs
+++ b/src-tauri/src/gateway/routes.rs
@@ -435,6 +435,7 @@ mod tests {
                 source_provider_id: None,
                 bridge_type: None,
                 stream_idle_timeout_seconds: None,
+                supports_websockets: None,
             },
         )
         .expect("insert provider")
@@ -481,6 +482,7 @@ mod tests {
                 source_provider_id: None,
                 bridge_type: None,
                 stream_idle_timeout_seconds: None,
+                supports_websockets: None,
             },
         )
         .expect("insert oauth provider")
@@ -514,6 +516,7 @@ mod tests {
                 source_provider_id: Some(source_provider_id),
                 bridge_type: Some("cx2cc".to_string()),
                 stream_idle_timeout_seconds: None,
+                supports_websockets: None,
             },
         )
         .expect("insert cx2cc bridge provider")

--- a/src-tauri/src/infra/cli_proxy/codex.rs
+++ b/src-tauri/src/infra/cli_proxy/codex.rs
@@ -11,6 +11,8 @@ use super::{
 };
 
 pub(super) const CODEX_PROVIDER_KEY: &str = "aio";
+/// Provider key used when remote_compaction is enabled (Codex requires "OpenAI" for Remote Compact).
+const CODEX_REMOTE_COMPACTION_PROVIDER_KEY: &str = "OpenAI";
 
 pub(super) fn codex_config_path<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
@@ -710,13 +712,17 @@ fn build_codex_config_toml_with_auth_strategy(
         input.lines().map(|l| l.to_string()).collect()
     };
 
-    upsert_root_model_provider(&mut lines, CODEX_PROVIDER_KEY);
+    let provider_key = codex_managed_provider_key_for_current_config(&lines);
+    upsert_root_model_provider(&mut lines, provider_key);
     if oauth_compatible {
         remove_root_preferred_auth_method_if_api_key(&mut lines);
     } else {
         upsert_root_preferred_auth_method(&mut lines, "apikey");
     }
-    upsert_model_provider_base_table(&mut lines, CODEX_PROVIDER_KEY, base_url);
+    if provider_key == CODEX_REMOTE_COMPACTION_PROVIDER_KEY {
+        remove_model_provider_section(&mut lines, CODEX_PROVIDER_KEY);
+    }
+    upsert_model_provider_base_table(&mut lines, provider_key, base_url);
     if platform == CodexConfigPlatform::Windows {
         upsert_windows_sandbox(&mut lines);
     }
@@ -724,6 +730,57 @@ fn build_codex_config_toml_with_auth_strategy(
     let mut out = lines.join("\n");
     out.push('\n');
     Ok(out.into_bytes())
+}
+
+fn codex_managed_provider_key_for_current_config(lines: &[String]) -> &'static str {
+    if codex_config_remote_compaction_enabled(lines)
+        || codex_config_root_model_provider_is(lines, CODEX_REMOTE_COMPACTION_PROVIDER_KEY)
+    {
+        CODEX_REMOTE_COMPACTION_PROVIDER_KEY
+    } else {
+        CODEX_PROVIDER_KEY
+    }
+}
+
+fn codex_config_remote_compaction_enabled(lines: &[String]) -> bool {
+    let mut in_features = false;
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_features = trimmed == "[features]";
+            continue;
+        }
+        if !in_features || trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        if key.trim() == "remote_compaction" {
+            return value.trim().trim_end_matches(',') == "true";
+        }
+    }
+    false
+}
+
+fn codex_config_root_model_provider_is(lines: &[String], provider_key: &str) -> bool {
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            return false;
+        }
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "model_provider" {
+            continue;
+        }
+        return value.trim().trim_matches('"') == provider_key;
+    }
+    false
 }
 
 pub(super) fn build_codex_auth_json(current: Option<Vec<u8>>) -> AppResult<Vec<u8>> {
@@ -756,9 +813,6 @@ pub(super) fn build_codex_auth_json(current: Option<Vec<u8>>) -> AppResult<Vec<u
     out.push(b'\n');
     Ok(out)
 }
-
-/// Provider key used when remote_compaction is enabled (Codex requires "OpenAI" for Remote Compact).
-const CODEX_REMOTE_COMPACTION_PROVIDER_KEY: &str = "OpenAI";
 
 /// Check whether Codex proxy config is currently applied.
 /// Supports both normal mode (provider key = "aio") and remote_compaction mode (provider key = "OpenAI").

--- a/src-tauri/src/infra/cli_proxy/codex.rs
+++ b/src-tauri/src/infra/cli_proxy/codex.rs
@@ -434,6 +434,7 @@ fn insert_model_provider_section(
         format!("base_url = \"{base_url}\""),
         "wire_api = \"responses\"".to_string(),
         "requires_openai_auth = true".to_string(),
+        "supports_websockets = true".to_string(),
     ];
 
     lines.splice(insert_at..insert_at, section);
@@ -496,7 +497,7 @@ fn patch_model_provider_base_table(
         };
 
         match k.trim() {
-            "name" | "base_url" | "wire_api" | "requires_openai_auth" => {}
+            "name" | "base_url" | "wire_api" | "requires_openai_auth" | "supports_websockets" => {}
             _ => body.push(line.clone()),
         }
     }
@@ -506,6 +507,7 @@ fn patch_model_provider_base_table(
         format!("base_url = \"{base_url}\""),
         "wire_api = \"responses\"".to_string(),
         "requires_openai_auth = true".to_string(),
+        "supports_websockets = true".to_string(),
     ];
 
     let mut patched: Vec<String> = Vec::with_capacity(managed.len() + body.len());

--- a/src-tauri/src/infra/cli_proxy/tests.rs
+++ b/src-tauri/src/infra/cli_proxy/tests.rs
@@ -271,6 +271,7 @@ foo = "bar"
     let s = String::from_utf8(out).expect("utf8");
 
     assert!(s.contains("base_url = \"http://new/v1\""), "{s}");
+    assert!(s.contains("supports_websockets = true"), "{s}");
     assert!(
         s.contains("[model_providers.aio.projects.\"C:\\\\work\"]"),
         "{s}"
@@ -304,6 +305,7 @@ trusted_roots = ["C:\\work"]
     let s = String::from_utf8(out).expect("utf8");
 
     assert!(s.contains("base_url = \"http://new/v1\""), "{s}");
+    assert!(s.contains("supports_websockets = true"), "{s}");
     assert!(s.contains("trusted_roots = [\"C:\\\\work\"]"), "{s}");
 }
 
@@ -333,6 +335,7 @@ trust_level = "trusted"
         + s.matches("[model_providers.'aio']").count();
     assert_eq!(count, 1, "{s}");
     assert!(s.contains("base_url = \"http://new/v1\""), "{s}");
+    assert!(s.contains("supports_websockets = true"), "{s}");
     assert!(
         s.contains("[model_providers.aio.projects.\"C:\\\\work\"]"),
         "{s}"
@@ -697,6 +700,7 @@ fn enabling_codex_oauth_compatible_proxy_writes_config_only_and_does_not_create_
         "{config}"
     );
     assert!(config.contains("requires_openai_auth = true"), "{config}");
+    assert!(config.contains("supports_websockets = true"), "{config}");
     assert!(!config.contains("preferred_auth_method"), "{config}");
     assert!(
         !auth_path.exists(),

--- a/src-tauri/src/infra/cli_proxy/tests.rs
+++ b/src-tauri/src/infra/cli_proxy/tests.rs
@@ -310,6 +310,60 @@ trusted_roots = ["C:\\work"]
 }
 
 #[test]
+fn codex_proxy_uses_openai_provider_when_remote_compaction_is_enabled() {
+    let input = r#"model_provider = "OpenAI"
+
+[model_providers.OpenAI]
+name = "OpenAI"
+base_url = "http://old/v1"
+wire_api = "responses"
+
+[features]
+remote_compaction = true
+responses_websockets_v2 = true
+"#;
+
+    let out = build_codex_config_toml(
+        Some(input.as_bytes().to_vec()),
+        "http://new/v1",
+        CodexConfigPlatform::Other,
+    )
+    .expect("build");
+    let s = String::from_utf8(out).expect("utf8");
+
+    assert!(s.contains("model_provider = \"OpenAI\""), "{s}");
+    assert!(s.contains("[model_providers.OpenAI]"), "{s}");
+    assert!(s.contains("name = \"OpenAI\""), "{s}");
+    assert!(s.contains("base_url = \"http://new/v1\""), "{s}");
+    assert!(s.contains("supports_websockets = true"), "{s}");
+    assert!(s.contains("remote_compaction = true"), "{s}");
+    assert!(!s.contains("[model_providers.aio]"), "{s}");
+}
+
+#[test]
+fn codex_proxy_keeps_openai_provider_if_model_provider_already_openai() {
+    let input = r#"model_provider = "OpenAI"
+
+[model_providers.OpenAI]
+name = "OpenAI"
+base_url = "http://old/v1"
+"#;
+
+    let out = build_codex_config_toml(
+        Some(input.as_bytes().to_vec()),
+        "http://new/v1",
+        CodexConfigPlatform::Other,
+    )
+    .expect("build");
+    let s = String::from_utf8(out).expect("utf8");
+
+    assert!(s.contains("model_provider = \"OpenAI\""), "{s}");
+    assert!(s.contains("[model_providers.OpenAI]"), "{s}");
+    assert!(s.contains("supports_websockets = true"), "{s}");
+    assert!(!s.contains("[model_providers.aio]"), "{s}");
+}
+
+#[test]
 fn codex_proxy_dedupes_multiple_base_tables() {
     let input = r#"
 [model_providers."aio"]

--- a/src-tauri/src/infra/codex_config/parsing.rs
+++ b/src-tauri/src/infra/codex_config/parsing.rs
@@ -128,6 +128,30 @@ pub(super) fn key_table_and_name(
     (table, k)
 }
 
+pub(super) fn is_aio_model_provider_table(table: &str) -> bool {
+    matches!(
+        table.trim(),
+        "model_providers.aio"
+            | "model_providers.\"aio\""
+            | "model_providers.'aio'"
+            | "\"model_providers\".aio"
+            | "\"model_providers\".\"aio\""
+            | "\"model_providers\".'aio'"
+            | "'model_providers'.aio"
+            | "'model_providers'.\"aio\""
+            | "'model_providers'.'aio'"
+            | "model_providers.OpenAI"
+            | "model_providers.\"OpenAI\""
+            | "model_providers.'OpenAI'"
+            | "\"model_providers\".OpenAI"
+            | "\"model_providers\".\"OpenAI\""
+            | "\"model_providers\".'OpenAI'"
+            | "'model_providers'.OpenAI"
+            | "'model_providers'.\"OpenAI\""
+            | "'model_providers'.'OpenAI'"
+    )
+}
+
 pub(super) fn is_allowed_value(value: &str, allowed: &[&str]) -> bool {
     allowed.iter().any(|v| v.eq_ignore_ascii_case(value))
 }
@@ -244,6 +268,7 @@ pub(super) fn make_state_from_bytes(
         service_tier: None,
 
         sandbox_workspace_write_network_access: None,
+        model_providers_aio_supports_websockets: None,
 
         features_unified_exec: None,
         features_shell_snapshot: None,
@@ -358,6 +383,10 @@ pub(super) fn make_state_from_bytes(
             ("features", "multi_agent") => state.features_multi_agent = parse_bool(&raw_value),
 
             _ => {}
+        }
+
+        if is_aio_model_provider_table(table) && key == "supports_websockets" {
+            state.model_providers_aio_supports_websockets = parse_bool(&raw_value);
         }
 
         update_multiline_string_state(raw_line, &mut in_multiline_double, &mut in_multiline_single);

--- a/src-tauri/src/infra/codex_config/patching.rs
+++ b/src-tauri/src/infra/codex_config/patching.rs
@@ -1,8 +1,8 @@
 //! Config.toml mutation (line-level patching) for Codex configuration.
 
 use super::parsing::{
-    is_any_table_header_line, normalize_key, parse_assignment, strip_toml_comment,
-    update_multiline_string_state, validate_enum_or_empty,
+    is_aio_model_provider_table, is_any_table_header_line, normalize_key, parse_assignment,
+    parse_table_header, strip_toml_comment, update_multiline_string_state, validate_enum_or_empty,
 };
 use super::types::CodexConfigPatch;
 
@@ -144,6 +144,82 @@ fn find_table_block(lines: &[String], table_header: &str) -> Option<(usize, usiz
         .map(|offset| start + 1 + offset)
         .unwrap_or(lines.len());
     Some((start, end))
+}
+
+fn find_aio_model_provider_table_block(lines: &[String]) -> Option<(usize, usize)> {
+    let start = lines.iter().position(|line| {
+        let cleaned = strip_toml_comment(line).trim();
+        parse_table_header(cleaned).is_some_and(|table| is_aio_model_provider_table(&table))
+    })?;
+    let end = lines[start.saturating_add(1)..]
+        .iter()
+        .position(|line| line.trim().starts_with('['))
+        .map(|offset| start + 1 + offset)
+        .unwrap_or(lines.len());
+    Some((start, end))
+}
+
+fn upsert_aio_model_provider_supports_websockets(lines: &mut Vec<String>, enabled: bool) {
+    let value = enabled.then(|| "true".to_string());
+
+    if find_aio_model_provider_table_block(lines).is_none() {
+        let Some(value) = value else {
+            return;
+        };
+        if !lines.is_empty() && !lines.last().unwrap_or(&String::new()).trim().is_empty() {
+            lines.push(String::new());
+        }
+        lines.push("[model_providers.aio]".to_string());
+        lines.push(format!("supports_websockets = {value}"));
+        return;
+    }
+
+    let Some((start, end)) = find_aio_model_provider_table_block(lines) else {
+        return;
+    };
+    let mut found_idx: Option<usize> = None;
+    for (idx, line) in lines
+        .iter()
+        .enumerate()
+        .take(end.min(lines.len()))
+        .skip(start + 1)
+    {
+        let cleaned = strip_toml_comment(line).trim();
+        if cleaned.is_empty() || cleaned.starts_with('#') {
+            continue;
+        }
+        let Some((k, _)) = parse_assignment(cleaned) else {
+            continue;
+        };
+        if normalize_key(&k) == "supports_websockets" {
+            found_idx = Some(idx);
+            break;
+        }
+    }
+
+    match (found_idx, value) {
+        (Some(idx), Some(v)) => lines[idx] = format!("supports_websockets = {v}"),
+        (Some(idx), None) => {
+            lines.remove(idx);
+        }
+        (None, Some(v)) => {
+            let mut insert_at = end.min(lines.len());
+            while insert_at > start + 1 && lines[insert_at - 1].trim().is_empty() {
+                insert_at -= 1;
+            }
+            lines.insert(insert_at, format!("supports_websockets = {v}"));
+        }
+        (None, None) => {}
+    }
+
+    if let Some((start, end)) = find_aio_model_provider_table_block(lines) {
+        let has_body_content = lines[start + 1..end]
+            .iter()
+            .any(|line| !line.trim().is_empty() && !line.trim_start().starts_with('#'));
+        if !has_body_content {
+            lines.drain(start..end);
+        }
+    }
 }
 
 fn upsert_table_keys(lines: &mut Vec<String>, table: &str, items: Vec<(&str, Option<String>)>) {
@@ -770,6 +846,10 @@ pub(super) fn patch_config_toml(
             &["network_access"],
             vec![("network_access", Some(v.to_string()))],
         );
+    }
+
+    if let Some(v) = patch.model_providers_aio_supports_websockets {
+        upsert_aio_model_provider_supports_websockets(&mut lines, v);
     }
 
     // features.*

--- a/src-tauri/src/infra/codex_config/tests.rs
+++ b/src-tauri/src/infra/codex_config/tests.rs
@@ -13,6 +13,7 @@ fn empty_patch() -> CodexConfigPatch {
         model_auto_compact_token_limit: None,
         service_tier: None,
         sandbox_workspace_write_network_access: None,
+        model_providers_aio_supports_websockets: None,
         features_unified_exec: None,
         features_shell_snapshot: None,
         features_apply_patch_freeform: None,
@@ -291,6 +292,55 @@ fn patch_writes_personality_and_websocket_feature() {
 }
 
 #[test]
+fn patch_writes_aio_model_provider_websocket_support() {
+    let input = r#"model_provider = "aio"
+
+[model_providers.aio]
+name = "aio"
+base_url = "http://127.0.0.1:37124/v1"
+wire_api = "responses"
+"#;
+
+    let out = patch_config_toml(
+        Some(input.as_bytes().to_vec()),
+        CodexConfigPatch {
+            model_providers_aio_supports_websockets: Some(true),
+            ..empty_patch()
+        },
+    )
+    .expect("patch_config_toml");
+
+    let s = String::from_utf8(out).expect("utf8");
+    assert!(s.contains("[model_providers.aio]"), "{s}");
+    assert!(s.contains("supports_websockets = true"), "{s}");
+}
+
+#[test]
+fn patch_removes_aio_model_provider_websocket_support_when_disabled() {
+    let input = r#"model_provider = "aio"
+
+[model_providers.aio]
+name = "aio"
+base_url = "http://127.0.0.1:37124/v1"
+wire_api = "responses"
+supports_websockets = true
+"#;
+
+    let out = patch_config_toml(
+        Some(input.as_bytes().to_vec()),
+        CodexConfigPatch {
+            model_providers_aio_supports_websockets: Some(false),
+            ..empty_patch()
+        },
+    )
+    .expect("patch_config_toml");
+
+    let s = String::from_utf8(out).expect("utf8");
+    assert!(!s.contains("supports_websockets ="), "{s}");
+    assert!(s.contains("[model_providers.aio]"), "{s}");
+}
+
+#[test]
 fn patch_deletes_personality_and_websocket_feature_when_disabled() {
     let input = r#"personality = "friendly"
 
@@ -523,12 +573,16 @@ fn parse_reads_personality_and_websocket_feature() {
 
 [features]
 responses_websockets_v2 = true
+
+[model_providers.aio]
+supports_websockets = true
 "#;
 
     let state = make_test_state(input).expect("make_test_state");
 
     assert_eq!(state.personality.as_deref(), Some("friendly"));
     assert_eq!(state.features_responses_websockets_v2, Some(true));
+    assert_eq!(state.model_providers_aio_supports_websockets, Some(true));
 }
 
 #[test]

--- a/src-tauri/src/infra/codex_config/types.rs
+++ b/src-tauri/src/infra/codex_config/types.rs
@@ -26,6 +26,8 @@ pub struct CodexConfigState {
 
     pub sandbox_workspace_write_network_access: Option<bool>,
 
+    pub model_providers_aio_supports_websockets: Option<bool>,
+
     pub features_unified_exec: Option<bool>,
     pub features_shell_snapshot: Option<bool>,
     pub features_apply_patch_freeform: Option<bool>,
@@ -64,6 +66,8 @@ pub struct CodexConfigPatch {
     pub service_tier: Option<String>,
 
     pub sandbox_workspace_write_network_access: Option<bool>,
+
+    pub model_providers_aio_supports_websockets: Option<bool>,
 
     pub features_unified_exec: Option<bool>,
     pub features_shell_snapshot: Option<bool>,

--- a/src-tauri/src/infra/config_migrate/export.rs
+++ b/src-tauri/src/infra/config_migrate/export.rs
@@ -83,7 +83,8 @@ SELECT
   tags_json,
   note,
   source_provider_id,
-  bridge_type
+  bridge_type,
+  supports_websockets
 FROM providers
 ORDER BY cli_key ASC, sort_order ASC, id ASC
 "#,
@@ -146,6 +147,7 @@ ORDER BY cli_key ASC, sort_order ASC, id ASC
                     .get::<_, Option<i64>>("source_provider_id")?
                     .and_then(|source_id| provider_cli_key_by_id.get(&source_id).cloned()),
                 bridge_type: row.get("bridge_type")?,
+                supports_websockets: row.get::<_, i64>("supports_websockets")? != 0,
             })
         })
         .map_err(|e| db_err!("failed to query providers for export: {e}"))?;

--- a/src-tauri/src/infra/config_migrate/import.rs
+++ b/src-tauri/src/infra/config_migrate/import.rs
@@ -79,6 +79,7 @@ pub(super) fn import_into_transaction(
             source_provider_id,
             source_provider_cli_key,
             bridge_type,
+            supports_websockets,
         } = provider;
 
         let sort_order = provider_sort_order_by_cli_key
@@ -128,9 +129,10 @@ INSERT INTO providers(
   oauth_last_error,
   source_provider_id,
   bridge_type,
+  supports_websockets,
   created_at,
   updated_at
-) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, NULL, ?36, ?37, ?37)
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, NULL, ?36, ?37, ?38, ?38)
 "#,
             params![
                 cli_key,
@@ -169,6 +171,7 @@ INSERT INTO providers(
                 oauth_last_refreshed_at,
                 oauth_last_error,
                 bridge_type,
+                bool_to_int(supports_websockets),
                 now,
             ],
         )

--- a/src-tauri/src/infra/config_migrate/mod.rs
+++ b/src-tauri/src/infra/config_migrate/mod.rs
@@ -99,6 +99,8 @@ pub struct ProviderExport {
     pub source_provider_id: Option<i64>,
     pub source_provider_cli_key: Option<String>,
     pub bridge_type: Option<String>,
+    #[serde(default)]
+    pub supports_websockets: bool,
 }
 
 #[derive(Serialize, Deserialize, specta::Type)]

--- a/src-tauri/src/infra/config_migrate/tests.rs
+++ b/src-tauri/src/infra/config_migrate/tests.rs
@@ -378,6 +378,7 @@ fn config_import_v2_restores_full_prompt_and_skill_payload() {
             source_provider_id: None,
             source_provider_cli_key: None,
             bridge_type: None,
+            supports_websockets: true,
         }],
         sort_modes: Vec::new(),
         sort_mode_active: HashMap::new(),

--- a/src-tauri/src/infra/db/migrations/ensure.rs
+++ b/src-tauri/src/infra/db/migrations/ensure.rs
@@ -21,6 +21,7 @@ pub(super) fn apply_ensure_patches(conn: &mut Connection) -> crate::shared::erro
     ensure_provider_bridge_type(conn)?;
     ensure_request_logs_extended_columns(conn)?;
     ensure_provider_stream_idle_timeout(conn)?;
+    ensure_provider_supports_websockets(conn)?;
     ensure_skills_update_columns(conn)?;
     Ok(())
 }
@@ -861,6 +862,34 @@ fn ensure_provider_stream_idle_timeout(conn: &mut Connection) -> Result<(), Stri
             "ALTER TABLE providers ADD COLUMN stream_idle_timeout_seconds INTEGER DEFAULT NULL;",
         )
         .map_err(|e| format!("failed to ensure providers.stream_idle_timeout_seconds: {e}"))?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// ensure_provider_supports_websockets
+// ---------------------------------------------------------------------------
+
+fn ensure_provider_supports_websockets(conn: &mut Connection) -> Result<(), String> {
+    let has_providers_table: bool = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'providers' LIMIT 1",
+            [],
+            |_| Ok(true),
+        )
+        .optional()
+        .map_err(|e| format!("failed to query sqlite_master: {e}"))?
+        .unwrap_or(false);
+
+    if !has_providers_table {
+        return Ok(());
+    }
+
+    if !column_exists(conn, "providers", "supports_websockets")? {
+        conn.execute_batch(
+            "ALTER TABLE providers ADD COLUMN supports_websockets INTEGER NOT NULL DEFAULT 0;",
+        )
+        .map_err(|e| format!("failed to ensure providers.supports_websockets: {e}"))?;
     }
     Ok(())
 }

--- a/src-tauri/src/infra/db/migrations/mod.rs
+++ b/src-tauri/src/infra/db/migrations/mod.rs
@@ -9,10 +9,11 @@ mod v28_to_v29;
 mod v29_to_v30;
 mod v30_to_v31;
 mod v31_to_v32;
+mod v32_to_v33;
 
 use rusqlite::Connection;
 
-const LATEST_SCHEMA_VERSION: i64 = 32;
+const LATEST_SCHEMA_VERSION: i64 = 33;
 const MAX_COMPAT_SCHEMA_VERSION: i64 = 34;
 const MIN_SUPPORTED_SCHEMA_VERSION: i64 = 25;
 
@@ -53,6 +54,7 @@ pub(super) fn apply_migrations(conn: &mut Connection) -> crate::shared::error::A
             29 => v29_to_v30::migrate_v29_to_v30(conn)?,
             30 => v30_to_v31::migrate_v30_to_v31(conn)?,
             31 => v31_to_v32::migrate_v31_to_v32(conn)?,
+            32 => v32_to_v33::migrate_v32_to_v33(conn)?,
             v => {
                 tracing::error!(
                     version = v,

--- a/src-tauri/src/infra/db/migrations/v32_to_v33.rs
+++ b/src-tauri/src/infra/db/migrations/v32_to_v33.rs
@@ -1,0 +1,49 @@
+//! Usage: SQLite migration v32->v33 - Add provider websocket support flag.
+
+use crate::shared::time::now_unix_seconds;
+use rusqlite::Connection;
+
+pub(super) fn migrate_v32_to_v33(conn: &mut Connection) -> Result<(), String> {
+    const VERSION: i64 = 33;
+    let tx = conn
+        .transaction()
+        .map_err(|e| format!("failed to start sqlite transaction: {e}"))?;
+
+    let has_table: bool = tx
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='providers'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0)
+        > 0;
+
+    if has_table {
+        let alter_stmt =
+            "ALTER TABLE providers ADD COLUMN supports_websockets INTEGER NOT NULL DEFAULT 0";
+
+        match tx.execute_batch(alter_stmt) {
+            Ok(()) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => return Err(format!("failed to alter providers table: {e}")),
+        }
+    }
+
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL)",
+    )
+    .map_err(|e| format!("failed to create schema_migrations table: {e}"))?;
+    let now = now_unix_seconds();
+    tx.execute(
+        "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+        [VERSION, now],
+    )
+    .map_err(|e| format!("failed to insert schema_migrations row for v{VERSION}: {e}"))?;
+
+    super::set_user_version(&tx, VERSION)?;
+
+    tx.commit()
+        .map_err(|e| format!("failed to commit sqlite transaction: {e}"))?;
+
+    Ok(())
+}

--- a/src-tauri/src/infra/request_logs/costing.rs
+++ b/src-tauri/src/infra/request_logs/costing.rs
@@ -11,7 +11,7 @@ pub(super) fn cost_usd_from_femto(cost_usd_femto: Option<i64>) -> Option<f64> {
 }
 
 pub(super) fn is_success_status(status: Option<i64>, error_code: Option<&str>) -> bool {
-    status.is_some_and(|v| (200..300).contains(&v)) && error_code.is_none()
+    status.is_some_and(|v| v == 101 || (200..300).contains(&v)) && error_code.is_none()
 }
 
 pub(super) fn usage_for_cost(item: &RequestLogInsert) -> cost::CostUsage {

--- a/src-tauri/src/test_support.rs
+++ b/src-tauri/src/test_support.rs
@@ -313,6 +313,7 @@ pub fn provider_upsert_json<R: tauri::Runtime>(
             source_provider_id: None,
             bridge_type: None,
             stream_idle_timeout_seconds: None,
+            supports_websockets: None,
         },
     )?;
     serialize_json(provider)

--- a/src/components/cli-manager/tabs/CodexTab.tsx
+++ b/src/components/cli-manager/tabs/CodexTab.tsx
@@ -1157,6 +1157,24 @@ export function CliManagerCodexTab({
                     disabled={saving}
                   />
                 </SettingItem>
+
+                <SettingItem
+                  label="supports_websockets"
+                  subtitle="Write supports_websockets under the aio model provider table so Codex can negotiate WebSocket-capable upstreams."
+                >
+                  <Switch
+                    checked={boolOrDefault(
+                      codexConfig.model_providers_aio_supports_websockets,
+                      false
+                    )}
+                    onCheckedChange={(checked) =>
+                      void persistCodexConfig({
+                        model_providers_aio_supports_websockets: checked,
+                      })
+                    }
+                    disabled={saving}
+                  />
+                </SettingItem>
               </div>
             </div>
 

--- a/src/components/cli-manager/tabs/CodexTab.tsx
+++ b/src/components/cli-manager/tabs/CodexTab.tsx
@@ -1317,7 +1317,10 @@ export function CliManagerCodexTab({
                   <Switch
                     checked={boolOrDefault(codexConfig.features_responses_websockets_v2, false)}
                     onCheckedChange={(checked) =>
-                      void persistCodexConfig({ features_responses_websockets_v2: checked })
+                      void persistCodexConfig({
+                        features_responses_websockets_v2: checked,
+                        ...(checked ? { model_providers_aio_supports_websockets: true } : {}),
+                      })
                     }
                     disabled={saving}
                   />

--- a/src/components/cli-manager/tabs/__tests__/ClaudeOAuthCard.test.tsx
+++ b/src/components/cli-manager/tabs/__tests__/ClaudeOAuthCard.test.tsx
@@ -60,6 +60,7 @@ function makeProvider(overrides: Partial<ProviderSummary> = {}): ProviderSummary
     api_key_configured: overrides.api_key_configured ?? false,
     ...overrides,
     stream_idle_timeout_seconds: overrides.stream_idle_timeout_seconds ?? null,
+    supports_websockets: overrides.supports_websockets ?? false,
   };
 }
 

--- a/src/components/cli-manager/tabs/__tests__/CodexTab.test.tsx
+++ b/src/components/cli-manager/tabs/__tests__/CodexTab.test.tsx
@@ -65,6 +65,7 @@ function createCodexConfig(overrides: Partial<any> = {}) {
     model_auto_compact_token_limit: null,
     service_tier: null,
     features_shell_snapshot: false,
+    model_providers_aio_supports_websockets: false,
     features_unified_exec: false,
     features_shell_tool: false,
     features_exec_policy: false,
@@ -149,6 +150,14 @@ describe("components/cli-manager/tabs/CodexTab", () => {
     fireEvent.click(within(websocketItem as HTMLElement).getByRole("switch"));
     expect(persistCodexConfig).toHaveBeenCalledWith({
       features_responses_websockets_v2: true,
+    });
+
+    const providerWebsocketItem =
+      screen.getByText("supports_websockets").parentElement?.parentElement;
+    expect(providerWebsocketItem).toBeTruthy();
+    fireEvent.click(within(providerWebsocketItem as HTMLElement).getByRole("switch"));
+    expect(persistCodexConfig).toHaveBeenCalledWith({
+      model_providers_aio_supports_websockets: true,
     });
 
     // Radio group

--- a/src/components/cli-manager/tabs/__tests__/CodexTab.test.tsx
+++ b/src/components/cli-manager/tabs/__tests__/CodexTab.test.tsx
@@ -150,6 +150,7 @@ describe("components/cli-manager/tabs/CodexTab", () => {
     fireEvent.click(within(websocketItem as HTMLElement).getByRole("switch"));
     expect(persistCodexConfig).toHaveBeenCalledWith({
       features_responses_websockets_v2: true,
+      model_providers_aio_supports_websockets: true,
     });
 
     const providerWebsocketItem =

--- a/src/components/cli-manager/tabs/__tests__/tabs.coverage.test.tsx
+++ b/src/components/cli-manager/tabs/__tests__/tabs.coverage.test.tsx
@@ -140,6 +140,7 @@ describe("cli-manager tabs (coverage)", () => {
           model_auto_compact_token_limit: 900000,
           service_tier: "fast",
           sandbox_workspace_write_network_access: false,
+          model_providers_aio_supports_websockets: true,
           features_unified_exec: true,
           features_shell_snapshot: true,
           features_apply_patch_freeform: true,

--- a/src/components/home/HomeLogShared.tsx
+++ b/src/components/home/HomeLogShared.tsx
@@ -127,6 +127,14 @@ export function hasClaudeModelMappingSpecialSetting(
   return false;
 }
 
+export function hasRequestLogSpecialSettingType(
+  specialSettingsJson: string | null | undefined,
+  type: string
+): boolean {
+  const settings = parseRequestLogSpecialSettings(specialSettingsJson);
+  return settings.some((setting) => setting.type === type);
+}
+
 export function formatClaudeModelMappingText(
   requestedModel: string | null | undefined,
   mapping: ClaudeModelMapping | null | undefined
@@ -196,7 +204,10 @@ export function buildRequestLogAuditMeta(log: RequestLogAuditInput): RequestLogA
   const settingTypes = new Set(settings.map((item) => item.type).filter(Boolean));
   const isWarmupIntercept = settingTypes.has("warmup_intercept");
   const isCliProxyGuard = settingTypes.has("cli_proxy_guard");
-  const isSuccessful = typeof log.status === "number" && log.status >= 200 && log.status < 300;
+  const isWebsocketProxy = settingTypes.has("websocket_proxy");
+  const isSuccessful =
+    typeof log.status === "number" &&
+    (log.status === 101 || (log.status >= 200 && log.status < 300));
   const isClientAbort =
     !isSuccessful &&
     (!!(log.error_code && CLIENT_ABORT_ERROR_CODES.has(log.error_code)) ||
@@ -222,6 +233,16 @@ export function buildRequestLogAuditMeta(log: RequestLogAuditInput): RequestLogA
         "代理守卫",
         "bg-orange-50/80 text-orange-700 ring-1 ring-inset ring-orange-500/10 dark:bg-orange-500/15 dark:text-orange-200 dark:ring-orange-400/20",
         "CLI 代理守卫提前处理了这次请求"
+      )
+    );
+  }
+
+  if (isWebsocketProxy) {
+    tags.push(
+      auditTag(
+        "WS",
+        "bg-indigo-50/80 text-indigo-700 ring-1 ring-inset ring-indigo-500/10 dark:bg-indigo-500/15 dark:text-indigo-200 dark:ring-indigo-400/20",
+        "WebSocket 代理请求"
       )
     );
   }
@@ -409,7 +430,8 @@ export function computeStatusBadge(input: {
 
   const isClientAbort = !!(input.errorCode && CLIENT_ABORT_ERROR_CODES.has(input.errorCode));
   const hasFailover = !!input.hasFailover;
-  const isSuccessStatus = input.status != null && input.status >= 200 && input.status < 400;
+  const isSuccessStatus =
+    input.status != null && (input.status === 101 || (input.status >= 200 && input.status < 400));
   const isError = input.status != null ? input.status >= 400 : input.errorCode != null;
 
   let text = STATUS_TEXT_UNKNOWN;

--- a/src/components/home/HomeRequestLogsPanel.tsx
+++ b/src/components/home/HomeRequestLogsPanel.tsx
@@ -48,6 +48,7 @@ import {
   getErrorCodeLabel,
   hasClaudeModelMappingSpecialSetting,
   hasPriorityServiceTierSpecialSetting,
+  hasRequestLogSpecialSettingType,
   resolveClaudeModelMappingFromSpecialSettings,
   resolveLiveTraceDurationMs,
   resolveLiveTraceProvider,
@@ -61,6 +62,7 @@ import {
   RefreshCw,
   ArrowUpRight,
   Loader2,
+  Wifi,
 } from "lucide-react";
 import { RealtimeTraceCards } from "./RealtimeTraceCards";
 import { CliBrandIcon } from "./CliBrandIcon";
@@ -90,6 +92,16 @@ function sessionFolderLookupKey(cliKey: string, sessionId: string | null | undef
   return `${cliKey}:${normalized}`;
 }
 
+function resolveSessionFolderForRequestLog(
+  log: RequestLogSummary,
+  trace: TraceSession | undefined,
+  folderLookupBySessionKey: Map<string, CliSessionsFolderLookupEntry>
+): CliSessionsFolderLookupEntry | null {
+  const sessionId = (log.session_id ?? trace?.session_id)?.trim();
+  const key = sessionFolderLookupKey(log.cli_key, sessionId);
+  return key ? (folderLookupBySessionKey.get(key) ?? null) : null;
+}
+
 function makeSortRequestLogsForDisplay(liveTraceIds: ReadonlySet<string>) {
   return (a: RequestLogSummary, b: RequestLogSummary) => {
     // Only treat a log as in-progress when the trace store still tracks it.
@@ -102,6 +114,44 @@ function makeSortRequestLogsForDisplay(liveTraceIds: ReadonlySet<string>) {
     if (aTsMs !== bTsMs) return bTsMs - aTsMs;
     return b.id - a.id;
   };
+}
+
+function isWebsocketAuditOnlyLog(log: RequestLogSummary) {
+  if (!hasRequestLogSpecialSettingType(log.special_settings_json, "websocket_proxy")) return false;
+  if (!log.excluded_from_stats) return false;
+  return (log.output_tokens ?? 0) <= 0;
+}
+
+function visibleRequestLogsForHomeList(requestLogs: RequestLogSummary[]) {
+  return requestLogs.filter((log) => !isWebsocketAuditOnlyLog(log));
+}
+
+function websocketConnectionGroupKey(log: RequestLogSummary) {
+  if (!hasRequestLogSpecialSettingType(log.special_settings_json, "websocket_proxy")) return null;
+  const sessionId = log.session_id?.trim();
+  if (!sessionId) return null;
+  return `${log.cli_key}:${sessionId}`;
+}
+
+function buildWebsocketReconnectCounts(requestLogs: RequestLogSummary[]) {
+  const ordered = requestLogs.slice().sort((a, b) => {
+    const aTs = requestLogCreatedAtMs(a);
+    const bTs = requestLogCreatedAtMs(b);
+    if (aTs !== bTs) return aTs - bTs;
+    return a.id - b.id;
+  });
+  const seenByGroup = new Map<string, number>();
+  const reconnectById = new Map<number, number>();
+
+  for (const log of ordered) {
+    const key = websocketConnectionGroupKey(log);
+    if (!key) continue;
+    const seen = seenByGroup.get(key) ?? 0;
+    if (seen > 0) reconnectById.set(log.id, seen);
+    seenByGroup.set(key, seen + 1);
+  }
+
+  return reconnectById;
 }
 
 function mergeTraceWithRequestLog(
@@ -175,6 +225,7 @@ type RequestLogCardProps = {
   compactMode: boolean;
   log: RequestLogSummary;
   liveTrace?: TraceSession;
+  reconnectCount?: number;
   nowMs: number;
   isSelected: boolean;
   sessionFolder?: CliSessionsFolderLookupEntry | null;
@@ -187,6 +238,7 @@ const RequestLogCard = memo(function RequestLogCard({
   compactMode,
   log,
   liveTrace,
+  reconnectCount,
   nowMs,
   isSelected,
   sessionFolder,
@@ -378,6 +430,16 @@ const RequestLogCard = memo(function RequestLogCard({
                   {getErrorCodeLabel(log.error_code)}
                 </span>
               )}
+
+              {reconnectCount ? (
+                <span
+                  className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md bg-cyan-50/80 px-2 py-0.5 text-[11px] font-semibold text-cyan-700 ring-1 ring-inset ring-cyan-500/10 dark:bg-cyan-500/15 dark:text-cyan-200 dark:ring-cyan-400/20"
+                  title="同一 session 的 WebSocket 已重新连接"
+                >
+                  <Wifi className="h-3 w-3 shrink-0" />
+                  Reconnect {reconnectCount}
+                </span>
+              ) : null}
 
               {auditMeta.tags.map((tag) => (
                 <span
@@ -853,12 +915,17 @@ const RequestLogsList = memo(function RequestLogsList({
   onSelectLogId,
 }: RequestLogsListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const websocketReconnectCounts = useMemo(
+    () => buildWebsocketReconnectCounts(requestLogs),
+    [requestLogs]
+  );
   const renderedRequestLogs = useMemo(() => {
-    if (realtimeTraceCandidates.length === 0) return requestLogs;
+    const visibleRequestLogs = visibleRequestLogsForHomeList(requestLogs);
+    if (realtimeTraceCandidates.length === 0) return visibleRequestLogs;
     const realtimeTraceIds = new Set(
       realtimeTraceCandidates.map((trace) => trace.trace_id?.trim()).filter(Boolean)
     );
-    return requestLogs.filter((log) => {
+    return visibleRequestLogs.filter((log) => {
       if (!isPersistedRequestLogInProgress(log)) return true;
       const traceId = log.trace_id?.trim();
       if (!traceId) return true;
@@ -885,16 +952,18 @@ const RequestLogsList = memo(function RequestLogsList({
       {renderedRequestLogs.map((log) => {
         const trace = tracesByTraceId.get(log.trace_id);
         const liveNow = trace && isPersistedRequestLogInProgress(log) ? nowMs : 0;
-        const sessionFolder = (() => {
-          const key = sessionFolderLookupKey(log.cli_key, log.session_id ?? trace?.session_id);
-          return key ? (folderLookupBySessionKey.get(key) ?? null) : null;
-        })();
+        const sessionFolder = resolveSessionFolderForRequestLog(
+          log,
+          trace,
+          folderLookupBySessionKey
+        );
         return (
           <RequestLogCard
             compactMode={compactMode}
             key={log.id}
             log={log}
             liveTrace={trace}
+            reconnectCount={websocketReconnectCounts.get(log.id)}
             nowMs={liveNow}
             isSelected={selectedLogId === log.id}
             sessionFolder={sessionFolder}
@@ -952,19 +1021,18 @@ const RequestLogsList = memo(function RequestLogsList({
               const vLog = renderedRequestLogs[virtualRow.index];
               const vTrace = tracesByTraceId.get(vLog.trace_id);
               const vNow = vTrace && isPersistedRequestLogInProgress(vLog) ? nowMs : 0;
-              const sessionFolder = (() => {
-                const key = sessionFolderLookupKey(
-                  vLog.cli_key,
-                  vLog.session_id ?? vTrace?.session_id
-                );
-                return key ? (folderLookupBySessionKey.get(key) ?? null) : null;
-              })();
+              const sessionFolder = resolveSessionFolderForRequestLog(
+                vLog,
+                vTrace,
+                folderLookupBySessionKey
+              );
               return (
                 <div key={vLog.id} data-index={virtualRow.index} ref={virtualizer.measureElement}>
                   <RequestLogCard
                     compactMode={compactMode}
                     log={vLog}
                     liveTrace={vTrace}
+                    reconnectCount={websocketReconnectCounts.get(vLog.id)}
                     nowMs={vNow}
                     isSelected={selectedLogId === vLog.id}
                     sessionFolder={sessionFolder}

--- a/src/components/home/__tests__/HomeLogShared.test.tsx
+++ b/src/components/home/__tests__/HomeLogShared.test.tsx
@@ -184,6 +184,14 @@ describe("components/home/HomeLogShared", () => {
       special_settings_json: "bad-json",
     });
     expect(plain).toMatchObject({ muted: false, summary: null, providerFallbackText: null });
+
+    const websocket = buildRequestLogAuditMeta({
+      cli_key: "codex",
+      path: "/v1/realtime",
+      status: 101,
+      special_settings_json: JSON.stringify([{ type: "websocket_proxy" }]),
+    });
+    expect(websocket.tags.map((tag) => tag.label)).toContain("WS");
   });
 
   it("computes status badges across success, failover, errors, and client aborts", () => {
@@ -199,6 +207,10 @@ describe("components/home/HomeLogShared", () => {
     expect(computeStatusBadge({ status: 204, errorCode: null })).toMatchObject({
       text: "204 成功",
       semanticText: "请求成功",
+    });
+    expect(computeStatusBadge({ status: 101, errorCode: null })).toMatchObject({
+      text: expect.stringContaining("101"),
+      isError: false,
     });
     expect(computeStatusBadge({ status: 500, errorCode: null })).toMatchObject({
       text: "500 失败",

--- a/src/components/home/__tests__/HomeRequestLogsPanel.test.tsx
+++ b/src/components/home/__tests__/HomeRequestLogsPanel.test.tsx
@@ -165,6 +165,187 @@ describe("components/home/HomeRequestLogsPanel", () => {
     expect(onSelectLogId).toHaveBeenCalledWith(1);
   });
 
+  it("hides websocket audit-only logs from the home list", () => {
+    render(
+      <MemoryRouter>
+        <HomeRequestLogsPanel
+          showCustomTooltip={false}
+          compactModeOverride={false}
+          traces={[]}
+          requestLogs={makeRequestLogs([
+            {
+              id: 1,
+              trace_id: "ws-audit",
+              cli_key: "codex",
+              session_id: "my_test",
+              requested_model: null,
+              status: 101,
+              excluded_from_stats: true,
+              special_settings_json: JSON.stringify([{ type: "websocket_proxy" }]),
+              output_tokens: null,
+            },
+            {
+              id: 2,
+              trace_id: "normal",
+              cli_key: "codex",
+              session_id: "my_test",
+              requested_model: "gpt-5.5",
+              status: 200,
+              final_provider_name: "Provider Visible",
+              output_tokens: 3,
+            },
+          ])}
+          requestLogsLoading={false}
+          requestLogsRefreshing={false}
+          requestLogsAvailable={true}
+          onRefreshRequestLogs={vi.fn()}
+          selectedLogId={null}
+          onSelectLogId={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("ws-audit")).not.toBeInTheDocument();
+    expect(screen.getByText("Provider Visible")).toBeInTheDocument();
+  });
+
+  it("marks visible websocket reconnect rows", () => {
+    render(
+      <MemoryRouter>
+        <HomeRequestLogsPanel
+          showCustomTooltip={false}
+          compactModeOverride={false}
+          traces={[]}
+          requestLogs={makeRequestLogs([
+            {
+              id: 1,
+              trace_id: "ws-connection-1",
+              cli_key: "codex",
+              session_id: "my_test",
+              status: 101,
+              excluded_from_stats: true,
+              special_settings_json: JSON.stringify([{ type: "websocket_proxy" }]),
+              created_at_ms: 1000,
+            },
+            {
+              id: 2,
+              trace_id: "ws-turn-2",
+              cli_key: "codex",
+              session_id: "my_test",
+              status: 101,
+              excluded_from_stats: false,
+              special_settings_json: JSON.stringify([
+                { type: "websocket_proxy" },
+                { type: "websocket_turn" },
+              ]),
+              requested_model: "gpt-5.5",
+              input_tokens: 10,
+              output_tokens: 2,
+              total_tokens: 12,
+              created_at_ms: 2000,
+            },
+          ])}
+          requestLogsLoading={false}
+          requestLogsRefreshing={false}
+          requestLogsAvailable={true}
+          onRefreshRequestLogs={vi.fn()}
+          selectedLogId={null}
+          onSelectLogId={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Reconnect 1")).toBeInTheDocument();
+  });
+
+  it("shows codex websocket project badge from folder lookup", () => {
+    useCliSessionsFolderLookupByIdsQueryMock.mockReturnValue({
+      data: [
+        {
+          source: "codex",
+          session_id: "codex-session-1",
+          folder_name: "aio-coding-hub",
+          folder_path: "F:\\github\\aio-coding-hub",
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <HomeRequestLogsPanel
+          showCustomTooltip={false}
+          compactModeOverride={false}
+          traces={[]}
+          requestLogs={makeRequestLogs([
+            {
+              id: 1,
+              trace_id: "ws-turn",
+              cli_key: "codex",
+              session_id: "codex-session-1",
+              status: 101,
+              excluded_from_stats: false,
+              special_settings_json: JSON.stringify([
+                { type: "websocket_proxy" },
+                { type: "websocket_turn" },
+              ]),
+              requested_model: "gpt-5.5",
+              input_tokens: 10,
+              output_tokens: 2,
+              total_tokens: 12,
+            },
+          ])}
+          requestLogsLoading={false}
+          requestLogsRefreshing={false}
+          requestLogsAvailable={true}
+          onRefreshRequestLogs={vi.fn()}
+          selectedLogId={null}
+          onSelectLogId={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("aio-coding-hub")).toBeInTheDocument();
+  });
+
+  it("does not show a codex websocket session id when folder lookup misses", () => {
+    render(
+      <MemoryRouter>
+        <HomeRequestLogsPanel
+          showCustomTooltip={false}
+          compactModeOverride={false}
+          traces={[]}
+          requestLogs={makeRequestLogs([
+            {
+              id: 1,
+              trace_id: "ws-turn",
+              cli_key: "codex",
+              session_id: "codex-session-missing",
+              status: 101,
+              excluded_from_stats: false,
+              special_settings_json: JSON.stringify([
+                { type: "websocket_proxy" },
+                { type: "websocket_turn" },
+              ]),
+              requested_model: "gpt-5.5",
+              input_tokens: 10,
+              output_tokens: 2,
+              total_tokens: 12,
+            },
+          ])}
+          requestLogsLoading={false}
+          requestLogsRefreshing={false}
+          requestLogsAvailable={true}
+          onRefreshRequestLogs={vi.fn()}
+          selectedLogId={null}
+          onSelectLogId={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("codex-session-missing")).not.toBeInTheDocument();
+  });
+
   it("renders Claude model mapping from historical request logs", () => {
     render(
       <MemoryRouter>

--- a/src/generated/bindings.ts
+++ b/src/generated/bindings.ts
@@ -2546,6 +2546,7 @@ export type ProviderSummary = {
   source_provider_id: number | null;
   bridge_type: string | null;
   stream_idle_timeout_seconds: number | null;
+  supports_websockets: boolean;
   api_key_configured: boolean;
 };
 export type ProviderUpsertInput = {
@@ -2572,6 +2573,7 @@ export type ProviderUpsertInput = {
   sourceProviderId: number | null;
   bridgeType: string | null;
   streamIdleTimeoutSeconds: number | null;
+  supportsWebsockets: boolean | null;
 };
 export type RequestAttemptLog = {
   id: number;

--- a/src/generated/bindings.ts
+++ b/src/generated/bindings.ts
@@ -2041,6 +2041,7 @@ export type CodexConfigPatch = {
   model_auto_compact_token_limit?: number | null;
   service_tier: string | null;
   sandbox_workspace_write_network_access: boolean | null;
+  model_providers_aio_supports_websockets: boolean | null;
   features_unified_exec: boolean | null;
   features_shell_snapshot: boolean | null;
   features_apply_patch_freeform: boolean | null;
@@ -2071,6 +2072,7 @@ export type CodexConfigState = {
   model_auto_compact_token_limit: number | null;
   service_tier: string | null;
   sandbox_workspace_write_network_access: boolean | null;
+  model_providers_aio_supports_websockets: boolean | null;
   features_unified_exec: boolean | null;
   features_shell_snapshot: boolean | null;
   features_apply_patch_freeform: boolean | null;

--- a/src/hooks/useRequestLogsFeed.ts
+++ b/src/hooks/useRequestLogsFeed.ts
@@ -7,7 +7,7 @@ import {
 import { logToConsole } from "../services/consoleLog";
 import { subscribeGatewayEvent } from "../services/gateway/gatewayEventBus";
 import { normalizeGatewayRequestSignalEvent } from "../services/gateway/gatewayEvents";
-import { isRequestSignalComplete } from "../services/gateway/requestLogState";
+import { isRequestSignalLogRefreshTrigger } from "../services/gateway/requestLogState";
 import { useCoalescedAsyncRefresh } from "./useCoalescedAsyncRefresh";
 import { useDocumentVisibility } from "./useDocumentVisibility";
 import { useWindowForeground } from "./useWindowForeground";
@@ -85,7 +85,7 @@ export function useRequestLogsFeed({
         return;
       }
 
-      if (!isRequestSignalComplete(requestSignal)) {
+      if (!isRequestSignalLogRefreshTrigger(requestSignal)) {
         return;
       }
 

--- a/src/pages/home/hooks/__tests__/useHomeOAuthQuota.test.tsx
+++ b/src/pages/home/hooks/__tests__/useHomeOAuthQuota.test.tsx
@@ -61,6 +61,7 @@ function makeProvider(
     source_provider_id: partial.source_provider_id ?? null,
     bridge_type: partial.bridge_type ?? null,
     stream_idle_timeout_seconds: partial.stream_idle_timeout_seconds ?? null,
+    supports_websockets: partial.supports_websockets ?? false,
     api_key_configured: partial.api_key_configured ?? false,
   };
 }

--- a/src/pages/home/hooks/useHomeFreshnessOwner.ts
+++ b/src/pages/home/hooks/useHomeFreshnessOwner.ts
@@ -5,7 +5,7 @@ import { useWindowForeground } from "../../../hooks/useWindowForeground";
 import { logToConsole } from "../../../services/consoleLog";
 import { subscribeGatewayEvent } from "../../../services/gateway/gatewayEventBus";
 import { normalizeGatewayRequestSignalEvent } from "../../../services/gateway/gatewayEvents";
-import { isRequestSignalComplete } from "../../../services/gateway/requestLogState";
+import { isRequestSignalLogRefreshTrigger } from "../../../services/gateway/requestLogState";
 
 type RefreshSource = "request_signal.complete" | "foreground" | "manual";
 
@@ -86,7 +86,7 @@ export function useHomeFreshnessOwner({
         return;
       }
 
-      if (!isRequestSignalComplete(requestSignal)) {
+      if (!isRequestSignalLogRefreshTrigger(requestSignal)) {
         return;
       }
 

--- a/src/pages/providers/ProviderEditorDialog.tsx
+++ b/src/pages/providers/ProviderEditorDialog.tsx
@@ -104,6 +104,22 @@ export function ProviderEditorDialog(props: ProviderEditorDialogProps) {
           />
         </FormField>
 
+        <FormField
+          label="WebSocket"
+          hint="仅当上游明确支持 Responses WebSocket 时开启；关闭时 WS 请求会跳过该 Provider。"
+        >
+          <div className="flex items-center justify-between rounded-md border border-border px-3 py-2 dark:border-border">
+            <span className="text-sm text-secondary-foreground">支持 WebSocket 上游</span>
+            <Switch
+              checked={f.supportsWebsockets}
+              onCheckedChange={(checked) =>
+                f.setValue("supports_websockets", checked, { shouldDirty: true })
+              }
+              disabled={f.saving}
+            />
+          </div>
+        </FormField>
+
         <LimitsSection form={f} />
         <ClaudeModelSection form={f} />
 

--- a/src/pages/providers/__tests__/ProviderEditorDialog.test.tsx
+++ b/src/pages/providers/__tests__/ProviderEditorDialog.test.tsx
@@ -77,6 +77,7 @@ function makeProvider(partial: Partial<ProviderSummary> = {}): ProviderSummary {
     api_key_configured: partial.api_key_configured ?? false,
     ...partial,
     stream_idle_timeout_seconds: partial.stream_idle_timeout_seconds ?? null,
+    supports_websockets: partial.supports_websockets ?? false,
   };
 }
 
@@ -105,6 +106,7 @@ function makeInitialValues(
     bridge_type: null,
     ...partial,
     stream_idle_timeout_seconds: partial.stream_idle_timeout_seconds ?? null,
+    supports_websockets: partial.supports_websockets ?? false,
   };
 }
 
@@ -208,6 +210,12 @@ describe("pages/providers/ProviderEditorDialog", () => {
     });
 
     fireEvent.click(dialog.getByText("Claude 模型映射"));
+    fireEvent.click(
+      within(dialog.getByText("支持 WebSocket 上游").parentElement as HTMLElement).getByRole(
+        "switch"
+      )
+    );
+
     fireEvent.change(dialog.getByPlaceholderText(/minimax-text-01/), {
       target: { value: "x".repeat(201) },
     });
@@ -227,6 +235,7 @@ describe("pages/providers/ProviderEditorDialog", () => {
           apiKey: "sk-test",
           enabled: true,
           costMultiplier: 1.0,
+          supportsWebsockets: true,
         })
       )
     );
@@ -749,7 +758,7 @@ describe("pages/providers/ProviderEditorDialog", () => {
     fireEvent.change(dialog.getByPlaceholderText("例如: 1000"), { target: { value: "2" } });
 
     // Toggle enabled switch (covers Switch onCheckedChange handler)
-    fireEvent.click(dialog.getByRole("switch"));
+    fireEvent.click(dialog.getAllByRole("switch")[0]);
 
     // Drive Claude models onChange handlers
     fireEvent.click(dialog.getByText("Claude 模型映射"));

--- a/src/pages/providers/__tests__/SortableProviderCard.test.tsx
+++ b/src/pages/providers/__tests__/SortableProviderCard.test.tsx
@@ -70,6 +70,7 @@ function makeProvider(partial: Partial<ProviderSummary> = {}): ProviderSummary {
     api_key_configured: partial.api_key_configured ?? false,
     ...partial,
     stream_idle_timeout_seconds: partial.stream_idle_timeout_seconds ?? null,
+    supports_websockets: partial.supports_websockets ?? false,
   };
 }
 

--- a/src/pages/providers/__tests__/providerDuplicate.test.ts
+++ b/src/pages/providers/__tests__/providerDuplicate.test.ts
@@ -33,6 +33,7 @@ function createProvider(overrides: Record<string, unknown> = {}) {
     oauth_last_error: null,
     source_provider_id: null,
     bridge_type: null,
+    supports_websockets: false,
     ...overrides,
   } as any;
 }
@@ -74,6 +75,7 @@ describe("pages/providers/providerDuplicate", () => {
       source_provider_id: null,
       bridge_type: null,
       stream_idle_timeout_seconds: null,
+      supports_websockets: false,
     });
     expect(duplicated.base_urls).toEqual(["https://a.example.com", "https://b.example.com"]);
     expect(duplicated.tags).toEqual(["tag-a", "tag-b"]);

--- a/src/pages/providers/__tests__/providerEditorSaveRunner.test.ts
+++ b/src/pages/providers/__tests__/providerEditorSaveRunner.test.ts
@@ -38,6 +38,7 @@ function makeSavedProvider(partial: Partial<ProviderSummary> = {}): ProviderSumm
     source_provider_id: partial.source_provider_id ?? null,
     bridge_type: partial.bridge_type ?? null,
     stream_idle_timeout_seconds: partial.stream_idle_timeout_seconds ?? null,
+    supports_websockets: partial.supports_websockets ?? false,
     api_key_configured: partial.api_key_configured ?? true,
   };
 }
@@ -63,6 +64,7 @@ function makeContext(overrides: Partial<SaveActionContext> = {}): SaveActionCont
     tags: [],
     claudeModels: {},
     streamIdleTimeoutSeconds: "",
+    supportsWebsockets: false,
     apiKeyConfigured: false,
     isCodexGatewaySource: false,
     sourceProviderId: null,

--- a/src/pages/providers/__tests__/providerEditorSubmitModel.test.ts
+++ b/src/pages/providers/__tests__/providerEditorSubmitModel.test.ts
@@ -16,6 +16,7 @@ function makeContext(
     tags: [],
     claudeModels: {},
     streamIdleTimeoutSeconds: "",
+    supportsWebsockets: false,
     apiKeyConfigured: false,
     isCodexGatewaySource: false,
     sourceProviderId: null,

--- a/src/pages/providers/providerDuplicate.ts
+++ b/src/pages/providers/providerDuplicate.ts
@@ -23,6 +23,7 @@ export type ProviderEditorInitialValues = {
   source_provider_id: number | null;
   bridge_type: string | null;
   stream_idle_timeout_seconds: number | null;
+  supports_websockets: boolean;
 };
 
 function normalizeProviderName(name: string) {
@@ -78,5 +79,6 @@ export function buildDuplicatedProviderInitialValues(
     source_provider_id: provider.source_provider_id ?? null,
     bridge_type: provider.bridge_type ?? null,
     stream_idle_timeout_seconds: provider.stream_idle_timeout_seconds ?? null,
+    supports_websockets: provider.supports_websockets ?? false,
   };
 }

--- a/src/pages/providers/providerEditorActionContext.ts
+++ b/src/pages/providers/providerEditorActionContext.ts
@@ -48,6 +48,7 @@ export type FormActionContext = {
   claudeModels: ClaudeModels;
   streamIdleTimeoutSeconds: string;
   apiKeyConfigured: boolean;
+  supportsWebsockets: boolean;
   apiKeyValue: string;
   form: {
     getValues: () => ProviderEditorDialogFormInput;
@@ -69,6 +70,7 @@ export type ProviderEditorPayloadContext = {
   tags: string[];
   claudeModels: ClaudeModels;
   streamIdleTimeoutSeconds: string;
+  supportsWebsockets: boolean;
   apiKeyConfigured: boolean;
   isCodexGatewaySource: boolean;
   sourceProviderId: number | null;

--- a/src/pages/providers/providerEditorSaveRunner.ts
+++ b/src/pages/providers/providerEditorSaveRunner.ts
@@ -61,6 +61,7 @@ export async function runProviderEditorSave(ctx: SaveActionContext) {
       tags: saved.tags,
       note: saved.note,
       stream_idle_timeout_seconds: saved.stream_idle_timeout_seconds,
+      supports_websockets: saved.supports_websockets,
     });
     toast(ctx.mode === "create" ? "Provider 已保存" : "Provider 已更新");
 

--- a/src/pages/providers/providerEditorSubmitModel.ts
+++ b/src/pages/providers/providerEditorSubmitModel.ts
@@ -132,6 +132,7 @@ export function buildProviderEditorUpsertInput(
     tags: ctx.tags,
     note: parsed.data.note,
     streamIdleTimeoutSeconds: parsedTimeout,
+    supportsWebsockets: ctx.supportsWebsockets,
     ...(ctx.cliKey === "claude" ? { claudeModels: ctx.claudeModels } : {}),
     sourceProviderId:
       ctx.authMode === "cx2cc" && !ctx.isCodexGatewaySource ? ctx.sourceProviderId : null,

--- a/src/pages/providers/providerEditorUtils.ts
+++ b/src/pages/providers/providerEditorUtils.ts
@@ -24,6 +24,7 @@ export const DEFAULT_FORM_VALUES: ProviderEditorDialogFormInput = {
   daily_reset_mode: "fixed",
   daily_reset_time: "00:00:00",
   enabled: true,
+  supports_websockets: false,
   note: "",
 };
 
@@ -92,6 +93,7 @@ export function buildFormValues(initialValues: ProviderEditorInitialValues | nul
     daily_reset_mode: initialValues.daily_reset_mode,
     daily_reset_time: initialValues.daily_reset_time,
     enabled: initialValues.enabled,
+    supports_websockets: initialValues.supports_websockets ?? false,
     note: initialValues.note,
   };
 }

--- a/src/pages/providers/useProviderEditorEffects.ts
+++ b/src/pages/providers/useProviderEditorEffects.ts
@@ -170,6 +170,7 @@ export function useProviderEditorEffects(d: EffectDeps) {
       daily_reset_mode: snapshot.daily_reset_mode ?? "fixed",
       daily_reset_time: snapshot.daily_reset_time ?? "00:00:00",
       enabled: snapshot.enabled,
+      supports_websockets: snapshot.supports_websockets ?? false,
       note: snapshot.note ?? "",
     });
     return () => {

--- a/src/pages/providers/useProviderEditorForm.ts
+++ b/src/pages/providers/useProviderEditorForm.ts
@@ -93,6 +93,7 @@ export function useProviderEditorForm(props: ProviderEditorDialogProps) {
 
   const { register, reset, setValue, watch } = form;
   const enabled = watch("enabled");
+  const supportsWebsockets = watch("supports_websockets");
   const dailyResetMode = watch("daily_reset_mode");
   const limit5hUsd = watch("limit_5h_usd");
   const limitDailyUsd = watch("limit_daily_usd");
@@ -191,6 +192,7 @@ export function useProviderEditorForm(props: ProviderEditorDialogProps) {
       tags,
       claudeModels,
       streamIdleTimeoutSeconds,
+      supportsWebsockets,
       apiKeyConfigured,
       isCodexGatewaySource,
       sourceProviderId,
@@ -207,6 +209,7 @@ export function useProviderEditorForm(props: ProviderEditorDialogProps) {
       tags,
       claudeModels,
       streamIdleTimeoutSeconds,
+      supportsWebsockets,
       apiKeyConfigured,
       isCodexGatewaySource,
       sourceProviderId,
@@ -320,6 +323,7 @@ export function useProviderEditorForm(props: ProviderEditorDialogProps) {
     setValue,
     watch,
     enabled,
+    supportsWebsockets,
     dailyResetMode,
     limit5hUsd,
     limitDailyUsd,

--- a/src/query/__tests__/cliManager.test.tsx
+++ b/src/query/__tests__/cliManager.test.tsx
@@ -149,6 +149,7 @@ function makeCodexConfigState(overrides: Partial<CodexConfigState> = {}): CodexC
     model_auto_compact_token_limit: null,
     service_tier: null,
     sandbox_workspace_write_network_access: null,
+    model_providers_aio_supports_websockets: null,
     features_unified_exec: null,
     features_shell_snapshot: null,
     features_apply_patch_freeform: null,

--- a/src/query/__tests__/providers.test.tsx
+++ b/src/query/__tests__/providers.test.tsx
@@ -91,6 +91,7 @@ function makeProvider(
     source_provider_id: partial.source_provider_id ?? null,
     bridge_type: partial.bridge_type ?? null,
     stream_idle_timeout_seconds: partial.stream_idle_timeout_seconds ?? null,
+    supports_websockets: partial.supports_websockets ?? false,
     api_key_configured: partial.api_key_configured ?? false,
   };
 }

--- a/src/schemas/__tests__/providerEditorDialog.test.ts
+++ b/src/schemas/__tests__/providerEditorDialog.test.ts
@@ -21,6 +21,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "00:00:00",
       enabled: true,
+      supports_websockets: false,
       note: "",
     } as const;
 
@@ -54,6 +55,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "01:02",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(res.success).toBe(true);
@@ -74,6 +76,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "25:00:00",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(bad.success).toBe(false);
@@ -102,6 +105,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "00:00:00",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(ok.success).toBe(true);
@@ -123,6 +127,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "00:00:00",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(badCost.success).toBe(false);
@@ -145,6 +150,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "00:00:00",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(badLimit.success).toBe(false);
@@ -170,6 +176,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "00:00:00",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(res.success).toBe(false);
@@ -193,6 +200,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "00:00:00",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(res.success).toBe(false);
@@ -216,6 +224,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "00:00:00",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(res.success).toBe(false);
@@ -241,6 +250,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "00:00:00",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(res.success).toBe(false);
@@ -266,6 +276,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "not-a-time",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(res.success).toBe(false);
@@ -291,6 +302,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(res.success).toBe(true);
@@ -314,6 +326,7 @@ describe("schemas/providerEditorDialog", () => {
       daily_reset_mode: "fixed",
       daily_reset_time: "00:00:00",
       enabled: true,
+      supports_websockets: false,
       note: "",
     });
     expect(res.success).toBe(true);

--- a/src/schemas/providerEditorDialog.ts
+++ b/src/schemas/providerEditorDialog.ts
@@ -106,6 +106,7 @@ export function createProviderEditorDialogSchema(options: {
       daily_reset_mode: z.enum(["fixed", "rolling"]),
       daily_reset_time: parseResetTimeHms(),
       enabled: z.boolean(),
+      supports_websockets: z.boolean(),
       note: z.string().trim().max(500, { message: "备注不能超过 500 字符" }),
     })
     .superRefine((values, ctx) => {

--- a/src/services/cli/__tests__/cliManager.service.test.ts
+++ b/src/services/cli/__tests__/cliManager.service.test.ts
@@ -86,6 +86,7 @@ function makeCodexConfigState(overrides: Partial<CodexConfigState> = {}): CodexC
     model_auto_compact_token_limit: null,
     service_tier: null,
     sandbox_workspace_write_network_access: null,
+    model_providers_aio_supports_websockets: null,
     features_unified_exec: null,
     features_shell_snapshot: null,
     features_apply_patch_freeform: null,

--- a/src/services/cli/cliManager.ts
+++ b/src/services/cli/cliManager.ts
@@ -50,6 +50,7 @@ const DEFAULT_CODEX_CONFIG_PATCH = {
   model_auto_compact_token_limit: null,
   service_tier: null,
   sandbox_workspace_write_network_access: null,
+  model_providers_aio_supports_websockets: null,
   features_unified_exec: null,
   features_shell_snapshot: null,
   features_apply_patch_freeform: null,

--- a/src/services/gateway/__tests__/requestLogState.test.ts
+++ b/src/services/gateway/__tests__/requestLogState.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isRequestSignalComplete, isRequestSignalLogRefreshTrigger } from "../requestLogState";
+
+describe("services/gateway/requestLogState", () => {
+  it("uses start and complete request signals to refresh request logs", () => {
+    expect(isRequestSignalComplete({ phase: "start" })).toBe(false);
+    expect(isRequestSignalComplete({ phase: "complete" })).toBe(true);
+    expect(isRequestSignalLogRefreshTrigger({ phase: "start" })).toBe(true);
+    expect(isRequestSignalLogRefreshTrigger({ phase: "complete" })).toBe(true);
+    expect(isRequestSignalLogRefreshTrigger({ phase: "other" })).toBe(false);
+  });
+});

--- a/src/services/gateway/requestLogState.ts
+++ b/src/services/gateway/requestLogState.ts
@@ -33,3 +33,7 @@ export function isPersistedRequestLogInProgress(log: RequestLogProgressInput) {
 export function isRequestSignalComplete(signal: RequestSignalLike | null | undefined) {
   return signal?.phase === "complete";
 }
+
+export function isRequestSignalLogRefreshTrigger(signal: RequestSignalLike | null | undefined) {
+  return signal?.phase === "start" || signal?.phase === "complete";
+}

--- a/src/services/providers/__tests__/providers.msw.test.ts
+++ b/src/services/providers/__tests__/providers.msw.test.ts
@@ -30,6 +30,7 @@ describe("services/providers via MSW bridge", () => {
       limitTotalUsd: 25,
       tags: ["a", "b"],
       note: "hello",
+      supportsWebsockets: true,
     });
 
     expect(saved).toMatchObject({
@@ -43,12 +44,14 @@ describe("services/providers via MSW bridge", () => {
       auth_mode: "api_key",
       tags: ["a", "b"],
       note: "hello",
+      supports_websockets: true,
     });
 
     expect(getProvidersState("claude")).toHaveLength(1);
     expect(getProvidersState("claude")[0]).toMatchObject({
       name: "Bridge Provider",
       limit_5h_usd: 5,
+      supports_websockets: true,
     });
   });
 

--- a/src/services/providers/__tests__/providers.service.test.ts
+++ b/src/services/providers/__tests__/providers.service.test.ts
@@ -88,6 +88,7 @@ function createProviderSummary(overrides: Partial<ProviderSummary> = {}): Provid
     source_provider_id: null,
     bridge_type: null,
     stream_idle_timeout_seconds: null,
+    supports_websockets: false,
     api_key_configured: false,
     ...overrides,
   };

--- a/src/services/providers/providers.ts
+++ b/src/services/providers/providers.ts
@@ -81,6 +81,7 @@ type ProviderUpsertFieldMap = {
   sourceProviderId: "sourceProviderId";
   bridgeType: "bridgeType";
   streamIdleTimeoutSeconds: "streamIdleTimeoutSeconds";
+  supportsWebsockets: "supportsWebsockets";
 };
 
 type ProviderUpsertAuthority = RemapGeneratedKeys<
@@ -91,7 +92,8 @@ type ProviderUpsertAuthority = RemapGeneratedKeys<
 
 type ProviderUpsertOptionalKeys =
   | NullableGeneratedKeys<ProviderUpsertAuthority>
-  | "streamIdleTimeoutSeconds";
+  | "streamIdleTimeoutSeconds"
+  | "supportsWebsockets";
 
 export type ProviderUpsertInput = Omit<
   ProviderUpsertAuthority,
@@ -102,9 +104,10 @@ export type ProviderUpsertInput = Omit<
 
 type ProviderUpsertTransportInput = Omit<
   GeneratedProviderUpsertInput,
-  "streamIdleTimeoutSeconds"
+  "streamIdleTimeoutSeconds" | "supportsWebsockets"
 > & {
   streamIdleTimeoutSeconds?: GeneratedProviderUpsertInput["streamIdleTimeoutSeconds"];
+  supportsWebsockets?: GeneratedProviderUpsertInput["supportsWebsockets"];
 };
 
 function toCliKey(value: string, label: string): CliKey {
@@ -169,16 +172,22 @@ function toProviderUpsertPayload(input: ProviderUpsertInput): ProviderUpsertTran
     note: input.note ?? null,
     sourceProviderId,
     bridgeType: input.bridgeType ?? null,
-  } satisfies Omit<GeneratedProviderUpsertInput, "streamIdleTimeoutSeconds">;
+  } satisfies Omit<GeneratedProviderUpsertInput, "streamIdleTimeoutSeconds" | "supportsWebsockets">;
+  const payloadWithWebsockets = Object.prototype.hasOwnProperty.call(input, "supportsWebsockets")
+    ? {
+        ...payloadBase,
+        supportsWebsockets: input.supportsWebsockets ?? false,
+      }
+    : payloadBase;
 
   if (Object.prototype.hasOwnProperty.call(input, "streamIdleTimeoutSeconds")) {
     return {
-      ...payloadBase,
+      ...payloadWithWebsockets,
       streamIdleTimeoutSeconds: input.streamIdleTimeoutSeconds ?? 0,
     } satisfies ProviderUpsertTransportInput;
   }
 
-  return payloadBase;
+  return payloadWithWebsockets;
 }
 
 function validateOrderedProviderIds(orderedProviderIds: number[]) {

--- a/src/test/msw/handlers.ts
+++ b/src/test/msw/handlers.ts
@@ -217,6 +217,10 @@ export const handlers = [
             ? input.streamIdleTimeoutSeconds
             : null
           : (existing?.stream_idle_timeout_seconds ?? null),
+      supports_websockets:
+        typeof input.supportsWebsockets === "boolean"
+          ? input.supportsWebsockets
+          : (existing?.supports_websockets ?? false),
     };
 
     setProvidersState(


### PR DESCRIPTION
## Summary
- Add a dedicated gateway WebSocket upgrade proxy path while keeping HTTP requests on the existing proxy handler.
- Write supports_websockets = true into the managed Codex model_providers.aio provider config.
- Expose supports_websockets in the Codex config UI and generated config types.

## Tests
- pnpm vitest run src/components/cli-manager/tabs/__tests__/CodexTab.test.tsx src/components/cli-manager/tabs/__tests__/tabs.coverage.test.tsx src/query/__tests__/cliManager.test.tsx
- pnpm check:precommit
- pnpm tauri:build -- --no-bundle
- pnpm test:unit:shards via pre-push hook

## Local Environment Note
- pnpm check:generated-bindings / pnpm tauri:gen-types compiled but 	arget-bindings\\debug\\examples\\export-bindings.exe failed to start locally with STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139).
- pnpm tauri:test -- codex_config hit the same Windows executable startup error locally.