### PR TITLE
fix(gateway): stop leaking success attempt context into error_details_json

### DIFF
--- a/src-tauri/src/gateway/proxy/request_end.rs
+++ b/src-tauri/src/gateway/proxy/request_end.rs
@@ -397,19 +397,18 @@ fn select_claude_model_mapping(
     mappings.pop()
 }
 
+fn is_error_attempt(attempt: &FailoverAttempt) -> bool {
+    attempt.error_code.is_some()
+        || attempt.error_category.is_some()
+        || attempt.reason.as_deref().and_then(non_empty_text).is_some()
+}
+
 fn select_error_observation_attempt(attempts: &[FailoverAttempt]) -> Option<&FailoverAttempt> {
+    // decision/reason_code/status are also set on success — key off real error signals only.
     attempts
         .iter()
         .rev()
-        .find(|attempt| {
-            attempt.error_code.is_some()
-                || attempt.error_category.is_some()
-                || attempt.reason.as_deref().and_then(non_empty_text).is_some()
-                || attempt.decision.is_some()
-                || attempt.reason_code.is_some()
-                || attempt.status.is_some()
-        })
-        .or_else(|| attempts.last())
+        .find(|attempt| is_error_attempt(attempt))
 }
 
 fn split_attempt_reason(reason: &str) -> (Option<&str>, Option<&str>, Option<&str>) {
@@ -458,6 +457,11 @@ fn build_error_details_json(
     error_code: Option<&str>,
     attempts: &[FailoverAttempt],
 ) -> Option<String> {
+    // Short-circuit pure-success requests; otherwise success attempts leak status=200 etc.
+    if error_code.is_none() && !attempts.iter().any(is_error_attempt) {
+        return None;
+    }
+
     let mut obj = serde_json::Map::new();
 
     if let Some(gateway_error_code) = error_code {
@@ -1629,5 +1633,31 @@ mod tests {
             Some(&json!("status=502, rule=bad_gateway"))
         );
         assert_eq!(value.get("matched_rule"), Some(&json!("bad_gateway")));
+    }
+
+    #[test]
+    fn build_error_details_json_returns_none_for_success_only_attempts() {
+        // A pure-success attempt must not surface as "HTTP 200 响应异常" in the UI.
+        let mut attempt = sample_attempt();
+        attempt.decision = Some("success");
+        attempt.reason_code = Some("ok");
+        attempt.circuit_state_before = Some("closed");
+        attempt.circuit_failure_count = Some(0);
+        attempt.circuit_failure_threshold = Some(3);
+
+        assert!(build_error_details_json(None, &[attempt]).is_none());
+    }
+
+    #[test]
+    fn select_error_observation_attempt_ignores_pure_success_attempts() {
+        let mut first = sample_attempt();
+        first.decision = Some("success");
+        first.reason_code = Some("ok");
+        let mut second = sample_attempt();
+        second.provider_id = 8;
+        second.decision = Some("success");
+        second.reason_code = Some("ok");
+
+        assert!(select_error_observation_attempt(&[first, second]).is_none());
     }
 }

--- a/src/components/home/__tests__/requestLogErrorDetails.test.ts
+++ b/src/components/home/__tests__/requestLogErrorDetails.test.ts
@@ -133,6 +133,30 @@ describe("components/home/requestLogErrorDetails", () => {
     );
   });
 
