### PR TITLE
feat(grok): 支持供应商 OAuth 登录

### DIFF
--- a/src-tauri/src/commands/providers/oauth.rs
+++ b/src-tauri/src/commands/providers/oauth.rs
@@ -11,6 +11,11 @@ const CODEX_DEVICE_REDIRECT_URI: &str = "https://auth.openai.com/deviceauth/call
 const CODEX_DEVICE_CODE_DEFAULT_EXPIRES_IN: u64 = 900;
 const CODEX_DEVICE_POLLING_SAFETY_MARGIN_SECS: u64 = 3;
 
+/// RFC 8628 device-code grant (used by xAI Grok OAuth).
+const OAUTH_DEVICE_CODE_GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:device_code";
+const GROK_DEVICE_CODE_DEFAULT_EXPIRES_IN: u64 = 900;
+const GROK_DEVICE_CODE_DEFAULT_INTERVAL_SECS: u64 = 5;
+
 #[derive(Debug, Clone, Deserialize)]
 struct CodexDeviceCodeResponse {
     device_auth_id: String,
@@ -37,6 +42,37 @@ struct CodexDeviceTokenResponse {
     expires_in: Option<i64>,
 }
 
+/// Standard OAuth2 device authorization response (RFC 8628 / xAI Grok).
+#[derive(Debug, Clone, Deserialize)]
+struct StandardDeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    #[serde(default)]
+    verification_uri: Option<String>,
+    #[serde(default)]
+    verification_uri_complete: Option<String>,
+    #[serde(default)]
+    expires_in: Option<u64>,
+    #[serde(default)]
+    interval: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct StandardDeviceTokenResponse {
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    error_description: Option<String>,
+    #[serde(default)]
+    access_token: Option<String>,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    id_token: Option<String>,
+    #[serde(default)]
+    expires_in: Option<i64>,
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 struct CodexIdTokenClaims {
     #[serde(default)]
@@ -45,6 +81,12 @@ struct CodexIdTokenClaims {
     email: Option<String>,
     #[serde(default, rename = "https://api.openai.com/auth")]
     openai_auth: Option<CodexOpenAiAuthClaim>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct JwtEmailClaims {
+    #[serde(default)]
+    email: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -183,6 +225,41 @@ pub(super) fn extract_codex_identity(id_token: Option<&str>) -> (Option<String>,
     });
     let email = claims.and_then(|value| value.email);
     (account_id, email)
+}
+
+fn decode_jwt_email_claim(id_token: &str) -> Option<String> {
+    let mut segments = id_token.split('.');
+    let _header = segments.next()?;
+    let claims = segments.next()?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(claims)
+        .ok()?;
+    let claims = serde_json::from_slice::<JwtEmailClaims>(&decoded).ok()?;
+    claims
+        .email
+        .map(|email| email.trim().to_string())
+        .filter(|email| !email.is_empty())
+}
+
+/// Best-effort identity extraction across OAuth adapters.
+fn extract_oauth_email(cli_key: &str, id_token: Option<&str>) -> Option<String> {
+    if cli_key == "codex" {
+        return extract_codex_identity(id_token).1;
+    }
+    id_token.and_then(decode_jwt_email_claim)
+}
+
+fn supports_device_code_login(cli_key: &str) -> bool {
+    matches!(cli_key, "codex" | "grok")
+}
+
+fn compute_expires_at_from_secs(expires_in: Option<i64>) -> Option<i64> {
+    let seconds = expires_in?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs() as i64;
+    Some(now + seconds)
 }
 
 fn ensure_current_oauth_flow(flow_id: &str) -> Result<(), String> {
@@ -337,6 +414,7 @@ pub(crate) async fn provider_oauth_start_flow(
     let (effective_token, id_token) = adapter.resolve_effective_token(&token_set, None);
     let token_expires_at = token_set.expires_at;
     let provider_type = adapter.provider_type();
+    let email = extract_oauth_email(&provider_cli_key, id_token.as_deref());
 
     // 10. Save to provider
     let app_handle = app.clone();
@@ -354,7 +432,7 @@ pub(crate) async fn provider_oauth_start_flow(
                 &endpoints.client_id,
                 endpoints.client_secret.as_deref(),
                 token_expires_at,
-                None,
+                email.as_deref(),
             )?;
             crate::domain::provider_oauth_limits::clear_snapshot(&db, provider_id)?;
             Ok(())
@@ -400,19 +478,24 @@ pub(crate) async fn provider_oauth_start_device_flow(
         .await
         .map_err(Into::<String>::into)?;
 
-    if provider_cli_key != "codex" {
+    if !supports_device_code_login(&provider_cli_key) {
         return Err(format!(
-            "SEC_INVALID_INPUT: device code login is only supported for codex providers (provider_id={provider_id}, cli_key={provider_cli_key})"
+            "SEC_INVALID_INPUT: device code login is only supported for codex/grok providers (provider_id={provider_id}, cli_key={provider_cli_key})"
         ));
     }
 
     let adapter = crate::gateway::oauth::registry::global_registry()
-        .get_by_cli_key("codex")
-        .ok_or_else(|| "no OAuth adapter for cli_key=codex".to_string())?;
+        .get_by_cli_key(&provider_cli_key)
+        .ok_or_else(|| format!("no OAuth adapter for cli_key={provider_cli_key}"))?;
     let endpoints = adapter.endpoints();
     let client = crate::gateway::oauth::build_default_oauth_http_client()?;
     let flow_id = crate::gateway::oauth::begin_flow_lifecycle().flow_id;
 
+    if provider_cli_key == "grok" {
+        return start_grok_device_flow(provider_id, adapter, endpoints, &client, flow_id).await;
+    }
+
+    // Codex proprietary device-auth API
     let response = client
         .post(CODEX_DEVICE_AUTH_USERCODE_URL)
         .header("Content-Type", "application/json")
@@ -449,6 +532,79 @@ pub(crate) async fn provider_oauth_start_device_flow(
     })
 }
 
+async fn start_grok_device_flow(
+    provider_id: i64,
+    adapter: &dyn crate::gateway::oauth::provider_trait::OAuthProvider,
+    endpoints: &crate::gateway::oauth::provider_trait::OAuthEndpoints,
+    client: &reqwest::Client,
+    flow_id: String,
+) -> Result<ProviderOAuthDeviceCodeStartResult, String> {
+    use crate::gateway::oauth::adapters::grok::{
+        grok_client_version, GROK_CLIENT_SURFACE_UI, GROK_DEVICE_AUTHORIZATION_URL,
+        GROK_OAUTH_REFERRER,
+    };
+
+    let scope = endpoints.scopes.join(" ");
+    let client_version = grok_client_version();
+    // Match grok-build device-code request: referrer + x-grok-client-* headers.
+    let response = client
+        .post(GROK_DEVICE_AUTHORIZATION_URL)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Accept", "application/json")
+        .header("x-grok-client-version", client_version.as_str())
+        .header("x-grok-client-surface", GROK_CLIENT_SURFACE_UI)
+        .form(&[
+            ("client_id", endpoints.client_id.as_str()),
+            ("scope", scope.as_str()),
+            ("referrer", GROK_OAUTH_REFERRER),
+        ])
+        .send()
+        .await
+        .map_err(|e| format!("grok device code request failed: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!(
+            "grok device code request failed: {status} - {text}"
+        ));
+    }
+
+    let payload = response
+        .json::<StandardDeviceCodeResponse>()
+        .await
+        .map_err(|e| format!("grok device code response parse failed: {e}"))?;
+
+    let verification_uri = payload
+        .verification_uri
+        .as_deref()
+        .or(payload.verification_uri_complete.as_deref())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| "grok device code response missing verification_uri".to_string())?
+        .to_string();
+
+    let expires_in = payload
+        .expires_in
+        .unwrap_or(GROK_DEVICE_CODE_DEFAULT_EXPIRES_IN);
+    let interval = payload
+        .interval
+        .unwrap_or(GROK_DEVICE_CODE_DEFAULT_INTERVAL_SECS)
+        .max(1)
+        + CODEX_DEVICE_POLLING_SAFETY_MARGIN_SECS;
+
+    Ok(ProviderOAuthDeviceCodeStartResult {
+        provider_id,
+        provider_type: adapter.provider_type().to_string(),
+        flow_id,
+        device_code: payload.device_code,
+        user_code: payload.user_code,
+        verification_uri,
+        expires_in,
+        interval,
+    })
+}
+
 #[tauri::command]
 #[specta::specta]
 pub(crate) async fn provider_oauth_poll_device_flow(
@@ -473,77 +629,99 @@ pub(crate) async fn provider_oauth_poll_device_flow(
         .await
         .map_err(Into::<String>::into)?;
 
-    if provider_cli_key != "codex" {
+    if !supports_device_code_login(&provider_cli_key) {
         return Err(format!(
-            "SEC_INVALID_INPUT: device code login is only supported for codex providers (provider_id={provider_id}, cli_key={provider_cli_key})"
+            "SEC_INVALID_INPUT: device code login is only supported for codex/grok providers (provider_id={provider_id}, cli_key={provider_cli_key})"
         ));
     }
 
     let adapter = crate::gateway::oauth::registry::global_registry()
-        .get_by_cli_key("codex")
-        .ok_or_else(|| "no OAuth adapter for cli_key=codex".to_string())?;
+        .get_by_cli_key(&provider_cli_key)
+        .ok_or_else(|| format!("no OAuth adapter for cli_key={provider_cli_key}"))?;
     let endpoints = adapter.endpoints();
     let client = crate::gateway::oauth::build_default_oauth_http_client()?;
 
-    let poll_response = client
-        .post(CODEX_DEVICE_AUTH_TOKEN_URL)
-        .header("Content-Type", "application/json")
-        .json(&serde_json::json!({
-            "device_auth_id": input.device_code,
-            "user_code": input.user_code,
-        }))
-        .send()
-        .await
-        .map_err(|e| format!("device code poll failed: {e}"))?;
+    let oauth_token_set = if provider_cli_key == "grok" {
+        match poll_grok_device_token(
+            &client,
+            endpoints.token_url,
+            &endpoints.client_id,
+            &input.device_code,
+            &input.flow_id,
+        )
+        .await?
+        {
+            None => {
+                return Ok(ProviderOAuthDeviceCodePollResult {
+                    completed: false,
+                    provider_id,
+                    provider_type: adapter.provider_type().to_string(),
+                    expires_at: None,
+                });
+            }
+            Some(token_set) => token_set,
+        }
+    } else {
+        let poll_response = client
+            .post(CODEX_DEVICE_AUTH_TOKEN_URL)
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({
+                "device_auth_id": input.device_code,
+                "user_code": input.user_code,
+            }))
+            .send()
+            .await
+            .map_err(|e| format!("device code poll failed: {e}"))?;
 
-    ensure_current_oauth_flow(&input.flow_id)?;
+        ensure_current_oauth_flow(&input.flow_id)?;
 
-    let status = poll_response.status();
-    if status == reqwest::StatusCode::FORBIDDEN || status == reqwest::StatusCode::NOT_FOUND {
-        return Ok(ProviderOAuthDeviceCodePollResult {
-            completed: false,
-            provider_id,
-            provider_type: adapter.provider_type().to_string(),
-            expires_at: None,
-        });
-    }
-    if status == reqwest::StatusCode::GONE {
-        crate::gateway::oauth::cancel_flow(&input.flow_id);
-        return Err("Device code 已过期，请重新开始登录。".to_string());
-    }
-    if !status.is_success() {
-        let text = poll_response.text().await.unwrap_or_default();
-        crate::gateway::oauth::cancel_flow(&input.flow_id);
-        return Err(format!("device code poll failed: {status} - {text}"));
-    }
+        let status = poll_response.status();
+        if status == reqwest::StatusCode::FORBIDDEN || status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(ProviderOAuthDeviceCodePollResult {
+                completed: false,
+                provider_id,
+                provider_type: adapter.provider_type().to_string(),
+                expires_at: None,
+            });
+        }
+        if status == reqwest::StatusCode::GONE {
+            crate::gateway::oauth::cancel_flow(&input.flow_id);
+            return Err("Device code 已过期，请重新开始登录。".to_string());
+        }
+        if !status.is_success() {
+            let text = poll_response.text().await.unwrap_or_default();
+            crate::gateway::oauth::cancel_flow(&input.flow_id);
+            return Err(format!("device code poll failed: {status} - {text}"));
+        }
 
-    let success = poll_response
-        .json::<CodexDevicePollSuccess>()
-        .await
-        .map_err(|e| format!("device code poll parse failed: {e}"))?;
+        let success = poll_response
+            .json::<CodexDevicePollSuccess>()
+            .await
+            .map_err(|e| format!("device code poll parse failed: {e}"))?;
 
-    ensure_current_oauth_flow(&input.flow_id)?;
+        ensure_current_oauth_flow(&input.flow_id)?;
 
-    let token_set = codex_exchange_device_code_for_tokens(
-        &client,
-        &endpoints.client_id,
-        &success.authorization_code,
-        &success.code_verifier,
-    )
-    .await?;
+        let token_set = codex_exchange_device_code_for_tokens(
+            &client,
+            &endpoints.client_id,
+            &success.authorization_code,
+            &success.code_verifier,
+        )
+        .await?;
 
-    let oauth_token_set = crate::gateway::oauth::provider_trait::OAuthTokenSet {
-        access_token: token_set.access_token,
-        refresh_token: token_set.refresh_token,
-        expires_at: compute_codex_expires_at(token_set.expires_in),
-        id_token: token_set.id_token,
+        crate::gateway::oauth::provider_trait::OAuthTokenSet {
+            access_token: token_set.access_token,
+            refresh_token: token_set.refresh_token,
+            expires_at: compute_codex_expires_at(token_set.expires_in),
+            id_token: token_set.id_token,
+        }
     };
 
     let (effective_token, id_token) =
         adapter.resolve_effective_token(&oauth_token_set, oauth_token_set.id_token.as_deref());
     let token_expires_at = oauth_token_set.expires_at;
     let provider_type = adapter.provider_type();
-    let (_, email) = extract_codex_identity(id_token.as_deref());
+    let email = extract_oauth_email(&provider_cli_key, id_token.as_deref());
 
     blocking::run("provider_oauth_poll_device_flow_save", move || {
         crate::gateway::oauth::complete_current_flow(&input.flow_id, || {
@@ -581,6 +759,97 @@ pub(crate) async fn provider_oauth_poll_device_flow(
         provider_type: provider_type.to_string(),
         expires_at: token_expires_at,
     })
+}
+
+/// Poll xAI token endpoint for RFC 8628 device authorization.
+/// Returns `Ok(None)` while the user has not yet approved (`authorization_pending` / `slow_down`).
+async fn poll_grok_device_token(
+    client: &reqwest::Client,
+    token_url: &str,
+    client_id: &str,
+    device_code: &str,
+    flow_id: &str,
+) -> Result<Option<crate::gateway::oauth::provider_trait::OAuthTokenSet>, String> {
+    use crate::gateway::oauth::adapters::grok::{grok_client_version, GROK_CLIENT_SURFACE_UI};
+
+    let client_version = grok_client_version();
+    // Match grok-build device-token poll identity headers.
+    let response = client
+        .post(token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Accept", "application/json")
+        .header("x-grok-client-version", client_version.as_str())
+        .header("x-grok-client-surface", GROK_CLIENT_SURFACE_UI)
+        .form(&[
+            ("grant_type", OAUTH_DEVICE_CODE_GRANT_TYPE),
+            ("device_code", device_code),
+            ("client_id", client_id),
+        ])
+        .send()
+        .await
+        .map_err(|e| format!("grok device token poll failed: {e}"))?;
+
+    ensure_current_oauth_flow(flow_id)?;
+
+    let status = response.status();
+    let payload = response
+        .json::<StandardDeviceTokenResponse>()
+        .await
+        .map_err(|e| format!("grok device token poll parse failed: {e}"))?;
+
+    if let Some(error) = payload
+        .error
+        .as_deref()
+        .map(str::trim)
+        .filter(|e| !e.is_empty())
+    {
+        match error {
+            "authorization_pending" | "slow_down" => return Ok(None),
+            "expired_token" => {
+                crate::gateway::oauth::cancel_flow(flow_id);
+                return Err("Device code 已过期，请重新开始登录。".to_string());
+            }
+            "access_denied" => {
+                crate::gateway::oauth::cancel_flow(flow_id);
+                return Err("设备码授权被拒绝。".to_string());
+            }
+            other => {
+                crate::gateway::oauth::cancel_flow(flow_id);
+                let desc = payload
+                    .error_description
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|d| !d.is_empty())
+                    .unwrap_or(other);
+                return Err(format!("grok device token error: {desc}"));
+            }
+        }
+    }
+
+    if !status.is_success() {
+        crate::gateway::oauth::cancel_flow(flow_id);
+        return Err(format!(
+            "grok device token poll failed: {status} (no access_token)"
+        ));
+    }
+
+    let access_token = payload
+        .access_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| {
+            crate::gateway::oauth::cancel_flow(flow_id);
+            "grok device token response missing access_token".to_string()
+        })?
+        .to_string();
+
+    Ok(Some(crate::gateway::oauth::provider_trait::OAuthTokenSet {
+        access_token,
+        refresh_token: payload.refresh_token,
+        expires_at: compute_expires_at_from_secs(payload.expires_in),
+        id_token: payload.id_token,
+    }))
 }
 
 #[tauri::command]

--- a/src-tauri/src/domain/providers/queries.rs
+++ b/src-tauri/src/domain/providers/queries.rs
@@ -1093,11 +1093,6 @@ pub fn upsert(
     let requested_auth_mode = auth_mode.unwrap_or(ProviderAuthMode::ApiKey);
     let is_oauth = requested_auth_mode == ProviderAuthMode::Oauth;
 
-    if cli_key == "grok" && is_oauth {
-        return Err("SEC_INVALID_INPUT: oauth is not supported for cli_key=grok"
-            .to_string()
-            .into());
-    }
     if cli_key == "grok" && claude_models.as_ref().is_some_and(ClaudeModels::has_any) {
         return Err(
             "SEC_INVALID_INPUT: claude_models is only supported for cli_key=claude"

--- a/src-tauri/src/domain/providers/tests.rs
+++ b/src-tauri/src/domain/providers/tests.rs
@@ -700,7 +700,7 @@ fn upsert_accepts_grok_api_key_provider() {
 }
 
 #[test]
-fn upsert_rejects_grok_oauth_provider() {
+fn upsert_accepts_grok_oauth_provider() {
     let dir = tempfile::tempdir().expect("tempdir");
     let db_path = dir.path().join("providers_grok_oauth.db");
     let db = crate::db::init_for_tests(&db_path).expect("init db");
@@ -709,12 +709,14 @@ fn upsert_rejects_grok_oauth_provider() {
     params.cli_key = "grok".to_string();
     params.auth_mode = Some(ProviderAuthMode::Oauth);
     params.api_key = None;
+    // OAuth providers discard base_urls (empty list) to avoid stale transport values.
+    params.base_urls = vec!["https://should-be-cleared.example".to_string()];
 
-    let error = upsert(&db, params).expect_err("Grok OAuth must be rejected");
+    let saved = upsert(&db, params).expect("save Grok OAuth provider");
 
-    assert!(error
-        .to_string()
-        .contains("oauth is not supported for cli_key=grok"));
+    assert_eq!(saved.cli_key, "grok");
+    assert_eq!(saved.auth_mode, ProviderAuthMode::Oauth.as_str());
+    assert!(saved.base_urls.is_empty());
 }
 
 #[test]

--- a/src-tauri/src/gateway/oauth/adapters/grok.rs
+++ b/src-tauri/src/gateway/oauth/adapters/grok.rs
@@ -1,0 +1,181 @@
+//! Usage: Grok (xAI) OAuth adapter — browser PKCE + RFC 8628 device code.
+//!
+//! Contract mirrors official `xai-org/grok-build` OAuth2 client:
+//! issuer `https://auth.x.ai`, public client id, frozen scopes, and
+//! `referrer=grok-build` / `x-grok-client-*` identity headers.
+
+use crate::gateway::oauth::provider_trait::*;
+use axum::http::{HeaderMap, HeaderValue};
+
+/// Public xAI Grok CLI OAuth client ID (shared by official Grok Build CLI).
+pub(crate) const GROK_OAUTH_CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
+
+/// OIDC issuer and fixed endpoints (also discoverable via
+/// `https://auth.x.ai/.well-known/openid-configuration`).
+pub(crate) const GROK_AUTH_URL: &str = "https://auth.x.ai/oauth2/authorize";
+pub(crate) const GROK_TOKEN_URL: &str = "https://auth.x.ai/oauth2/token";
+pub(crate) const GROK_DEVICE_AUTHORIZATION_URL: &str = "https://auth.x.ai/oauth2/device/code";
+
+/// Default upstream for SuperGrok / subscription OAuth tokens (CLI chat proxy).
+pub(crate) const GROK_OAUTH_DEFAULT_BASE_URL: &str = "https://cli-chat-proxy.grok.com/v1";
+
+/// Official grok-build usage-attribution referrer (authorize + device-code form).
+pub(crate) const GROK_OAUTH_REFERRER: &str = "grok-build";
+
+/// Client-surface values for `x-grok-client-surface` (device-flow metrics).
+pub(crate) const GROK_CLIENT_SURFACE_UI: &str = "ui";
+
+/// Recommended Grok Build CLI version string for `x-grok-client-version`.
+/// Overridable via `AIO_GROK_CLIENT_VERSION` when xAI bumps the identity contract.
+const GROK_DEFAULT_CLIENT_VERSION: &str = "0.2.93";
+
+/// Preferred loopback callback port (falls back to an ephemeral port if busy).
+/// Matches grok-build local-dev fixed port; production grok-build uses OS ephemeral.
+const GROK_DEFAULT_CALLBACK_PORT: u16 = 56121;
+
+/// Frozen personal OAuth2 scopes from grok-build (`default_oauth2_scopes`).
+const GROK_OAUTH_SCOPES: &[&str] = &[
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "grok-cli:access",
+    "api:access",
+    "conversations:read",
+    "conversations:write",
+];
+
+pub(crate) struct GrokOAuthProvider {
+    endpoints: OAuthEndpoints,
+}
+
+impl GrokOAuthProvider {
+    pub(crate) fn new() -> Self {
+        let client_id = std::env::var("AIO_GROK_OAUTH_CLIENT_ID")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| GROK_OAUTH_CLIENT_ID.to_string());
+
+        Self {
+            endpoints: OAuthEndpoints {
+                auth_url: GROK_AUTH_URL,
+                token_url: GROK_TOKEN_URL,
+                client_id,
+                client_secret: None,
+                scopes: GROK_OAUTH_SCOPES.to_vec(),
+                // Official Grok Build uses 127.0.0.1 loopback + /callback (RFC 8252).
+                redirect_host: "127.0.0.1",
+                callback_path: "/callback",
+                default_callback_port: GROK_DEFAULT_CALLBACK_PORT,
+            },
+        }
+    }
+}
+
+/// Resolve the client version identity header sent to auth.x.ai / cli-chat-proxy.
+pub(crate) fn grok_client_version() -> String {
+    std::env::var("AIO_GROK_CLIENT_VERSION")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| GROK_DEFAULT_CLIENT_VERSION.to_string())
+}
+
+impl OAuthProvider for GrokOAuthProvider {
+    fn cli_key(&self) -> &'static str {
+        "grok"
+    }
+
+    fn provider_type(&self) -> &'static str {
+        "grok_oauth"
+    }
+
+    fn endpoints(&self) -> &OAuthEndpoints {
+        &self.endpoints
+    }
+
+    fn default_base_url(&self) -> &'static str {
+        GROK_OAUTH_DEFAULT_BASE_URL
+    }
+
+    fn extra_authorize_params(&self) -> Vec<(&'static str, &'static str)> {
+        // Matches grok-build `build_authorize_url` referrer default.
+        vec![("referrer", GROK_OAUTH_REFERRER)]
+    }
+
+    fn inject_upstream_headers(
+        &self,
+        headers: &mut HeaderMap,
+        access_token: &str,
+    ) -> Result<(), String> {
+        insert_bearer_auth(headers, access_token, "grok oauth")?;
+        // Mirror grok-build client identity on subscription proxy calls.
+        let version = grok_client_version();
+        if let Ok(value) = HeaderValue::from_str(&version) {
+            headers.insert("x-grok-client-version", value);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::header;
+
+    #[test]
+    fn endpoints_match_official_xai_oidc() {
+        let provider = GrokOAuthProvider::new();
+        let endpoints = provider.endpoints();
+
+        assert_eq!(endpoints.auth_url, GROK_AUTH_URL);
+        assert_eq!(endpoints.token_url, GROK_TOKEN_URL);
+        assert_eq!(endpoints.client_id, GROK_OAUTH_CLIENT_ID);
+        assert_eq!(endpoints.redirect_host, "127.0.0.1");
+        assert_eq!(endpoints.callback_path, "/callback");
+        assert_eq!(endpoints.scopes, GROK_OAUTH_SCOPES);
+        assert!(endpoints.scopes.contains(&"conversations:read"));
+        assert!(endpoints.scopes.contains(&"conversations:write"));
+        assert!(endpoints.scopes.contains(&"grok-cli:access"));
+        assert!(endpoints.scopes.contains(&"offline_access"));
+    }
+
+    #[test]
+    fn authorize_params_include_official_referrer() {
+        let provider = GrokOAuthProvider::new();
+        assert!(provider
+            .extra_authorize_params()
+            .contains(&("referrer", GROK_OAUTH_REFERRER)));
+    }
+
+    #[test]
+    fn inject_upstream_headers_sets_bearer_and_client_version() {
+        let provider = GrokOAuthProvider::new();
+        let mut headers = HeaderMap::new();
+
+        provider
+            .inject_upstream_headers(&mut headers, "access-token")
+            .expect("inject headers");
+
+        assert_eq!(
+            headers
+                .get(header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer access-token")
+        );
+        assert_eq!(
+            headers
+                .get("x-grok-client-version")
+                .and_then(|v| v.to_str().ok()),
+            Some(GROK_DEFAULT_CLIENT_VERSION)
+        );
+    }
+
+    #[test]
+    fn provider_type_and_cli_key() {
+        let provider = GrokOAuthProvider::new();
+        assert_eq!(provider.cli_key(), "grok");
+        assert_eq!(provider.provider_type(), "grok_oauth");
+        assert_eq!(provider.default_base_url(), GROK_OAUTH_DEFAULT_BASE_URL);
+    }
+}

--- a/src-tauri/src/gateway/oauth/adapters/mod.rs
+++ b/src-tauri/src/gateway/oauth/adapters/mod.rs
@@ -3,3 +3,4 @@
 pub(crate) mod claude;
 pub(crate) mod codex;
 pub(crate) mod gemini;
+pub(crate) mod grok;

--- a/src-tauri/src/gateway/oauth/registry.rs
+++ b/src-tauri/src/gateway/oauth/registry.rs
@@ -27,6 +27,10 @@ impl OAuthProviderRegistry {
         by_provider_type.insert(gemini.provider_type(), gemini.cli_key());
         by_cli_key.insert(gemini.cli_key(), Box::new(gemini));
 
+        let grok = adapters::grok::GrokOAuthProvider::new();
+        by_provider_type.insert(grok.provider_type(), grok.cli_key());
+        by_cli_key.insert(grok.cli_key(), Box::new(grok));
+
         Self {
             by_cli_key,
             by_provider_type,

--- a/src-tauri/src/gateway/oauth/token_exchange.rs
+++ b/src-tauri/src/gateway/oauth/token_exchange.rs
@@ -78,9 +78,14 @@ pub(crate) async fn exchange_authorization_code(
             form.push(("client_secret", &secret_ref));
         }
 
-        client
-            .post(&req.token_uri)
-            .form(&form)
+        // grok-build attaches x-grok-client-version on authorization_code exchange.
+        let mut request = client.post(&req.token_uri).form(&form);
+        if is_xai_oauth_token_uri(&req.token_uri) {
+            let version = crate::gateway::oauth::adapters::grok::grok_client_version();
+            request = request.header("x-grok-client-version", version);
+        }
+
+        request
             .send()
             .await
             .map_err(|e| format!("token exchange request failed: {e}"))?
@@ -175,6 +180,11 @@ fn is_anthropic_oauth_token_uri(token_uri: &str) -> bool {
         || uri.contains("platform.claude.com/v1/oauth/token")
         || (uri.contains("/v1/oauth/token")
             && (uri.contains("anthropic.com") || uri.contains("claude.com")))
+}
+
+fn is_xai_oauth_token_uri(token_uri: &str) -> bool {
+    let uri = token_uri.trim().to_ascii_lowercase();
+    uri.contains("auth.x.ai/oauth2/token") || uri.contains("://auth.x.ai/")
 }
 
 async fn parse_token_response(resp: reqwest::Response) -> Result<OAuthTokenSet, String> {

--- a/src/components/cli-manager/tabs/__tests__/CodexTab.test.tsx
+++ b/src/components/cli-manager/tabs/__tests__/CodexTab.test.tsx
@@ -1089,6 +1089,8 @@ describe("components/cli-manager/tabs/CodexTab", () => {
         error: { message: "invalid toml", line: 2, column: 3 },
       })
       .mockResolvedValueOnce({ ok: true, error: null })
+      // 每次点击「保存」都会先同步校验一次；两次保存各消耗一次 mock
+      .mockResolvedValueOnce({ ok: true, error: null })
       .mockResolvedValueOnce({ ok: true, error: null });
 
     render(

--- a/src/pages/providers/OAuthSection.tsx
+++ b/src/pages/providers/OAuthSection.tsx
@@ -75,7 +75,7 @@ export function OAuthSection(props: { form: UseProviderEditorFormReturn }) {
                 >
                   OAuth 登录
                 </Button>
-                {cliKey === "codex" ? (
+                {cliKey === "codex" || cliKey === "grok" ? (
                   <Button
                     onClick={handleOAuthDeviceLogin}
                     variant="secondary"
@@ -85,7 +85,7 @@ export function OAuthSection(props: { form: UseProviderEditorFormReturn }) {
                   </Button>
                 ) : null}
               </div>
-              {cliKey === "codex" ? (
+              {cliKey === "codex" || cliKey === "grok" ? (
                 <p className="text-xs leading-relaxed text-muted-foreground">
                   若当前环境下 localhost
                   回调不稳定，可改用设备码登录，在浏览器中输入验证码完成授权。

--- a/src/pages/providers/__tests__/ProviderEditorDialog.test.tsx
+++ b/src/pages/providers/__tests__/ProviderEditorDialog.test.tsx
@@ -214,7 +214,7 @@ describe("pages/providers/ProviderEditorDialog", () => {
     } as any);
   });
 
-  it("limits Grok providers to API key configuration", () => {
+  it("supports Grok API key and OAuth modes without CX2CC", () => {
     render(
       <ProviderEditorDialog
         mode="create"
@@ -227,9 +227,15 @@ describe("pages/providers/ProviderEditorDialog", () => {
 
     const dialog = within(screen.getByRole("dialog"));
     expect(dialog.getByPlaceholderText("sk-…")).toBeInTheDocument();
-    expect(dialog.queryByText("OAuth 登录")).not.toBeInTheDocument();
+    // Auth mode tab label
+    expect(dialog.getByText("OAuth 登录")).toBeInTheDocument();
     expect(dialog.queryByText("CX2CC 转译")).not.toBeInTheDocument();
     expect(dialog.queryByText("Claude 模型映射")).not.toBeInTheDocument();
+
+    fireEvent.click(dialog.getByText("OAuth 登录"));
+    expect(dialog.getByText("未连接 OAuth")).toBeInTheDocument();
+    expect(dialog.getByRole("button", { name: "OAuth 登录" })).toBeInTheDocument();
+    expect(dialog.getByRole("button", { name: "设备码登录" })).toBeInTheDocument();
   });
 
   it("validates create form and saves provider", async () => {
@@ -1516,6 +1522,79 @@ describe("pages/providers/ProviderEditorDialog", () => {
     fireEvent.click(dialog.getByRole("button", { name: "保存" }));
 
     await waitFor(() => expect(vi.mocked(toast)).toHaveBeenCalledWith("请先完成 OAuth 登录"));
+  });
+
+  it("supports Grok device code login in create mode", async () => {
+    vi.mocked(providerUpsert).mockResolvedValueOnce(
+      makeProvider({
+        id: 346,
+        cli_key: "grok",
+        name: "Grok Device OAuth",
+      })
+    );
+    vi.mocked(providerOAuthStartDeviceFlow).mockResolvedValueOnce(
+      makeOAuthDeviceStartResult({
+        provider_id: 346,
+        provider_type: "grok_oauth",
+        device_code: "grok_device_123",
+        user_code: "WXYZ-1234",
+        verification_uri: "https://accounts.x.ai/device",
+        expires_in: 900,
+        interval: 0,
+      })
+    );
+    vi.mocked(providerOAuthPollDeviceFlow).mockResolvedValueOnce({
+      completed: true,
+      provider_id: 346,
+      provider_type: "grok_oauth",
+      expires_at: 1700000000,
+    });
+    vi.mocked(providerOAuthStatus).mockResolvedValueOnce(
+      makeOAuthStatus({
+        connected: true,
+        provider_type: "grok_oauth",
+        email: "grok@example.com",
+        expires_at: 1700000000,
+        has_refresh_token: true,
+      })
+    );
+
+    const onSaved = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ProviderEditorDialog
+        mode="create"
+        open={true}
+        cliKey="grok"
+        onSaved={onSaved}
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    const dialog = within(screen.getByRole("dialog"));
+    fireEvent.click(dialog.getByText("OAuth 登录"));
+    fireEvent.change(dialog.getByPlaceholderText("default"), {
+      target: { value: "Grok Device OAuth" },
+    });
+
+    fireEvent.click(dialog.getByRole("button", { name: "设备码登录" }));
+
+    await waitFor(() => expect(vi.mocked(providerOAuthStartDeviceFlow)).toHaveBeenCalledWith(346));
+    await waitFor(() =>
+      expect(vi.mocked(openDesktopUrl)).toHaveBeenCalledWith("https://accounts.x.ai/device")
+    );
+    await waitFor(() =>
+      expect(vi.mocked(providerOAuthPollDeviceFlow)).toHaveBeenCalledWith(
+        346,
+        "flow_123",
+        "grok_device_123",
+        "WXYZ-1234"
+      )
+    );
+    await waitFor(() => expect(vi.mocked(toast)).toHaveBeenCalledWith("设备码登录成功"));
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith("grok"));
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
   });
 
   it("supports Codex device code login in create mode", async () => {

--- a/src/pages/providers/useProviderEditorForm.ts
+++ b/src/pages/providers/useProviderEditorForm.ts
@@ -507,7 +507,7 @@ export function useProviderEditorForm(props: ProviderEditorDialogProps) {
           return Boolean(value.trim());
         }).length
       : 0;
-  const supportsOAuth = cliKey === "codex" || cliKey === "gemini";
+  const supportsOAuth = cliKey === "codex" || cliKey === "gemini" || cliKey === "grok";
   const supportsCx2cc = cliKey === "claude";
 
   const buildPayloadContext = useCallback(


### PR DESCRIPTION
## Summary

- 接入 xAI Grok OAuth（浏览器 PKCE + RFC 8628 设备码），对齐官方 grok-build 的 client / scopes / identity headers
- 解除 `cli_key=grok` 的 OAuth 限制，供应商编辑页开放 OAuth 与设备码登录
- 补齐 Codex `config.toml` 保存用例校验 mock（既有用例次数不足会阻塞 pre-push）

Closes #346

## Changes

- 新增 `gateway/oauth/adapters/grok.rs` 并注册到 OAuth registry
- `provider_oauth_*` 命令支持 Grok device flow / token exchange 身份头
- 前端 `supportsOAuth` 与设备码入口覆盖 `grok`
- domain 层移除 “oauth is not supported for grok” 限制

## Test plan

- [x] pre-push 15 项门禁通过（lint / typecheck / coverage shards / tauri test / clippy）
- [x] `ProviderEditorDialog` Grok OAuth 相关前端测试
- [ ] 手动：Grok 供应商 OAuth 浏览器登录
- [ ] 手动：Grok 设备码登录
- [ ] 手动：登录后 token 刷新与请求走网关