### PR TITLE
fix(cli-manager): include exe parent dir in PATH for version probe

### DIFF
--- a/src-tauri/src/infra/cli_manager.rs
+++ b/src-tauri/src/infra/cli_manager.rs
@@ -609,9 +609,18 @@ fn run_version(exe: &Path) -> crate::shared::error::AppResult<String> {
     // GUI-launched processes on macOS/Linux inherit a minimal PATH that often
     // lacks Homebrew / nvm / system dirs. Prepend the standard locations so that
     // shebang-based CLIs (#!/usr/bin/env node) can resolve their runtime.
+    //
+    // Crucially, include the executable's own parent directory: version managers
+    // (nvm, volta, fnm, asdf) place both `node` and global npm packages in the
+    // same bin dir, so adding it ensures `#!/usr/bin/env node` resolves.
     #[cfg(not(windows))]
     {
-        let extra = platform_extra_path_dirs().join(":");
+        let mut extra_dirs: Vec<&str> = platform_extra_path_dirs().to_vec();
+        let exe_parent = exe.parent().map(|p| p.to_string_lossy().to_string());
+        if let Some(ref dir) = exe_parent {
+            extra_dirs.insert(0, dir.as_str());
+        }
+        let extra = extra_dirs.join(":");
         cmd.env(
             "PATH",
             format!("{}:{}", extra, std::env::var("PATH").unwrap_or_default()),
@@ -841,5 +850,36 @@ mod tests {
             .to_string();
 
         assert!(err.contains("claude/settings.json too large"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_version_resolves_shebang_interpreter_from_exe_parent_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir(&bin_dir).expect("create bin dir");
+
+        // Create a fake "node" interpreter that just prints a version string.
+        let node_path = bin_dir.join("node");
+        fs::write(&node_path, "#!/bin/sh\necho \"v20.0.0\"\n").expect("write fake node");
+        fs::set_permissions(&node_path, fs::Permissions::from_mode(0o755))
+            .expect("chmod fake node");
+
+        // Create a fake CLI script with #!/usr/bin/env node shebang.
+        let cli_path = bin_dir.join("fakecli");
+        fs::write(&cli_path, "#!/usr/bin/env node\nconsole.log(\"1.2.3\")\n")
+            .expect("write fake cli");
+        fs::set_permissions(&cli_path, fs::Permissions::from_mode(0o755)).expect("chmod fake cli");
+
+        // run_version should succeed because it adds exe's parent dir to PATH,
+        // allowing `#!/usr/bin/env node` to find the fake node in the same dir.
+        let result = run_version(&cli_path);
+        assert!(
+            result.is_ok(),
+            "run_version should resolve shebang interpreter from exe's parent dir, got: {:?}",
+            result.err()
+        );
     }
 }

--- a/src-tauri/src/infra/cli_manager.rs
+++ b/src-tauri/src/infra/cli_manager.rs
@@ -2,6 +2,8 @@
 
 use crate::shared::fs::{read_optional_file_with_max_len, write_file_atomic_if_changed};
 use serde::Serialize;
+#[cfg(not(windows))]
+use std::ffi::{OsStr, OsString};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -446,6 +448,24 @@ fn platform_extra_path_dirs() -> &'static [&'static str] {
     }
 }
 
+#[cfg(not(windows))]
+fn version_probe_path(
+    exe: &Path,
+    current_path: Option<&OsStr>,
+) -> crate::shared::error::AppResult<OsString> {
+    let mut paths: Vec<PathBuf> = Vec::new();
+    if let Some(parent) = exe.parent().filter(|p| !p.as_os_str().is_empty()) {
+        paths.push(parent.to_path_buf());
+    }
+    paths.extend(platform_extra_path_dirs().iter().map(PathBuf::from));
+    if let Some(current_path) = current_path {
+        paths.extend(std::env::split_paths(current_path));
+    }
+
+    std::env::join_paths(paths)
+        .map_err(|err| format!("failed to build PATH for version probe: {err}").into())
+}
+
 fn find_exe_in_path(names: &[String]) -> Option<PathBuf> {
     let path = std::env::var_os("PATH")?;
     let raw = path.to_string_lossy().to_string();
@@ -615,16 +635,8 @@ fn run_version(exe: &Path) -> crate::shared::error::AppResult<String> {
     // same bin dir, so adding it ensures `#!/usr/bin/env node` resolves.
     #[cfg(not(windows))]
     {
-        let mut extra_dirs: Vec<&str> = platform_extra_path_dirs().to_vec();
-        let exe_parent = exe.parent().map(|p| p.to_string_lossy().to_string());
-        if let Some(ref dir) = exe_parent {
-            extra_dirs.insert(0, dir.as_str());
-        }
-        let extra = extra_dirs.join(":");
-        cmd.env(
-            "PATH",
-            format!("{}:{}", extra, std::env::var("PATH").unwrap_or_default()),
-        );
+        let current_path = std::env::var_os("PATH");
+        cmd.env("PATH", version_probe_path(exe, current_path.as_deref())?);
     }
 
     #[cfg(windows)]
@@ -873,13 +885,28 @@ mod tests {
             .expect("write fake cli");
         fs::set_permissions(&cli_path, fs::Permissions::from_mode(0o755)).expect("chmod fake cli");
 
-        // run_version should succeed because it adds exe's parent dir to PATH,
-        // allowing `#!/usr/bin/env node` to find the fake node in the same dir.
-        let result = run_version(&cli_path);
-        assert!(
-            result.is_ok(),
-            "run_version should resolve shebang interpreter from exe's parent dir, got: {:?}",
-            result.err()
-        );
+        // run_version should use the fake node from exe's parent dir, not any
+        // node inherited from the developer machine PATH.
+        assert_eq!(run_version(&cli_path).expect("run version"), "v20.0.0");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn version_probe_path_prepends_exe_parent_and_preserves_existing_path() {
+        let dir = tempdir().expect("tempdir");
+        let bin_dir = dir.path().join("bin");
+        let exe = bin_dir.join("fakecli");
+        let existing_path =
+            std::env::join_paths([PathBuf::from("/usr/bin"), PathBuf::from("/bin")])
+                .expect("join fixture path");
+
+        let path = version_probe_path(&exe, Some(existing_path.as_os_str())).expect("probe path");
+        let entries: Vec<PathBuf> = std::env::split_paths(&path).collect();
+
+        assert_eq!(entries.first(), Some(&bin_dir));
+        for dir in platform_extra_path_dirs() {
+            assert!(entries.contains(&PathBuf::from(dir)));
+        }
+        assert!(entries.ends_with(&[PathBuf::from("/usr/bin"), PathBuf::from("/bin")]));
     }
 }


### PR DESCRIPTION
## Summary

Fixes the `env: node: No such file or directory` error when probing shebang-based CLIs on the CLI Manager page.

GUI-launched processes on macOS/Linux inherit a minimal PATH that lacks nvm/volta/fnm/asdf bin directories. When probing a CLI with a `#!/usr/bin/env node` shebang, the spawned child process could not resolve `node`, causing the probe to fail.

## Fix

In `run_version` (`src-tauri/src/infra/cli_manager.rs`), prepend the probed executable's own parent directory to the child process PATH. Version managers colocate `node` and global npm packages in the same bin dir, so this ensures the shebang interpreter resolves correctly.

## Test

Adds a unit test (`run_version_resolves_shebang_interpreter_from_exe_parent_dir`) that creates a fake `node` interpreter and a `#!/usr/bin/env node` CLI in a temp bin dir, and asserts `run_version` succeeds by resolving the interpreter from the exe's parent dir.

## Scope

Only macOS/Linux are affected (Windows does not use shebangs).

Closes #305