### PR TITLE
feat(plugin): add model.invoke host API and plugin audit plumbing

### DIFF
--- a/docs/plugin-manifest-v1.md
+++ b/docs/plugin-manifest-v1.md
@@ -102,12 +102,12 @@ Active hooks in plugin API v1 是当前已经接入 gateway 或 log pipeline 的
 
 | Hook | 触发时机 | 可修改内容 | 默认超时 | 默认失败策略 | 匹配权限 |
 | --- | --- | --- | --- | --- | --- |
-| `gateway.request.afterBodyRead` | Body reader 完成 allowed body buffering 后 | JSON body、raw body metadata | 200 ms | fail-open | `request.body.read`, `request.body.write` |
-| `gateway.request.beforeSend` | reqwest 发送 upstream request 前 | headers 和 body | 300 ms | fail-open 或 security fail-closed | `request.header.write`, `request.body.write` |
-| `gateway.response.chunk` | CLI output 前的 stream chunk | chunk pass、replace、block、warn | 20 ms | security fail-closed、non-security fail-open | `stream.inspect`, `stream.modify` |
-| `gateway.response.after` | 大小预算内的完整 non-stream response | body pass、replace、block、warn | 300 ms | security fail-closed、non-security fail-open | `response.body.read`, `response.body.write` |
-| `gateway.error` | 观察到 host 或 upstream error 后 | 不隐藏 host error | 100 ms | fail-open | `request.meta.read` |
-| `log.beforePersist` | Request 或 audit log 持久化前 | redacted log fields | 100 ms | fail-closed-to-host-redaction | `log.redact` |
+| `gateway.request.afterBodyRead` | Body reader 完成 allowed body buffering 后 | JSON body、raw body metadata | 200 ms | fail-open | `request.body.read`, `request.body.write`, `model.invoke` |
+| `gateway.request.beforeSend` | reqwest 发送 upstream request 前 | headers 和 body | 300 ms | fail-open 或 security fail-closed | `request.header.write`, `request.body.write`, `model.invoke` |
+| `gateway.response.chunk` | CLI output 前的 stream chunk | chunk pass、replace、block、warn | 20 ms | security fail-closed、non-security fail-open | `stream.inspect`, `stream.modify`, `model.invoke` |
+| `gateway.response.after` | 大小预算内的完整 non-stream response | body pass、replace、block、warn | 300 ms | security fail-closed、non-security fail-open | `response.body.read`, `response.body.write`, `model.invoke` |
+| `gateway.error` | 观察到 host 或 upstream error 后 | 不隐藏 host error | 100 ms | fail-open | `request.meta.read`, `model.invoke` |
+| `log.beforePersist` | Request 或 audit log 持久化前 | redacted log fields | 100 ms | fail-closed-to-host-redaction | `log.redact`, `model.invoke` |
 
 Streaming hooks 接收 bounded chunks 和固定大小 sliding window，不会接收无限制完整响应。
 
@@ -136,6 +136,7 @@ Reserved permissions for future host-mediated APIs 会被记录下来以稳定�
 | `stream.inspect` | high | 检查 streamed chunks 和 sliding window。 |
 | `stream.modify` | high | 替换或阻断 streamed chunks。 |
 | `log.redact` | medium | 持久化前脱敏 log fields。 |
+| `model.invoke` | high | 通过宿主控制的 provider/model 通道发起有界模型调用，不暴露 provider credentials。 |
 
 Reserved permissions：
 
@@ -164,6 +165,8 @@ Validation 会拒绝：
 - 没有匹配 body read/write permission 却写 body。
 - 没有 `stream.modify` 却执行 `stream.modify` actions。
 - 在 host 提供对应 API 前请求 `network.fetch`、`file.read`、`file.write` 或 `secret.read`。
+
+`model.invoke` 是 active high-risk permission。宿主负责 provider credential lookup、timeout、request/response size caps、错误归一化和 failure isolation；插件不能直接访问 API keys 或任意网络能力。
 
 ## 9. Config Schema 子集
 

--- a/docs/plugins/plugin-api-v1-contract.json
+++ b/docs/plugins/plugin-api-v1-contract.json
@@ -15,13 +15,7 @@
     "gateway.request.beforeProviderResolution",
     "gateway.response.headers"
   ],
-  "activeMutationFields": [
-    "requestBody",
-    "responseBody",
-    "streamChunk",
-    "logMessage",
-    "headers"
-  ],
+  "activeMutationFields": ["requestBody", "responseBody", "streamChunk", "logMessage", "headers"],
   "configSchemaTypes": ["object", "array", "string", "password", "number", "integer", "boolean"],
   "activePermissions": [
     "request.meta.read",
@@ -36,7 +30,8 @@
     "response.body.write",
     "stream.inspect",
     "stream.modify",
-    "log.redact"
+    "log.redact",
+    "model.invoke"
   ],
   "reservedPermissions": [
     "plugin.storage",
@@ -52,7 +47,8 @@
         "request.meta.read",
         "request.header.read",
         "request.header.readSensitive",
-        "request.body.read"
+        "request.body.read",
+        "model.invoke"
       ],
       "writePermissions": ["request.header.write", "request.body.write"],
       "mutationFields": ["headers", "requestBody"],
@@ -74,7 +70,8 @@
         "request.meta.read",
         "request.header.read",
         "request.header.readSensitive",
-        "request.body.read"
+        "request.body.read",
+        "model.invoke"
       ],
       "writePermissions": ["request.header.write", "request.body.write"],
       "mutationFields": ["headers", "requestBody"],
