### PR TITLE
fix: 保留供应商编辑后的列表滚动位置

### DIFF
--- a/src-tauri/src/infra/cli_proxy/mod.rs
+++ b/src-tauri/src/infra/cli_proxy/mod.rs
@@ -673,7 +673,7 @@ fn manifest_target_paths_changed<R: tauri::Runtime>(
         else {
             continue;
         };
-        if PathBuf::from(&entry.path) != target.path {
+        if Path::new(&entry.path) != target.path {
             return Ok(true);
         }
     }

--- a/src-tauri/src/infra/settings/types.rs
+++ b/src-tauri/src/infra/settings/types.rs
@@ -3,41 +3,32 @@
 use super::defaults::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum GatewayListenMode {
+    #[default]
     Localhost,
     WslAuto,
     Lan,
     Custom,
 }
 
-impl Default for GatewayListenMode {
-    fn default() -> Self {
-        Self::Localhost
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum WslHostAddressMode {
+    #[default]
     Auto,
     Custom,
 }
 
-impl Default for WslHostAddressMode {
-    fn default() -> Self {
-        Self::Auto
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
 pub enum HomeUsagePeriod {
     #[serde(rename = "last7")]
     #[specta(rename = "last7")]
     Last7,
     #[serde(rename = "last15")]
     #[specta(rename = "last15")]
+    #[default]
     Last15,
     #[serde(rename = "last30")]
     #[specta(rename = "last30")]
@@ -47,24 +38,13 @@ pub enum HomeUsagePeriod {
     Month,
 }
 
-impl Default for HomeUsagePeriod {
-    fn default() -> Self {
-        Self::Last15
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum CodexHomeMode {
+    #[default]
     UserHomeDefault,
     FollowCodexHome,
     Custom,
-}
-
-impl Default for CodexHomeMode {
-    fn default() -> Self {
-        Self::UserHomeDefault
-    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, specta::Type, PartialEq, Eq)]

--- a/src/pages/providers/ProvidersView.tsx
+++ b/src/pages/providers/ProvidersView.tsx
@@ -1,5 +1,6 @@
 // Usage: Rendered by ProvidersPage when `view === "providers"`.
 
+import { useEffect, useRef } from "react";
 import { Search } from "lucide-react";
 import { DndContext, closestCenter } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
@@ -18,6 +19,12 @@ import { useProvidersViewDataModel } from "./hooks/useProvidersViewDataModel";
 export type ProvidersViewProps = {
   activeCli: CliKey;
   setActiveCli: (cliKey: CliKey) => void;
+};
+
+type PendingProvidersScrollRestore = {
+  cliKey: CliKey;
+  scrollTop: number;
+  observedRefresh: boolean;
 };
 
 export function ProvidersView({ activeCli }: ProvidersViewProps) {
@@ -68,6 +75,47 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
     testingByProviderId,
   } = model;
   const enabledProviders = providers.filter((provider) => provider.enabled);
+  const providersListScrollRef = useRef<HTMLDivElement | null>(null);
+  const pendingProvidersScrollRestoreRef = useRef<PendingProvidersScrollRestore | null>(null);
+
+  useEffect(() => {
+    const pendingRestore = pendingProvidersScrollRestoreRef.current;
+    if (!pendingRestore) return;
+
+    if (pendingRestore.cliKey !== activeCli) {
+      pendingProvidersScrollRestoreRef.current = null;
+      return;
+    }
+
+    if (providersLoading) {
+      pendingProvidersScrollRestoreRef.current = {
+        ...pendingRestore,
+        observedRefresh: true,
+      };
+      return;
+    }
+
+    // 等待保存后的刷新确实开始并结束，再恢复位置，避免过早清掉待恢复记录。
+    if (!pendingRestore.observedRefresh) return;
+
+    const providersListElement = providersListScrollRef.current;
+    if (!providersListElement) return;
+
+    providersListElement.scrollTop = pendingRestore.scrollTop;
+    pendingProvidersScrollRestoreRef.current = null;
+  }, [activeCli, providersLoading, providers.length, filteredProviders.length]);
+
+  function captureProvidersListScrollPosition(cliKey: CliKey) {
+    const providersListElement = providersListScrollRef.current;
+    if (!providersListElement) return;
+
+    // 保存前先记录滚动位置，便于编辑成功后的后台刷新完成后恢复原视口。
+    pendingProvidersScrollRestoreRef.current = {
+      cliKey,
+      scrollTop: providersListElement.scrollTop,
+      observedRefresh: false,
+    };
+  }
 
   return (
     <>
@@ -173,7 +221,10 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
         </div>
 
         <div className="grid gap-4 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(0,1fr)_280px] xl:grid-cols-[minmax(0,1fr)_320px]">
-          <div className="lg:min-h-0 lg:overflow-auto lg:pr-1 scrollbar-overlay">
+          <div
+            ref={providersListScrollRef}
+            className="lg:min-h-0 lg:overflow-auto lg:pr-1 scrollbar-overlay"
+          >
             {providersLoading ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Spinner size="sm" />
@@ -298,7 +349,9 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
           cliKey={createDialogState.cliKey}
           initialValues={createDialogState.initialValues}
           codexProviders={codexProviders}
-          onSaved={() => {}}
+          onSaved={(cliKey) => {
+            captureProvidersListScrollPosition(cliKey);
+          }}
         />
       ) : null}
 
@@ -311,7 +364,9 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
           }}
           provider={editTarget}
           codexProviders={codexProviders}
-          onSaved={() => {}}
+          onSaved={(cliKey) => {
+            captureProvidersListScrollPosition(cliKey);
+          }}
         />
       ) : null}
 

--- a/src/pages/providers/__tests__/ProvidersView.test.tsx
+++ b/src/pages/providers/__tests__/ProvidersView.test.tsx
@@ -1211,7 +1211,7 @@ describe("pages/providers/ProvidersView", () => {
         <ProvidersView activeCli="claude" setActiveCli={vi.fn()} />
       </QueryClientProvider>
     );
-    fireEvent.click(screen.getByTitle("编辑"));
+    fireEvent.click(screen.getAllByTitle("编辑")[0]!);
     expect(screen.getByTestId("provider-editor")).toHaveTextContent("edit");
 
     rerender(
@@ -1367,7 +1367,7 @@ describe("pages/providers/ProvidersView", () => {
     await waitFor(() => expect(screen.queryByTestId("provider-editor")).not.toBeInTheDocument());
 
     // edit dialog onSaved + onOpenChange
-    fireEvent.click(screen.getByTitle("编辑"));
+    fireEvent.click(screen.getAllByTitle("编辑")[0]!);
     const editEditor = screen
       .getAllByTestId("provider-editor")
       .find((el) => el.textContent?.includes("edit"));
@@ -1395,6 +1395,88 @@ describe("pages/providers/ProvidersView", () => {
     fireEvent.click(screen.getByTitle("删除"));
     fireEvent.click(screen.getByRole("button", { name: "取消" }));
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("restores providers list scroll position after editing saves and background refresh completes", async () => {
+    const providers = [
+      {
+        id: 1,
+        cli_key: "claude",
+        name: "P1",
+        enabled: true,
+        base_urls: ["https://a"],
+        base_url_mode: "order",
+        cost_multiplier: 1,
+        claude_models: {},
+      },
+      {
+        id: 2,
+        cli_key: "claude",
+        name: "P2",
+        enabled: true,
+        base_urls: ["https://b"],
+        base_url_mode: "order",
+        cost_multiplier: 1,
+        claude_models: {},
+      },
+    ] as any[];
+
+    let providersFetching = false;
+    vi.mocked(useProvidersListQuery).mockImplementation(() => {
+      return { data: providers, isFetching: providersFetching } as any;
+    });
+    vi.mocked(useGatewayCircuitStatusQuery).mockReturnValue({
+      data: [],
+      isFetching: false,
+      refetch: vi.fn().mockResolvedValue({ data: [] }),
+    } as any);
+    vi.mocked(useProviderSetEnabledMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
+    vi.mocked(useProviderDeleteMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
+    vi.mocked(useProvidersReorderMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
+    vi.mocked(useGatewayCircuitResetProviderMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+    } as any);
+    vi.mocked(useGatewayCircuitResetCliMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
+
+    const client = createTestQueryClient();
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <ProvidersView activeCli="claude" setActiveCli={vi.fn()} />
+      </QueryClientProvider>
+    );
+
+    const providersScrollContainer = document.querySelectorAll(".scrollbar-overlay")[0] as
+      | HTMLElement
+      | undefined;
+    expect(providersScrollContainer).toBeTruthy();
+
+    providersScrollContainer!.scrollTop = 180;
+
+    fireEvent.click(screen.getAllByTitle("编辑")[0]!);
+    const editEditor = screen
+      .getAllByTestId("provider-editor")
+      .find((el) => el.textContent?.includes("edit"));
+    expect(editEditor).toBeTruthy();
+
+    fireEvent.click(within(editEditor as HTMLElement).getByRole("button", { name: "saved" }));
+
+    // 模拟后台刷新临时替换列表内容，导致浏览器滚动位置被重置。
+    providersFetching = true;
+    providersScrollContainer!.scrollTop = 0;
+    rerender(
+      <QueryClientProvider client={client}>
+        <ProvidersView activeCli="claude" setActiveCli={vi.fn()} />
+      </QueryClientProvider>
+    );
+
+    providersFetching = false;
+    rerender(
+      <QueryClientProvider client={client}>
+        <ProvidersView activeCli="claude" setActiveCli={vi.fn()} />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(providersScrollContainer!.scrollTop).toBe(180));
   });
 
   it("covers providers loading and empty branches", () => {


### PR DESCRIPTION
## 概述

编辑供应商弹框点击“保存”后，供应商列表刷新会回到顶部，长列表场景下连续编辑需要反复重新定位。

## 实现

- 保存成功时记录当前供应商列表的滚动位置
- 等待供应商列表刷新开始并结束后恢复原滚动位置
- 补充供应商视图回归测试，覆盖刷新后恢复滚动位置场景
- 顺手修复 tauri pre-push 阶段的 Clippy 阻塞项，保证分支可正常推送

## 验证

- `npx vitest run src/pages/providers/__tests__/ProvidersView.test.tsx`
- `pnpm typecheck`
- `pnpm lint`
- 仓库 pre-push 全量检查通过

Closes #290