### PR TITLE
chore(grok): 将内置默认 model 改为 grok-4.5

### DIFF
--- a/src-tauri/src/infra/grok_config.rs
+++ b/src-tauri/src/infra/grok_config.rs
@@ -9,7 +9,7 @@ use toml_edit::DocumentMut;
 
 const GROK_HOME_ENV: &str = "GROK_HOME";
 pub(crate) const GROK_CONFIG_MAX_BYTES: usize = 1024 * 1024;
-pub(crate) const DEFAULT_GROK_MODEL: &str = "grok-build";
+pub(crate) const DEFAULT_GROK_MODEL: &str = "grok-4.5";
 const GROK_MODEL_ID_MAX_CHARS: usize = 256;
 
 static PATH_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
@@ -890,14 +890,15 @@ mod tests {
     }
 
     #[test]
-    fn missing_config_uses_grok_build_responses_candidate() {
+    fn missing_config_uses_default_model_responses_candidate() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("config.toml");
 
         let state = inspect_path(&path).expect("inspect missing config");
 
         assert!(!state.file_exists);
-        assert_eq!(state.preferences.model_id, "grok-build");
+        assert_eq!(state.preferences.model_id, DEFAULT_GROK_MODEL);
+        assert_eq!(state.preferences.model_id, "grok-4.5");
         assert_eq!(state.preferences.api_backend, GrokApiBackend::Responses);
         assert_eq!(state.default_profile, None);
     }

--- a/src/components/cli-manager/tabs/GrokTab.tsx
+++ b/src/components/cli-manager/tabs/GrokTab.tsx
@@ -348,7 +348,7 @@ export function CliManagerGrokTab(props: CliManagerGrokTabProps) {
               value={preferencesDraft.model_id}
               onChange={(e) => props.setModelIdDraft(e.currentTarget.value)}
               onBlur={() => void props.persistModelId(preferencesDraft.model_id)}
-              placeholder="例如 grok-build"
+              placeholder="例如 grok-4.5"
               aria-label="模型 ID (model_id)"
               className="font-mono w-[280px] max-w-full"
               disabled={configControlsDisabled}

--- a/src/components/cli-manager/tabs/__tests__/CodexTab.test.tsx
+++ b/src/components/cli-manager/tabs/__tests__/CodexTab.test.tsx
@@ -1089,6 +1089,8 @@ describe("components/cli-manager/tabs/CodexTab", () => {
         error: { message: "invalid toml", line: 2, column: 3 },
       })
       .mockResolvedValueOnce({ ok: true, error: null })
+      // 每次点击「保存」都会先同步校验一次；两次保存各消耗一次 mock
+      .mockResolvedValueOnce({ ok: true, error: null })
       .mockResolvedValueOnce({ ok: true, error: null });
 
     render(


### PR DESCRIPTION
## Summary

- 将 Grok 内置兜底默认 model 从 `grok-build` 调整为 `grok-4.5`
- 仅影响 AIO 偏好与 `config.toml` 都取不到 model_id 时的回落值
- 同步 CLI 管理页 model_id 输入框 placeholder
- 顺带补齐 Codex `config.toml` 保存用例校验 mock（main 上该用例次数不足会阻塞 pre-push）

## Notes

- 已有 AIO `grok_proxy_preferences` 或用户 `config.toml` 配置时，仍优先使用现有值
- 与 OAuth 登录 PR 独立，可单独合入

## Test plan

- [x] pre-push 15 项门禁通过
- [x] `grok_config` 缺省配置用例断言 `DEFAULT_GROK_MODEL == "grok-4.5"`
- [x] 手动：清空 AIO Grok 偏好 + 无有效 config model 时，CLI 管理显示/写入 `grok-4.5`