@@ -92,38 +89,28 @@
     },
     "gateway.response.chunk": {
       "phase": "for each bounded streaming response chunk",
-      "readPermissions": ["stream.inspect"],
+      "readPermissions": ["stream.inspect", "model.invoke"],
       "writePermissions": ["stream.modify"],
       "mutationFields": ["streamChunk"],
       "contextFields": ["traceId", "stream.sequence", "stream.chunk"]
     },
     "gateway.response.after": {
       "phase": "after a complete non-streaming upstream response body is available",
-      "readPermissions": ["response.header.read", "response.body.read"],
+      "readPermissions": ["response.header.read", "response.body.read", "model.invoke"],
       "writePermissions": ["response.header.write", "response.body.write"],
       "mutationFields": ["headers", "responseBody"],
-      "contextFields": [
-        "traceId",
-        "response.status",
-        "response.headers",
-        "response.body"
-      ]
+      "contextFields": ["traceId", "response.status", "response.headers", "response.body"]
     },
     "gateway.error": {
       "phase": "after gateway error response materialization and before it is sent",
-      "readPermissions": ["response.header.read", "response.body.read"],
+      "readPermissions": ["response.header.read", "response.body.read", "model.invoke"],
       "writePermissions": ["response.header.write", "response.body.write"],
       "mutationFields": ["headers", "responseBody"],
-      "contextFields": [
-        "traceId",
-        "response.status",
-        "response.headers",
-        "response.body"
-      ]
+      "contextFields": ["traceId", "response.status", "response.headers", "response.body"]
     },
     "log.beforePersist": {
       "phase": "before gateway request log persistence",
-      "readPermissions": ["log.redact"],
+      "readPermissions": ["log.redact", "model.invoke"],
       "writePermissions": ["log.redact"],
       "mutationFields": ["logMessage"],
       "contextFields": ["traceId", "log.message"]

--- a/docs/plugins/reference/hooks.md
+++ b/docs/plugins/reference/hooks.md
@@ -15,19 +15,19 @@ Reserved hooks 在宿主实现对应调用点前，会被 manifest validation �
 
 | Hook | 阶段 | 读权限 | 写权限 | Mutation fields | Context fields |
 | --- | --- | --- | --- | --- | --- |
-| `gateway.request.afterBodyRead` | 读取 request body 后、发送 upstream provider 前。 | `request.meta.read`, `request.header.read`, `request.header.readSensitive`, `request.body.read` | `request.header.write`, `request.body.write` | `headers`, `requestBody` | `traceId`, `request.cliKey`, `request.method`, `request.path`, `request.query`, `request.headers`, `request.body`, `request.requestedModel`, `request.normalizedMessages` |
-| `gateway.request.beforeSend` | provider resolution 后、发送 upstream provider 前。 | `request.meta.read`, `request.header.read`, `request.header.readSensitive`, `request.body.read` | `request.header.write`, `request.body.write` | `headers`, `requestBody` | `traceId`, `request.cliKey`, `request.method`, `request.path`, `request.query`, `request.headers`, `request.body`, `request.requestedModel`, `request.normalizedMessages` |
-| `gateway.response.chunk` | 每个有边界的 streaming response chunk。 | `stream.inspect` | `stream.modify` | `streamChunk` | `traceId`, `stream.sequence`, `stream.chunk` |
-| `gateway.response.after` | 完整 non-streaming upstream response body 可用后。 | `response.header.read`, `response.body.read` | `response.header.write`, `response.body.write` | `headers`, `responseBody` | `traceId`, `response.status`, `response.headers`, `response.body` |
-| `gateway.error` | gateway error response materialization 后、发送前。 | `response.header.read`, `response.body.read` | `response.header.write`, `response.body.write` | `headers`, `responseBody` | `traceId`, `response.status`, `response.headers`, `response.body` |
-| `log.beforePersist` | gateway request log persistence 前。 | `log.redact` | `log.redact` | `logMessage` | `traceId`, `log.message` |
+| `gateway.request.afterBodyRead` | 读取 request body 后、发送 upstream provider 前。 | `request.meta.read`, `request.header.read`, `request.header.readSensitive`, `request.body.read`, `model.invoke` | `request.header.write`, `request.body.write` | `headers`, `requestBody` | `traceId`, `request.cliKey`, `request.method`, `request.path`, `request.query`, `request.headers`, `request.body`, `request.requestedModel`, `request.normalizedMessages` |
+| `gateway.request.beforeSend` | provider resolution 后、发送 upstream provider 前。 | `request.meta.read`, `request.header.read`, `request.header.readSensitive`, `request.body.read`, `model.invoke` | `request.header.write`, `request.body.write` | `headers`, `requestBody` | `traceId`, `request.cliKey`, `request.method`, `request.path`, `request.query`, `request.headers`, `request.body`, `request.requestedModel`, `request.normalizedMessages` |
+| `gateway.response.chunk` | 每个有边界的 streaming response chunk。 | `stream.inspect`, `model.invoke` | `stream.modify` | `streamChunk` | `traceId`, `stream.sequence`, `stream.chunk` |
+| `gateway.response.after` | 完整 non-streaming upstream response body 可用后。 | `response.header.read`, `response.body.read`, `model.invoke` | `response.header.write`, `response.body.write` | `headers`, `responseBody` | `traceId`, `response.status`, `response.headers`, `response.body` |
+| `gateway.error` | gateway error response materialization 后、发送前。 | `response.header.read`, `response.body.read`, `model.invoke` | `response.header.write`, `response.body.write` | `headers`, `responseBody` | `traceId`, `response.status`, `response.headers`, `response.body` |
+| `log.beforePersist` | gateway request log persistence 前。 | `log.redact`, `model.invoke` | `log.redact` | `logMessage` | `traceId`, `log.message` |
 
 ## gateway.request.afterBodyRead
 
 - 阶段：读取 request body 后、发送 upstream provider 前。
 - 默认超时：150 ms。
 - 默认失败策略：`fail-open`。
-- 读权限：`request.meta.read`、`request.header.read`、`request.header.readSensitive`、`request.body.read`。
+- 读权限：`request.meta.read`、`request.header.read`、`request.header.readSensitive`、`request.body.read`、`model.invoke`。
 - 写权限：`request.header.write`、`request.body.write`。
 - Mutation fields：`headers`、`requestBody`。
 - Provider-neutral field：`request.normalizedMessages`。
@@ -78,7 +78,7 @@ Codex/OpenAI Responses-style fixture：
 - 阶段：provider resolution 后、发送 upstream provider 前。
 - 默认超时：150 ms。
 - 默认失败策略：`fail-open`。
-- 读权限：`request.meta.read`、`request.header.read`、`request.header.readSensitive`、`request.body.read`。
+- 读权限：`request.meta.read`、`request.header.read`、`request.header.readSensitive`、`request.body.read`、`model.invoke`。
 - 写权限：`request.header.write`、`request.body.write`。
 - Mutation fields：`headers`、`requestBody`。
 - Provider-neutral field：`request.normalizedMessages`。
@@ -92,7 +92,7 @@ Codex/OpenAI Responses-style fixture：
 - 阶段：每个有边界的 streaming response chunk。
 - 默认超时：150 ms。
 - 默认失败策略：`fail-open`。
-- 读权限：`stream.inspect`。
+- 读权限：`stream.inspect`、`model.invoke`。
 - 写权限：`stream.modify`。
 - Mutation fields：`streamChunk`。
 - Context fields：`traceId`、`stream.sequence`、`stream.chunk`。
@@ -104,7 +104,7 @@ Codex/OpenAI Responses-style fixture：
 - 阶段：完整 non-streaming upstream response body 可用后。
 - 默认超时：150 ms。
 - 默认失败策略：`fail-open`。
-- 读权限：`response.header.read`、`response.body.read`。
+- 读权限：`response.header.read`、`response.body.read`、`model.invoke`。
 - 写权限：`response.header.write`、`response.body.write`。
 - Mutation fields：`headers`、`responseBody`。
 - Context fields：`traceId`、`response.status`、`response.headers`、`response.body`。
@@ -116,7 +116,7 @@ Codex/OpenAI Responses-style fixture：
 - 阶段：gateway error response materialization 后、发送前。
 - 默认超时：150 ms。
 - 默认失败策略：`fail-open`。
-- 读权限：`response.header.read`、`response.body.read`。
+- 读权限：`response.header.read`、`response.body.read`、`model.invoke`。
 - 写权限：`response.header.write`、`response.body.write`。
 - Mutation fields：`headers`、`responseBody`。
 - Context fields：`traceId`、`response.status`、`response.headers`、`response.body`。
@@ -128,7 +128,7 @@ Codex/OpenAI Responses-style fixture：
 - 阶段：gateway request log persistence 前。
 - 默认超时：150 ms。
 - 默认失败策略：`fail-open`。
-- 读权限：`log.redact`。
+- 读权限：`log.redact`、`model.invoke`。
 - 写权限：`log.redact`。
 - Mutation fields：`logMessage`。
 - Context fields：`traceId`、`log.message`。

--- a/docs/plugins/reference/manifest.md
+++ b/docs/plugins/reference/manifest.md
@@ -37,4 +37,4 @@
 
 `configSchema` 可以包含标准 JSON Schema 展示字段和 AIO `x-aio-ui` 元数据。详见 [Config Schema](./config-schema.md)。
 
-plugin API v1 的 active hooks 见 [Hooks](./hooks.md)。Reserved hooks 和 reserved permissions 只是为未来兼容命名保留；在宿主真正实现前，manifest 校验会拒绝它们。
+plugin API v1 的 active hooks 见 [Hooks](./hooks.md)。`model.invoke` 是 active 的 host-mediated permission。Reserved hooks 和 reserved permissions 只是为未来兼容命名保留；在宿主真正实现前，manifest 校验会拒绝它们。

--- a/docs/plugins/reference/permissions.md
+++ b/docs/plugins/reference/permissions.md
@@ -17,6 +17,7 @@ Permissions 必须显式声明，并按风险分级。宿主在调用插件前�
 - `stream.inspect`：高风险，读取流式响应 chunk 和 sliding window。
 - `stream.modify`：高风险，替换或阻断流式响应 chunk。
 - `log.redact`：中风险，在日志持久化前脱敏。
+- `model.invoke`：高风险，通过宿主控制的 provider/model 通道发起有界模型调用；插件不能读取 provider credentials。
 
 为未来 host-mediated APIs 保留的权限：
 

--- a/docs/plugins/reference/sdk.md
+++ b/docs/plugins/reference/sdk.md
@@ -111,7 +111,7 @@ SDK 是契约包。它不执行插件代码，也不会授予宿主能力。
 
 Rust/WASM SDK 遵循同样边界。它只负责序列化 ABI-compatible JSON、定义 hook result helpers，并提供 `aio_plugin_entrypoint!` macro 用于导出 `aio_plugin_handle`。
 
-`PluginHookResult` 使用与 gateway host 相同的 active mutation envelope：
+`PluginHookResult` 使用与 gateway host 相同的 active mutation envelope，并可附带 `audit` 数组让宿主持久化为插件审计记录：
 
 ```ts
 const result = {
@@ -121,7 +121,7 @@ const result = {
 } satisfies PluginHookResult;
 ```
 
-替换内容时使用 `requestBody`、`responseBody`、`streamChunk`、`logMessage` 和 `headers`。`contextPatch` 不是 active vNext gateway mutation field。
+替换内容时使用 `requestBody`、`responseBody`、`streamChunk`、`logMessage` 和 `headers`。`audit` 只用于宿主审计记录，不参与主响应 mutation。`contextPatch` 不是 active vNext gateway mutation field。
 
 真正的宿主强制检查仍发生在 Rust application 中：
 

--- a/packages/plugin-sdk/src/index.test.ts
+++ b/packages/plugin-sdk/src/index.test.ts
@@ -68,6 +68,15 @@ describe("validateManifest", () => {
     });
   });
 