+  it("ignores leaked success context in error_details_json for HTTP 200 responses", () => {
+    // Historical rows may carry success attempt fields inside error_details_json; guard here.
+    const observation = resolveRequestLogErrorObservation(
+      createRequestLogDetail({
+        status: 200,
+        error_code: null,
+        error_details_json: JSON.stringify({
+          attempt_duration_ms: 3940,
+          decision: "success",
+          outcome: "success",
+          provider_id: 42,
+          provider_index: 0,
+          provider_name: "Provider A",
+          reason_code: "ok",
+          retry_index: 0,
+          selection_method: "ordered",
+          upstream_status: 200,
+        }),
+      })
+    );
+
+    expect(observation).toBeNull();
+  });
+
   describe("buildAttemptFailureSummary", () => {
     it("groups timeout attempts with count, deduped providers, and max timeout secs (AC1)", () => {
       const summary = buildAttemptFailureSummary([

--- a/src/components/home/requestLogErrorDetails.ts
+++ b/src/components/home/requestLogErrorDetails.ts
@@ -283,25 +283,15 @@ function parseErrorDetailsJson(
 }
 
 function hasObservationSignal(input: RequestLogErrorObservation) {
+  // Only genuine error signals; decision/reasonCode/providerId are also set on success.
   return (
     input.displayErrorCode != null ||
     input.gatewayErrorCode != null ||
     input.errorCategory != null ||
-    input.outcome != null ||
-    input.decision != null ||
-    input.reasonCode != null ||
-    input.selectionMethod != null ||
     input.matchedRule != null ||
-    input.attemptDurationMs != null ||
-    input.circuitStateBefore != null ||
-    input.circuitStateAfter != null ||
-    input.circuitFailureCount != null ||
-    input.circuitFailureThreshold != null ||
     input.upstreamStatus != null ||
     input.reason != null ||
     input.upstreamBodyPreview != null ||
-    input.providerId != null ||
-    input.providerName != null ||
     input.rawDetailsText != null
   );
 }
@@ -339,7 +329,10 @@ export function resolveRequestLogErrorObservation(
     source: selectedLog.error_details_json != null ? "error_details_json" : "summary",
     upstreamBodyPreview: parsedJson.upstreamBodyPreview,
     upstreamStatus:
-      parsedJson.upstreamStatus ??
+      // Both sides gated on >= 400 so leaked HTTP 200 in historical rows never fires.
+      (parsedJson.upstreamStatus != null && parsedJson.upstreamStatus >= 400
+        ? parsedJson.upstreamStatus
+        : null) ??
       (selectedLog.status != null && selectedLog.status >= 400 ? selectedLog.status : null),
   };
 


### PR DESCRIPTION
## Summary

Successful HTTP 200 requests were rendered with a red **"HTTP 200 响应异常"** banner in the request-log detail dialog. The green **"200 成功"** badge on the same view showed the correct status, so the top banner and the badge contradicted each other.

Root cause: on pure-success requests the request-end pipeline still serialised the successful attempt's fields (`status=200`, `decision="success"`, `reason_code=success_reason_code`, `provider_*`, `attempt_duration_ms`, `circuit_*`) into `error_details_json`. The frontend then treated the non-empty payload as an error observation and used `upstream_status=200` to compose the fallback title `HTTP 200 响应异常`.

## Fix

**Backend** (`src-tauri/src/gateway/proxy/request_end.rs`)
- Extract `is_error_attempt` (`error_code` / `error_category` / non-empty `reason`) as the single truth for "this attempt failed".
- `select_error_observation_attempt` keys only off `is_error_attempt`; drop the `decision` / `reason_code` / `status` branches and the `attempts.last()` fallback.
- `build_error_details_json` short-circuits to `None` when neither the top-level `error_code` nor any attempt carries an error signal.

**Frontend** (`src/components/home/requestLogErrorDetails.ts`)
- `resolveRequestLogErrorObservation` gates `parsedJson.upstreamStatus` on `>= 400` (mirroring the existing `selectedLog.status` guard) so a leaked HTTP 200 never fires the error card. This also shields historical rows that already carry leaked success context.
- `hasObservationSignal` narrows to real error fields (`displayErrorCode` / `gatewayErrorCode` / `errorCategory` / `matchedRule` / `upstreamStatus` / `reason` / `upstreamBodyPreview` / `rawDetailsText`); `decision` / `reasonCode` / `providerId` / `attemptDurationMs` / `circuitState*` no longer trigger the card on their own.

## Test

**RED first, then GREEN** for every new behaviour:

- Rust: `build_error_details_json_returns_none_for_success_only_attempts`, `select_error_observation_attempt_ignores_pure_success_attempts`.
- TS: `resolveRequestLogErrorObservation > ignores leaked success context in error_details_json for HTTP 200 responses` — verifies a pure-success payload resolves to `null`.

Full regression:
- `cargo test --lib` — 1680 passed / 0 failed
- `cargo clippy --lib -- -D warnings` — clean
- `pnpm test:unit` — 274 files / 2080 tests passed
- `pnpm typecheck` / `pnpm lint` — clean

## Scope

Genuine 4xx/5xx / fake-200 error paths are unaffected: those attempts carry `error_code` / `error_category` / `reason`, so `is_error_attempt` fires and behaviour is unchanged. The frontend narrowing of `hasObservationSignal` is a superset of what real errors set on `error_details_json`, so error rows still render exactly as before.

Closes #330