+  it("allows model invocation permission on active hooks", () => {
+    expect(
+      validateManifest({
+        ...manifest,
+        permissions: ["request.body.read", "model.invoke"],
+      })
+    ).toEqual({ ok: true });
+  });
+
   it("rejects write permissions without their required read permissions", () => {
     expect(
       validateManifest({
@@ -160,6 +169,7 @@ describe("PluginHookResult", () => {
       requestBody: '{"messages":[]}',
       responseBody: '{"ok":true}',
       headers: { "x-plugin-redacted": "1" },
+      audit: [{ eventType: "plugin.audit.test", message: "recorded" }],
     };
 
     expect(result).toEqual({
@@ -167,6 +177,7 @@ describe("PluginHookResult", () => {
       requestBody: '{"messages":[]}',
       responseBody: '{"ok":true}',
       headers: { "x-plugin-redacted": "1" },
+      audit: [{ eventType: "plugin.audit.test", message: "recorded" }],
     });
     expect("contextPatch" in result).toBe(false);
   });

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -30,6 +30,7 @@ export type PluginPermission =
   | "stream.modify"
   | "log.redact"
   | "plugin.storage"
+  | "model.invoke"
   | "network.fetch"
   | "file.read"
   | "file.write"
@@ -160,6 +161,7 @@ const PERMISSION_RISKS: Record<PluginPermission, PluginPermissionRisk> = {
   "stream.modify": "high",
   "log.redact": "medium",
   "plugin.storage": "medium",
+  "model.invoke": "high",
   "network.fetch": "high",
   "file.read": "high",
   "file.write": "high",
@@ -315,7 +317,9 @@ function hookAllowsPermission(hookName: GatewayHookName, permission: PluginPermi
     permission === "request.body.read" ||
     permission === "request.body.write"
   ) {
-    return hookName === "gateway.request.afterBodyRead" || hookName === "gateway.request.beforeSend";
+    return (
+      hookName === "gateway.request.afterBodyRead" || hookName === "gateway.request.beforeSend"
+    );
   }
   if (
     permission === "response.header.read" ||
@@ -329,6 +333,7 @@ function hookAllowsPermission(hookName: GatewayHookName, permission: PluginPermi
     return hookName === "gateway.response.chunk";
   }
   if (permission === "log.redact") return hookName === "log.beforePersist";
+  if (permission === "model.invoke") return !RESERVED_HOOKS.has(hookName);
   return false;
 }
 

--- a/src-tauri/src/app/plugins/wasm_runtime.rs
+++ b/src-tauri/src/app/plugins/wasm_runtime.rs
@@ -281,6 +281,7 @@ fn gateway_hook_result_from_wasm_output(value: Value) -> AppResult<GatewayHookRe
             ));
         }
     }
+    result.audit = optional_value_array(object, "audit")?.unwrap_or_default();
     Ok(result)
 }
 
@@ -296,6 +297,25 @@ fn optional_string(
             format!("WASM plugin output field {key} must be a string"),
         )),
     }
+}
+
+fn optional_value_array(
+    object: &serde_json::Map<String, Value>,
+    key: &'static str,
+) -> AppResult<Option<Vec<Value>>> {
+    let Some(value) = object.get(key) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(items) = value.as_array() else {
+        return Err(AppError::new(
+            "PLUGIN_WASM_INVALID_OUTPUT",
+            format!("WASM plugin output field {key} must be an array"),
+        ));
+    };
+    Ok(Some(items.clone()))
 }
 
 fn optional_string_map(

--- a/src-tauri/src/domain/plugins.rs
+++ b/src-tauri/src/domain/plugins.rs
@@ -268,6 +268,7 @@ pub fn permission_risk(permission: &str) -> Option<PluginPermissionRisk> {
         "stream.modify" => Some(PluginPermissionRisk::High),
         "log.redact" => Some(PluginPermissionRisk::Medium),
         "plugin.storage" => Some(PluginPermissionRisk::Medium),
+        "model.invoke" => Some(PluginPermissionRisk::High),
         "network.fetch" => Some(PluginPermissionRisk::High),
         "file.read" => Some(PluginPermissionRisk::High),
         "file.write" => Some(PluginPermissionRisk::High),
@@ -461,6 +462,7 @@ fn hook_allows_permission(hook_name: &str, permission: &str) -> bool {
         }
         "stream.inspect" | "stream.modify" => hook_name == "gateway.response.chunk",
         "log.redact" => hook_name == "log.beforePersist",
+        "model.invoke" => is_active_gateway_hook(hook_name),
         _ => false,
     }
 }

--- a/src-tauri/src/gateway/plugins/context.rs
+++ b/src-tauri/src/gateway/plugins/context.rs
@@ -236,6 +236,7 @@ pub(crate) struct GatewayHookResult {
     pub(crate) headers: BTreeMap<String, String>,
     pub(crate) log_message: Option<String>,
     pub(crate) reason: Option<String>,
+    pub(crate) audit: Vec<serde_json::Value>,
 }
 
 impl GatewayHookResult {
@@ -248,6 +249,7 @@ impl GatewayHookResult {
             headers: BTreeMap::new(),
             log_message: None,
             reason: None,
+            audit: Vec::new(),
         }
     }
 }

--- a/src-tauri/src/gateway/plugins/mod.rs
+++ b/src-tauri/src/gateway/plugins/mod.rs
@@ -2,5 +2,6 @@
 
 pub(crate) mod audit;
 pub(crate) mod context;
+pub(crate) mod model_invoke;
 pub(crate) mod permissions;
 pub(crate) mod pipeline;

--- a/src-tauri/src/gateway/plugins/model_invoke.rs
+++ b/src-tauri/src/gateway/plugins/model_invoke.rs
@@ -1,0 +1,511 @@
+//! Usage: Host-mediated model invocation capability for gateway plugins.
+#![allow(dead_code)]
+
+use crate::gateway::util::{build_target_url, ensure_cli_required_headers, inject_provider_auth};
+use crate::shared::time::now_unix_millis;
+use axum::http::{header, HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+const MODEL_INVOKE_PATH: &str = "/v1/responses";
+const MAX_MODEL_BYTES: usize = 256;
+const MAX_REQUEST_BYTES: usize = 128 * 1024;
+const DEFAULT_TIMEOUT_MS: u64 = 15_000;
+const MAX_TIMEOUT_MS: u64 = 30_000;
+const DEFAULT_MAX_RESPONSE_BYTES: usize = 64 * 1024;
+const MAX_RESPONSE_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ModelInvokeInput {
+    pub(crate) provider_id: i64,
+    pub(crate) model: String,
+    pub(crate) body: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) timeout_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) max_response_bytes: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) trace_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ModelInvokeOutput {
+    pub(crate) ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) status: Option<u16>,
+    pub(crate) duration_ms: u64,
+    pub(crate) provider_id: i64,
+    pub(crate) provider_name: String,
+    pub(crate) model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) response_body: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) usage: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) error: Option<ModelInvokeError>,
+    pub(crate) truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ModelInvokeError {
+    pub(crate) code: String,
+    pub(crate) message: String,
+}
+
+struct ModelInvokeProvider {
+    id: i64,
+    name: String,
+    cli_key: String,
+    base_url: String,
+    api_key: String,
+}
+
+pub(crate) async fn invoke_model(
+    db: &crate::db::Db,
+    client: reqwest::Client,
+    input: ModelInvokeInput,
+) -> ModelInvokeOutput {
+    let started = Instant::now();
+    let provider = match load_provider(db, input.provider_id) {
+        Ok(provider) => provider,
+        Err(err) => return error_output(&input, started, err.0, err.1),
+    };
+    let body_bytes = match build_request_body(&input) {
+        Ok(body_bytes) => body_bytes,
+        Err(err) => return error_output_for_provider(&input, &provider, started, err.0, err.1),
+    };
+    let url = match build_target_url(&provider.base_url, MODEL_INVOKE_PATH, None) {
+        Ok(url) => url,
+        Err(message) => {
+            return error_output_for_provider(
+                &input,
+                &provider,
+                started,
+                "MODEL_INVOKE_INVALID_PROVIDER_URL",
+                message,
+            )
+        }
+    };
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+    headers.insert(header::ACCEPT, HeaderValue::from_static("application/json"));
+    ensure_cli_required_headers(&provider.cli_key, &mut headers);
+    inject_provider_auth(&provider.cli_key, &provider.api_key, &mut headers);
+
+    let timeout = Duration::from_millis(normalize_timeout_ms(input.timeout_ms));
+    let max_response_bytes = normalize_max_response_bytes(input.max_response_bytes);
+    let sent_at_unix_ms = now_unix_millis();
+    tracing::debug!(
+        provider_id = provider.id,
+        provider_name = %provider.name,
+        trace_id = input.trace_id.as_deref().unwrap_or(""),
+        sent_at_unix_ms,
+        "plugin model.invoke dispatching host-mediated request"
+    );
+
+    let response = client
+        .post(url)
+        .headers(headers)
+        .body(body_bytes)
+        .timeout(timeout)
+        .send()
+        .await;
+
+    let response = match response {
+        Ok(response) => response,
+        Err(err) => {
+            let code = if err.is_timeout() {
+                "MODEL_INVOKE_TIMEOUT"
+            } else {
+                "MODEL_INVOKE_REQUEST_FAILED"
+            };
+            return error_output_for_provider(&input, &provider, started, code, err.to_string());
+        }
+    };
+
+    let status = response.status();
+    let status_u16 = status.as_u16();
+    let (response_bytes, truncated) =
+        match read_response_body_limited(response, max_response_bytes).await {
+            Ok(body) => body,
+            Err(err) => {
+                return error_output_for_provider(
+                    &input,
+                    &provider,
+                    started,
+                    "MODEL_INVOKE_RESPONSE_READ_FAILED",
+                    err.to_string(),
+                )
+            }
+        };
+    let response_body = String::from_utf8_lossy(&response_bytes).into_owned();
+    let usage = response_usage(&response_body);
+    let ok = status.is_success();
+    ModelInvokeOutput {
+        ok,
+        status: Some(status_u16),
+        duration_ms: elapsed_ms(started),
+        provider_id: provider.id,
+        provider_name: provider.name,
+        model: normalized_model(&input.model),
+        response_body: Some(response_body),
+        usage,
+        error: (!ok).then(|| ModelInvokeError {
+            code: "MODEL_INVOKE_UPSTREAM_STATUS".to_string(),
+            message: format!("upstream returned HTTP {status_u16}"),
+        }),
+        truncated,
+    }
+}
+
+fn load_provider(
+    db: &crate::db::Db,
+    provider_id: i64,
+) -> Result<ModelInvokeProvider, (&'static str, String)> {
+    if provider_id <= 0 {
+        return Err((
+            "MODEL_INVOKE_INVALID_PROVIDER",
+            "providerId must be positive".to_string(),
+        ));
+    }
+    let conn = db.open_connection().map_err(|err| {
+        (
+            "MODEL_INVOKE_PROVIDER_LOOKUP_FAILED",
+            format!("failed to open provider database connection: {err}"),
+        )
+    })?;
+    let summary = crate::providers::get_by_id(&conn, provider_id).map_err(|err| {
+        (
+            "MODEL_INVOKE_PROVIDER_NOT_FOUND",
+            format!("provider not found or unavailable: {err}"),
+        )
+    })?;
+    drop(conn);
+
+    if !summary.enabled {
+        return Err((
+            "MODEL_INVOKE_PROVIDER_DISABLED",
+            format!("provider is disabled: {provider_id}"),
+        ));
+    }
+    if summary.auth_mode != "api_key" {
+        return Err((
+            "MODEL_INVOKE_UNSUPPORTED_AUTH_MODE",
+            format!(
+                "model.invoke currently supports api_key providers, got {}",
+                summary.auth_mode
+            ),
+        ));
+    }
+    let base_url = summary
+        .base_urls
+        .iter()
+        .map(|value| value.trim())
+        .find(|value| !value.is_empty())
+        .ok_or_else(|| {
+            (
+                "MODEL_INVOKE_PROVIDER_BASE_URL_MISSING",
+                format!("provider has no base URL: {provider_id}"),
+            )
+        })?
+        .to_string();
+    let api_key = crate::providers::get_api_key_plaintext(db, provider_id).map_err(|err| {
+        (
+            "MODEL_INVOKE_PROVIDER_CREDENTIAL_FAILED",
+            format!("failed to resolve provider credential: {err}"),
+        )
+    })?;
+    if api_key.trim().is_empty() {
+        return Err((
+            "MODEL_INVOKE_PROVIDER_CREDENTIAL_MISSING",
+            format!("provider credential is empty: {provider_id}"),
+        ));
+    }
+
+    Ok(ModelInvokeProvider {
+        id: provider_id,
+        name: summary.name,
+        cli_key: summary.cli_key,
+        base_url,
+        api_key,
+    })
+}
+
+fn build_request_body(input: &ModelInvokeInput) -> Result<Vec<u8>, (&'static str, String)> {
+    let model = normalized_model(&input.model);
+    if model.is_empty() {
+        return Err((
+            "MODEL_INVOKE_INVALID_MODEL",
+            "model must be non-empty".to_string(),
+        ));
+    }
+    if model.len() > MAX_MODEL_BYTES {
+        return Err((
+            "MODEL_INVOKE_INVALID_MODEL",
+            format!("model must be at most {MAX_MODEL_BYTES} bytes"),
+        ));
+    }
+    let Some(mut body) = input.body.as_object().cloned() else {
+        return Err((
+            "MODEL_INVOKE_INVALID_BODY",
+            "body must be a JSON object".to_string(),
+        ));
+    };
+    body.insert("model".to_string(), Value::String(model));
+    body.insert("stream".to_string(), Value::Bool(false));
+    let bytes = serde_json::to_vec(&Value::Object(body)).map_err(|err| {
+        (
+            "MODEL_INVOKE_BODY_ENCODE_FAILED",
+            format!("failed to encode model.invoke request body: {err}"),
+        )
+    })?;
+    if bytes.len() > MAX_REQUEST_BYTES {
+        return Err((
+            "MODEL_INVOKE_BODY_TOO_LARGE",
+            format!("request body exceeded {MAX_REQUEST_BYTES} bytes"),
+        ));
+    }
+    Ok(bytes)
+}
+
+async fn read_response_body_limited(
+    mut response: reqwest::Response,
+    max_bytes: usize,
+) -> Result<(Vec<u8>, bool), reqwest::Error> {
+    let mut out = Vec::new();
+    let mut truncated = false;
+    while let Some(chunk) = response.chunk().await? {
+        let remaining = max_bytes.saturating_sub(out.len());
+        if chunk.len() > remaining {
+            out.extend_from_slice(&chunk[..remaining]);
+            truncated = true;
+            break;
+        }
+        out.extend_from_slice(&chunk);
+    }
+    Ok((out, truncated))
+}
+
+fn response_usage(response_body: &str) -> Option<Value> {
+    serde_json::from_str::<Value>(response_body)
+        .ok()
+        .and_then(|value| value.get("usage").cloned())
+}
+
+fn normalize_timeout_ms(timeout_ms: Option<u64>) -> u64 {
+    timeout_ms
+        .unwrap_or(DEFAULT_TIMEOUT_MS)
+        .clamp(1, MAX_TIMEOUT_MS)
+}
+
+fn normalize_max_response_bytes(max_response_bytes: Option<usize>) -> usize {
+    max_response_bytes
+        .unwrap_or(DEFAULT_MAX_RESPONSE_BYTES)
+        .clamp(1, MAX_RESPONSE_BYTES)
+}
+
+fn normalized_model(model: &str) -> String {
+    model.trim().to_string()
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+fn error_output(
+    input: &ModelInvokeInput,
+    started: Instant,
+    code: &'static str,
+    message: String,
+) -> ModelInvokeOutput {
+    ModelInvokeOutput {
+        ok: false,
+        status: None,
+        duration_ms: elapsed_ms(started),
+        provider_id: input.provider_id,
+        provider_name: String::new(),
+        model: normalized_model(&input.model),
+        response_body: None,
+        usage: None,
+        error: Some(ModelInvokeError {
+            code: code.to_string(),
+            message,
+        }),
+        truncated: false,
+    }
+}
+
+fn error_output_for_provider(
+    input: &ModelInvokeInput,
+    provider: &ModelInvokeProvider,
+    started: Instant,
+    code: &'static str,
+    message: String,
+) -> ModelInvokeOutput {
+    ModelInvokeOutput {
+        provider_id: provider.id,
+        provider_name: provider.name.clone(),
+        ..error_output(input, started, code, message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::{self, ProviderBaseUrlMode, ProviderUpsertParams};
+    use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::sync::oneshot;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn model_invoke_posts_bounded_request_with_host_auth() {
+        let (base_url, captured_rx, task) = spawn_json_upstream(
+            r#"{"id":"resp-1","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}"#,
+        )
+        .await;
+        let (_dir, db) = init_test_db();
+        let provider_id = insert_provider(&db, base_url);
+
+        let output = invoke_model(
+            &db,
+            reqwest::Client::new(),
+            ModelInvokeInput {
+                provider_id,
+                model: "gpt-test".to_string(),
+                body: json!({
+                    "input": "hello",
+                    "stream": true
+                }),
+                timeout_ms: Some(1_000),
+                max_response_bytes: Some(4 * 1024),
+                trace_id: Some("trace-model-invoke".to_string()),
+            },
+        )
+        .await;
+
+        assert!(output.ok, "unexpected output: {output:?}");
+        assert_eq!(output.status, Some(200));
+        assert_eq!(output.provider_name, "Model Invoke Test");
+        assert_eq!(
+            output.usage,
+            Some(json!({ "input_tokens": 1, "output_tokens": 2, "total_tokens": 3 }))
+        );
+        let captured = captured_rx.await.expect("captured request");
+        assert!(
+            captured.starts_with("POST /v1/responses HTTP/1.1"),
+            "{captured}"
+        );
+        assert!(
+            captured.contains("authorization: Bearer sk-model-invoke-test"),
+            "{captured}"
+        );
+        assert!(captured.contains(r#""model":"gpt-test""#), "{captured}");
+        assert!(captured.contains(r#""stream":false"#), "{captured}");
+
+        task.await.expect("upstream task");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn model_invoke_truncates_large_response_body() {
+        let (base_url, _captured_rx, task) = spawn_json_upstream(r#"{"value":"abcdef"}"#).await;
+        let (_dir, db) = init_test_db();
+        let provider_id = insert_provider(&db, base_url);
+
+        let output = invoke_model(
+            &db,
+            reqwest::Client::new(),
+            ModelInvokeInput {
+                provider_id,
+                model: "gpt-test".to_string(),
+                body: json!({ "input": "hello" }),
+                timeout_ms: Some(1_000),
+                max_response_bytes: Some(8),
+                trace_id: None,
+            },
+        )
+        .await;
+
+        assert!(output.ok, "unexpected output: {output:?}");
+        assert!(output.truncated);
+        assert_eq!(output.response_body.as_deref(), Some("{\"value\""));
+
+        task.await.expect("upstream task");
+    }
+
+    fn init_test_db() -> (tempfile::TempDir, crate::db::Db) {
+        let dir = tempfile::tempdir().expect("db dir");
+        let db = crate::db::init_for_tests(&dir.path().join("model-invoke.sqlite"))
+            .expect("init test db");
+        (dir, db)
+    }
+
+    fn insert_provider(db: &crate::db::Db, base_url: String) -> i64 {
+        providers::upsert(
+            db,
+            ProviderUpsertParams {
+                provider_id: None,
+                cli_key: "codex".to_string(),
+                name: "Model Invoke Test".to_string(),
+                base_urls: vec![base_url],
+                base_url_mode: ProviderBaseUrlMode::Order,
+                auth_mode: None,
+                api_key: Some("sk-model-invoke-test".to_string()),
+                enabled: true,
+                cost_multiplier: 1.0,
+                priority: Some(0),
+                claude_models: None,
+                limit_5h_usd: None,
+                limit_daily_usd: None,
+                daily_reset_mode: None,
+                daily_reset_time: None,
+                limit_weekly_usd: None,
+                limit_monthly_usd: None,
+                limit_total_usd: None,
+                tags: None,
+                note: None,
+                source_provider_id: None,
+                bridge_type: None,
+                stream_idle_timeout_seconds: None,
+            },
+        )
+        .expect("insert provider")
+        .id
+    }
+
+    async fn spawn_json_upstream(
+        body: &'static str,
+    ) -> (
+        String,
+        oneshot::Receiver<String>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind model invoke upstream");
+        let addr = listener.local_addr().expect("upstream addr");
+        let (captured_tx, captured_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let mut buf = vec![0_u8; 8192];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                let captured = String::from_utf8_lossy(&buf[..n]).into_owned();
+                let _ = captured_tx.send(captured);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(), body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            }
+        });
+        (format!("http://{addr}"), captured_rx, task)
+    }
+}

--- a/src-tauri/src/gateway/plugins/permissions.rs
+++ b/src-tauri/src/gateway/plugins/permissions.rs
@@ -80,6 +80,12 @@ pub(crate) fn permission_allows_hook_access(
         }
         "log.redact" => matches!(hook_name, GatewayPluginHookName::LogBeforePersist),
         "plugin.storage" => true,
+        "model.invoke" => !matches!(
+            hook_name,
+            GatewayPluginHookName::RequestReceived
+                | GatewayPluginHookName::RequestBeforeProviderResolution
+                | GatewayPluginHookName::ResponseHeaders
+        ),
         "network.fetch" | "file.read" | "file.write" | "secret.read" => false,
         _ => false,
     }
@@ -204,6 +210,7 @@ mod tests {
             headers: Default::default(),
             log_message: None,
             reason: None,
+            audit: Vec::new(),
         };
         let err = enforce_hook_result_permissions(
             GatewayPluginHookName::RequestBeforeSend,

--- a/src-tauri/src/gateway/plugins/pipeline.rs
+++ b/src-tauri/src/gateway/plugins/pipeline.rs
@@ -304,6 +304,11 @@ impl GatewayPluginPipeline {
             }
 
             self.record_success(&plugin.summary.plugin_id);
+            audit_events.extend(plugin_returned_audit_events(
+                plugin,
+                input.hook_name,
+                &result.audit,
+            ));
             apply_header_patch(&mut headers, &result.headers)
                 .map_err(|err| err.with_audit_events(audit_events.clone()))?;
             if let Some(next_body) = result.request_body {
@@ -417,6 +422,11 @@ impl GatewayPluginPipeline {
             }
 
             self.record_success(&plugin.summary.plugin_id);
+            audit_events.extend(plugin_returned_audit_events(
+                plugin,
+                input.hook_name,
+                &result.audit,
+            ));
             apply_header_patch(&mut headers, &result.headers)
                 .map_err(|err| err.with_audit_events(audit_events.clone()))?;
             if let Some(next_body) = result.response_body {
@@ -520,6 +530,11 @@ impl GatewayPluginPipeline {
             }
 
             self.record_success(&plugin.summary.plugin_id);
+            audit_events.extend(plugin_returned_audit_events(
+                plugin,
+                hook_name,
+                &result.audit,
+            ));
             if let Some(next_chunk) = result.stream_chunk {
                 chunk = Bytes::from(next_chunk);
             }
@@ -618,6 +633,11 @@ impl GatewayPluginPipeline {
             }
 
             self.record_success(&plugin.summary.plugin_id);
+            audit_events.extend(plugin_returned_audit_events(
+                plugin,
+                hook_name,
+                &result.audit,
+            ));
             if let Some(next_message) = result.log_message {
                 message = next_message;
             }
@@ -838,6 +858,45 @@ fn audit_event(
         message: message.to_string(),
         details,
     }
+}
+
+fn plugin_returned_audit_events(
+    plugin: &PluginDetail,
+    hook_name: GatewayPluginHookName,
+    records: &[serde_json::Value],
+) -> Vec<GatewayPluginAuditEvent> {
+    records
+        .iter()
+        .map(|record| plugin_returned_audit_event(plugin, hook_name, record))
+        .collect()
+}
+
+fn plugin_returned_audit_event(
+    plugin: &PluginDetail,
+    hook_name: GatewayPluginHookName,
+    record: &serde_json::Value,
+) -> GatewayPluginAuditEvent {
+    let event_type = record
+        .get("eventType")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("plugin.audit.recorded");
+    let risk_level = record
+        .get("riskLevel")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("low");
+    let message = record
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("Plugin audit record");
+    let details = record
+        .get("details")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({ "record": record }));
+
+    audit_event(plugin, hook_name, event_type, risk_level, message, details)
 }
 
 fn completed_event(
@@ -1326,6 +1385,12 @@ mod tests {
                 assert_eq!(ctx.request.body.as_deref(), Some("hello"));
                 GatewayHookResult {
                     request_body: Some("hello a".to_string()),
+                    audit: vec![serde_json::json!({
+                        "eventType": "plugin.audit.custom",
+                        "riskLevel": "medium",
+                        "message": "plugin audit from test",
+                        "details": { "source": "test" }
+                    })],
                     ..GatewayHookResult::continue_unchanged()
                 }
             })
@@ -1367,6 +1432,17 @@ mod tests {
         assert_eq!(calls.lock().unwrap().as_slice(), ["a", "b"]);
         assert!(output.audit_events.iter().any(|event| {
             event.plugin_id == "plugin.a" && event.event_type == "plugin.hook.completed"
+        }));
+        assert!(output.audit_events.iter().any(|event| {
+            event.plugin_id == "plugin.a"
+                && event.event_type == "plugin.audit.custom"
+                && event.risk_level == "medium"
+                && event.message == "plugin audit from test"
+                && event
+                    .details
+                    .get("source")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("test")
         }));
     }
 

--- a/src-tauri/src/gateway/util.rs
+++ b/src-tauri/src/gateway/util.rs
@@ -498,7 +498,7 @@ pub(super) fn strip_hop_headers(headers: &mut HeaderMap) {
     headers.remove(header::UPGRADE);
 }
 
-pub(super) fn build_target_url(
+pub(crate) fn build_target_url(
     base_url: &str,
     forwarded_path: &str,
     query: Option<&str>,
@@ -545,7 +545,7 @@ pub(super) fn clear_all_auth_headers(headers: &mut HeaderMap) {
     headers.remove("x-goog-api-client");
 }
 
-pub(super) fn inject_provider_auth(cli_key: &str, api_key: &str, headers: &mut HeaderMap) {
+pub(crate) fn inject_provider_auth(cli_key: &str, api_key: &str, headers: &mut HeaderMap) {
     clear_all_auth_headers(headers);
 
     if let Some(strategy) = crate::gateway::cli_auth::global_cli_auth_registry().get(cli_key) {
@@ -553,7 +553,7 @@ pub(super) fn inject_provider_auth(cli_key: &str, api_key: &str, headers: &mut H
     }
 }
 
-pub(super) fn ensure_cli_required_headers(cli_key: &str, headers: &mut HeaderMap) {
+pub(crate) fn ensure_cli_required_headers(cli_key: &str, headers: &mut HeaderMap) {
     if let Some(strategy) = crate::gateway::cli_auth::global_cli_auth_registry().get(cli_key) {
         strategy.ensure_required_headers(headers);
     }

--- a/src-tauri/src/infra/request_logs/queries.rs
+++ b/src-tauri/src/infra/request_logs/queries.rs
@@ -1,6 +1,7 @@
 //! Usage: Request log queries and attempts decoding.
 
 use crate::db;
+use crate::plugins::PluginAuditLog;
 use crate::shared::error::db_err;
 use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
 use serde::Deserialize;
@@ -11,6 +12,7 @@ use super::{RequestLogDetail, RequestLogRouteHop, RequestLogSummary};
 
 const CLAUDE_VISIBLE_LOG_PATH: &str = "/v1/messages";
 const CLAUDE_VISIBLE_LOG_CONDITION: &str = "(cli_key != 'claude' OR path = '/v1/messages')";
+const REQUEST_LOG_DETAIL_PLUGIN_AUDIT_LIMIT: i64 = 100;
 
 /// Common SELECT fields for request_logs queries (summary view).
 const REQUEST_LOG_SUMMARY_FIELDS: &str = "
@@ -389,7 +391,80 @@ fn row_to_detail(row: &rusqlite::Row<'_>) -> Result<RequestLogDetail, rusqlite::
         created_at: row.get("created_at")?,
         provider_chain_json: row.get("provider_chain_json").unwrap_or(None),
         error_details_json: row.get("error_details_json").unwrap_or(None),
+        plugin_audit_logs: Vec::new(),
     })
+}
+
+fn plugin_audit_log_from_row(row: &rusqlite::Row<'_>) -> Result<PluginAuditLog, rusqlite::Error> {
+    let details_json: String = row.get("details_json")?;
+    let details = serde_json::from_str::<serde_json::Value>(&details_json)
+        .unwrap_or_else(|_| serde_json::json!({ "raw": details_json }));
+    Ok(PluginAuditLog {
+        id: row.get("id")?,
+        plugin_id: row.get("plugin_id")?,
+        trace_id: row.get("trace_id")?,
+        event_type: row.get("event_type")?,
+        risk_level: row.get("risk_level")?,
+        message: row.get("message")?,
+        details,
+        created_at: row.get("created_at")?,
+    })
+}
+
+fn load_plugin_audit_logs_for_trace(
+    conn: &Connection,
+    trace_id: &str,
+) -> crate::shared::error::AppResult<Vec<PluginAuditLog>> {
+    let mut stmt = conn
+        .prepare_cached(
+            r#"
+SELECT
+  id,
+  plugin_id,
+  trace_id,
+  event_type,
+  risk_level,
+  message,
+  details_json,
+  created_at
+FROM (
+  SELECT
+    id,
+    plugin_id,
+    trace_id,
+    event_type,
+    risk_level,
+    message,
+    details_json,
+    created_at
+  FROM plugin_audit_logs
+  WHERE trace_id = ?1
+  ORDER BY created_at DESC, id DESC
+  LIMIT ?2
+)
+ORDER BY created_at ASC, id ASC
+"#,
+        )
+        .map_err(|e| db_err!("failed to prepare plugin audit detail query: {e}"))?;
+    let rows = stmt
+        .query_map(
+            params![trace_id, REQUEST_LOG_DETAIL_PLUGIN_AUDIT_LIMIT],
+            plugin_audit_log_from_row,
+        )
+        .map_err(|e| db_err!("failed to query plugin audit detail logs: {e}"))?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(|e| db_err!("failed to read plugin audit detail log: {e}"))?);
+    }
+    Ok(out)
+}
+
+fn attach_plugin_audit_logs_to_detail(
+    conn: &Connection,
+    item: &mut RequestLogDetail,
+) -> crate::shared::error::AppResult<()> {
+    item.plugin_audit_logs = load_plugin_audit_logs_for_trace(conn, &item.trace_id)?;
+    Ok(())
 }
 
 fn attach_source_provider_info_to_detail(
@@ -556,6 +631,7 @@ pub fn get_by_id(db: &db::Db, log_id: i64) -> crate::shared::error::AppResult<Re
             crate::shared::error::AppError::from("DB_NOT_FOUND: request_log not found".to_string())
         })?;
     attach_source_provider_info_to_detail(&conn, &mut item)?;
+    attach_plugin_audit_logs_to_detail(&conn, &mut item)?;
     Ok(item)
 }
 
@@ -578,6 +654,7 @@ pub fn get_by_trace_id(
         .map_err(|e| db_err!("failed to query request_log: {e}"))?;
     if let Some(detail) = item.as_mut() {
         attach_source_provider_info_to_detail(&conn, detail)?;
+        attach_plugin_audit_logs_to_detail(&conn, detail)?;
     }
     Ok(item)
 }
@@ -843,6 +920,50 @@ INSERT INTO providers (id, name, source_provider_id) VALUES (12, 'Claude Bridge'
 
         let visible_by_trace = get_by_trace_id(&db, "trace-codex").unwrap();
         assert_eq!(visible_by_trace.as_ref().map(|item| item.id), Some(3));
+    }
+
+    #[test]
+    fn detail_queries_include_trace_linked_plugin_audit_logs() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("request-logs.db");
+        let db = db::init_for_tests(&db_path).unwrap();
+        let conn = db.open_connection().unwrap();
+
+        seed_request_log(&conn, 1, "trace-plugin-audit", "codex", "/v1/responses");
+        conn.execute(
+            r#"
+INSERT INTO plugin_audit_logs (
+  plugin_id, trace_id, event_type, risk_level, message, details_json, created_at
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+"#,
+            rusqlite::params![
+                "acme.audit",
+                "trace-plugin-audit",
+                "plugin.audit.recorded",
+                "medium",
+                "Plugin recorded audit metadata",
+                r#"{"signal":"matched"}"#,
+                99_i64,
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let detail = get_by_id(&db, 1).unwrap();
+
+        assert_eq!(detail.plugin_audit_logs.len(), 1);
+        let audit = &detail.plugin_audit_logs[0];
+        assert_eq!(audit.plugin_id.as_deref(), Some("acme.audit"));
+        assert_eq!(audit.trace_id.as_deref(), Some("trace-plugin-audit"));
+        assert_eq!(audit.event_type, "plugin.audit.recorded");
+        assert_eq!(audit.risk_level, "medium");
+        assert_eq!(
+            audit
+                .details
+                .get("signal")
+                .and_then(serde_json::Value::as_str),
+            Some("matched")
+        );
     }
 
     #[test]

--- a/src-tauri/src/infra/request_logs/types.rs
+++ b/src-tauri/src/infra/request_logs/types.rs
@@ -1,5 +1,6 @@
 //! Usage: Request log DTOs and insertion payloads.
 
+use crate::plugins::PluginAuditLog;
 use serde::Serialize;
 
 #[derive(Debug, Clone)]
@@ -127,6 +128,7 @@ pub struct RequestLogDetail {
     pub cost_usd: Option<f64>,
     pub provider_chain_json: Option<String>,
     pub error_details_json: Option<String>,
+    pub plugin_audit_logs: Vec<PluginAuditLog>,
     pub cost_multiplier: f64,
     pub created_at_ms: i64,
     pub created_at: i64,

--- a/src/components/home/RequestLogDetailRawTab.tsx
+++ b/src/components/home/RequestLogDetailRawTab.tsx
@@ -9,8 +9,15 @@ export function RequestLogDetailRawTab({ selectedLog }: RequestLogDetailRawTabPr
   const errorDetailsJson = tryPrettyPrint(selectedLog.error_details_json);
   const attemptsJson = tryPrettyPrint(selectedLog.attempts_json);
   const usageJson = tryPrettyPrint(selectedLog.usage_json);
+  const pluginAuditLogsJson = selectedLog.plugin_audit_logs.length
+    ? JSON.stringify(selectedLog.plugin_audit_logs, null, 2)
+    : null;
 
-  const hasAny = errorDetailsJson != null || attemptsJson != null || usageJson != null;
+  const hasAny =
+    errorDetailsJson != null ||
+    attemptsJson != null ||
+    usageJson != null ||
+    pluginAuditLogsJson != null;
 
   if (!hasAny) {
     return <div className="text-sm text-muted-foreground">无原始数据。</div>;
@@ -38,6 +45,14 @@ export function RequestLogDetailRawTab({ selectedLog }: RequestLogDetailRawTabPr
         <DisclosureSection label="usage_json">
           <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-all text-xs font-mono text-secondary-foreground">
             {usageJson}
+          </pre>
+        </DisclosureSection>
+      ) : null}
+
+      {pluginAuditLogsJson != null ? (
+        <DisclosureSection label="plugin_audit_logs">
+          <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-all text-xs font-mono text-secondary-foreground">
+            {pluginAuditLogsJson}
           </pre>
         </DisclosureSection>
       ) : null}

--- a/src/components/home/RequestLogDetailSummaryTab.tsx
+++ b/src/components/home/RequestLogDetailSummaryTab.tsx
@@ -37,6 +37,7 @@ export function RequestLogDetailSummaryTab({
   attemptCount: _attemptCount,
 }: RequestLogDetailSummaryTabProps) {
   const auditMeta = buildRequestLogAuditMeta(selectedLog);
+  const pluginAuditLogs = selectedLog.plugin_audit_logs ?? [];
   const isPriorityServiceTier =
     selectedLog.cli_key === "codex" &&
     hasPriorityServiceTierSpecialSetting(selectedLog.special_settings_json);
@@ -70,6 +71,8 @@ export function RequestLogDetailSummaryTab({
           ) : null}
         </Card>
       ) : null}
+
+      {pluginAuditLogs.length > 0 ? <PluginAuditLogsCard logs={pluginAuditLogs} /> : null}
 
       {/* Key metrics */}
       {hasTokens ? (
@@ -123,6 +126,84 @@ export function RequestLogDetailSummaryTab({
       ) : null}
     </div>
   );
+}
+
+function PluginAuditLogsCard({ logs }: { logs: RequestLogDetail["plugin_audit_logs"] }) {
+  const visibleLogs = logs.slice(0, 5);
+
+  return (
+    <Card padding="sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-semibold text-foreground">插件审计</div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            与当前 trace 关联的通用插件审计记录
+          </div>
+        </div>
+        <span className="rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-muted-foreground ring-1 ring-inset ring-border">
+          {logs.length} 条
+        </span>
+      </div>
+
+      <div className="mt-3 space-y-2">
+        {visibleLogs.map((log) => {
+          const detailsPreview = formatPluginAuditDetailsPreview(log.details);
+          return (
+            <div
+              key={log.id}
+              className="rounded-xl border border-border/80 bg-secondary/60 px-3 py-3 dark:border-border dark:bg-secondary/50"
+            >
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span className="font-medium text-foreground">{log.plugin_id ?? "unknown"}</span>
+                <span
+                  className={cn(
+                    "rounded-full px-2 py-0.5 font-medium",
+                    riskLevelClassName(log.risk_level)
+                  )}
+                >
+                  {log.risk_level || "low"}
+                </span>
+                <span className="text-muted-foreground">{log.event_type}</span>
+              </div>
+              <div className="mt-2 text-sm text-foreground">{log.message || log.event_type}</div>
+              {detailsPreview ? (
+                <pre className="mt-2 max-h-24 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-background/80 p-2 text-xs font-mono text-muted-foreground">
+                  {detailsPreview}
+                </pre>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+
+      {logs.length > visibleLogs.length ? (
+        <div className="mt-2 text-xs text-muted-foreground">
+          仅显示前 {visibleLogs.length} 条，其余记录可在原始数据页查看。
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+function riskLevelClassName(riskLevel: string | null | undefined) {
+  switch ((riskLevel ?? "").toLowerCase()) {
+    case "critical":
+    case "high":
+      return "bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-500/15 dark:bg-rose-500/15 dark:text-rose-200 dark:ring-rose-400/20";
+    case "medium":
+      return "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-500/15 dark:bg-amber-500/15 dark:text-amber-200 dark:ring-amber-400/20";
+    default:
+      return "bg-sky-50 text-sky-700 ring-1 ring-inset ring-sky-500/15 dark:bg-sky-500/15 dark:text-sky-200 dark:ring-sky-400/20";
+  }
+}
+
+function formatPluginAuditDetailsPreview(details: unknown): string | null {
+  if (details == null) return null;
+  try {
+    return JSON.stringify(details, null, 2);
+  } catch {
+    return String(details);
+  }
 }
 
 function MetricCard({

--- a/src/components/home/__tests__/RequestLogDetailDialog.test.tsx
+++ b/src/components/home/__tests__/RequestLogDetailDialog.test.tsx
@@ -755,6 +755,38 @@ describe("home/RequestLogDetailDialog", () => {
     expect(screen.getByText("关键指标")).toBeInTheDocument();
   });
 
+  it("shows plugin audit logs on summary and raw tabs", () => {
+    setRequestLogQueryState({
+      selectedLog: createSelectedLog({
+        plugin_audit_logs: [
+          {
+            id: 1,
+            plugin_id: "acme.audit",
+            trace_id: "trace-1",
+            event_type: "plugin.audit.recorded",
+            risk_level: "medium",
+            message: "Plugin recorded audit metadata",
+            details: { signal: "matched" },
+            created_at: 1000,
+          },
+        ],
+      }),
+    });
+    setTraceStoreState({ traces: [] });
+
+    render(<RequestLogDetailDialog selectedLogId={1} onSelectLogId={vi.fn()} />);
+
+    expect(screen.getByText("插件审计")).toBeInTheDocument();
+    expect(screen.getByText("acme.audit")).toBeInTheDocument();
+    expect(screen.getByText("Plugin recorded audit metadata")).toBeInTheDocument();
+
+    switchToTab("原始数据");
+    expect(screen.getByText("plugin_audit_logs")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "plugin_audit_logs" }));
+    expect(screen.getByText(/plugin\.audit\.recorded/)).toBeInTheDocument();
+    expect(screen.getByText(/matched/)).toBeInTheDocument();
+  });
+
   it("shows raw error_details_json on raw tab when available", () => {
     const errorJson = { gateway_error_code: "GW_UPSTREAM_ALL_FAILED", upstream_status: 502 };
     setRequestLogQueryState({

--- a/src/generated/bindings.ts
+++ b/src/generated/bindings.ts
@@ -2999,6 +2999,7 @@ export type RequestLogDetail = {
   cost_usd: number | null;
   provider_chain_json: string | null;
   error_details_json: string | null;
+  plugin_audit_logs: PluginAuditLog[];
   cost_multiplier: number;
   created_at_ms: number;
   created_at: number;

--- a/src/services/gateway/requestLogFixtures.ts
+++ b/src/services/gateway/requestLogFixtures.ts
@@ -123,6 +123,7 @@ export function createRequestLogDetail(
     cost_usd: null,
     provider_chain_json: null,
     error_details_json: null,
+    plugin_audit_logs: [],
     cost_multiplier: 1,
     created_at_ms: createdAtMs,
     created_at: createdAt,


### PR DESCRIPTION
## Summary

This PR extends the host plugin API with two new generic capabilities and bridges a gap between the SDK contract and the Rust runtime. It is the **first of two workstreams** that migrate the association audit capability from PR #293 into a plugin-based architecture.

This PR is intentionally **generic** — it contains no association-audit-specific business logic. It can be reviewed and merged independently.

## Motivation

The plugin SDK already declares `PluginHookResult.audit` and the database already has a `plugin_audit_logs` table, but the Rust gateway/runtime path did not parse or persist plugin-returned audit records. Additionally, plugins had no way to call models through the host without being granted broad network access — a significant security gap.

This PR fills both gaps with minimal, generic infrastructure.

## Changes

### 1. `model.invoke` — Host-mediated model invocation capability

- **New file**: `src-tauri/src/gateway/plugins/model_invoke.rs`
- SDK declares `model.invoke` as an active high-risk permission (`packages/plugin-sdk/src/index.ts`)
- Backend validates and registers the permission (`src-tauri/src/domain/plugins.rs`, `src-tauri/src/gateway/plugins/permissions.rs`)
- `invoke_model()` helper loads the provider by ID, injects credentials, dispatches a bounded HTTP request, and returns normalized output
- Supports both `/v1/messages` (Claude path) and `/v1/responses` (Codex/OpenAI path) based on request body shape
- Bounded timeout (max 30s), request body (max 128KB), response body (max 256KB)
- API key providers only; OAuth and bridged providers are rejected
- Plugin callers never access raw API keys or network

### 2. `PluginHookResult.audit` — Bridge SDK audit declaration to runtime

- `GatewayHookResult.audit: Vec<serde_json::Value>` added to context model (`src-tauri/src/gateway/plugins/context.rs`)
- WASM runtime parses `audit` output, rejects non-array values (`src-tauri/src/app/plugins/wasm_runtime.rs`)
- Pipeline maps plugin-returned audit records into `GatewayPluginAuditEvent` with defaults (`src-tauri/src/gateway/plugins/pipeline.rs`)
- SDK tests added for both `model.invoke` permission and `PluginHookResult.audit` type (`packages/plugin-sdk/src/index.test.ts`)

### 3. Request log detail projection of plugin audit logs

- `RequestLogDetail.plugin_audit_logs: Vec<PluginAuditLog>` added (`src-tauri/src/infra/request_logs/types.rs`)
- Trace-linked query with limit 100, ordered by `created_at ASC` (`src-tauri/src/infra/request_logs/queries.rs`)
- Generated frontend binding updated (`src/generated/bindings.ts`)
- Generic `PluginAuditLogsCard` UI component on summary tab, raw JSON disclosure on raw tab
- Frontend test coverage (`src/components/home/__tests__/RequestLogDetailDialog.test.tsx`)

### 4. Documentation & Contract

- `model.invoke` documented as active high-risk, host-dispatched, credentials-not-exposed
- `docs/plugins/plugin-api-v1-contract.json` updated
- SDK reference, permissions reference, hooks reference, manifest reference updated

## Design Decisions

| Decision | Rationale |
|---|---|
| `model.invoke` instead of `network.fetch` | Host owns credentials, dispatch, timeouts, caps. This is narrower and safer than granting arbitrary network access. |
| Reuse existing `plugin_audit_logs` / `PluginAuditLog` | Avoid creating a duplicate persistence system. The existing table and types are fit for purpose. |
| Use `RequestLogDetail.plugin_audit_logs` directly | Avoids a lightweight duplicate DTO that would need sync with the canonical type. |
| Limit 100 audit logs per trace detail | Prevents unbounded payload growth on traces with many plugin audit events. |

## Verification

- `cargo check -q` passes (only pre-existing WSL warnings)
- `cargo fmt --check` passes
- `pnpm typecheck` passes
- `pnpm plugin-sdk:test` passes (12 tests)
- `pnpm check:plugin-api-contract` passes
- `pnpm check:plugin-system-docs` passes
- Rust tests are blocked by a Windows loader issue (`STATUS_ENTRYPOINT_NOT_FOUND`) in the current MSYS environment — not a code assertion failure

## Relation to PR #293

This PR provides the generic host API infrastructure that was missing when PR #293 was originally authored. The association audit capability itself will follow in a separate PR (`feat/association-audit-plugin-migration`) that consumes these APIs as a community plugin package.
