### PR TITLE
fix(providers): 刷新 OAuth Token 后同步更新到期时间展示

### DIFF
--- a/src/pages/providers/__tests__/providerEditorOAuthActions.test.ts
+++ b/src/pages/providers/__tests__/providerEditorOAuthActions.test.ts
@@ -155,6 +155,7 @@ function makeCtx(overrides: Partial<OAuthActionContext> = {}) {
     oauthStatus: null,
     setOauthStatus: vi.fn(),
     refreshOauthStatus: vi.fn().mockResolvedValue(makeStatus()),
+    writeOauthStatusCache: vi.fn(),
     setOauthLoading: vi.fn(),
     oauthDeviceFlow: null,
     setOauthDeviceFlow: vi.fn(),
@@ -215,7 +216,7 @@ describe("providerEditorOAuthActions", () => {
       expect.objectContaining({ cliKey: "claude", name: "OAuth Provider", authMode: "oauth" })
     );
     expect(providerOAuthStartFlow).toHaveBeenCalledWith("claude", 9);
-    expect(ctx.setOauthStatus).toHaveBeenCalledWith(makeStatus());
+    expect(ctx.setOauthStatus).toHaveBeenCalledWith(makeStatus({ expires_at: 123 }));
     expect(providerOAuthFetchLimits).toHaveBeenCalledWith(9);
     expect(toast).toHaveBeenCalledWith("OAuth 登录成功");
     expect(ctx.onSaved).toHaveBeenCalledWith("claude");
@@ -480,7 +481,8 @@ describe("providerEditorOAuthActions", () => {
     await handleOAuthDisconnect(ctx);
     await handleOAuthDisconnect(ctx);
 
-    expect(ctx.setOauthStatus).toHaveBeenCalledWith(makeStatus());
+    expect(ctx.setOauthStatus).toHaveBeenCalledWith(makeStatus({ expires_at: 456 }));
+    expect(ctx.writeOauthStatusCache).toHaveBeenCalledWith(makeStatus({ expires_at: 456 }), 7);
     expect(ctx.setOauthStatus).toHaveBeenCalledWith(null);
     expect(toast).toHaveBeenCalledWith("Token 刷新成功");
     expect(toast).toHaveBeenCalledWith("Token 刷新失败");

--- a/src/pages/providers/__tests__/providerEditorOAuthActions.test.ts
+++ b/src/pages/providers/__tests__/providerEditorOAuthActions.test.ts
@@ -216,13 +216,48 @@ describe("providerEditorOAuthActions", () => {
       expect.objectContaining({ cliKey: "claude", name: "OAuth Provider", authMode: "oauth" })
     );
     expect(providerOAuthStartFlow).toHaveBeenCalledWith("claude", 9);
-    expect(ctx.setOauthStatus).toHaveBeenCalledWith(makeStatus({ expires_at: 123 }));
+    expect(ctx.setOauthStatus).toHaveBeenCalledWith(makeStatus());
     expect(providerOAuthFetchLimits).toHaveBeenCalledWith(9);
     expect(toast).toHaveBeenCalledWith("OAuth 登录成功");
     expect(ctx.onSaved).toHaveBeenCalledWith("claude");
     expect(ctx.onOpenChange).toHaveBeenCalledWith(false);
     expect(ctx.removeProvider).not.toHaveBeenCalled();
     expect(ctx.setOauthLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it("falls back to login result and syncs cache when status fetch fails after login", async () => {
+    vi.mocked(providerOAuthStartFlow).mockResolvedValue({
+      success: true,
+      provider_id: 9,
+      provider_type: "codex_oauth",
+      expires_at: 1234,
+    });
+    vi.mocked(providerOAuthFetchLimits).mockResolvedValue({
+      limit_short_label: null,
+      limit_5h_text: "5h $1",
+      limit_weekly_text: "weekly $7",
+      limit_5h_reset_at: null,
+      limit_weekly_reset_at: null,
+      reset_credit_available_count: null,
+    });
+
+    const { ctx } = makeCtx({
+      refreshOauthStatus: vi.fn().mockRejectedValue(new Error("ipc down")),
+    });
+    await handleOAuthLogin(ctx);
+
+    const fallback = {
+      connected: true,
+      provider_type: "codex_oauth",
+      email: null,
+      expires_at: 1234,
+      has_refresh_token: null,
+    };
+    expect(ctx.setOauthStatus).toHaveBeenCalledWith(fallback);
+    expect(ctx.writeOauthStatusCache).toHaveBeenCalledWith(fallback, 9);
+    expect(toast).toHaveBeenCalledWith("OAuth 登录成功，但读取连接状态失败，可稍后重试");
+    expect(toast).toHaveBeenCalledWith("OAuth 登录成功");
+    expect(ctx.removeProvider).not.toHaveBeenCalled();
   });
 
   it("rolls back auto-saved provider when browser OAuth fails or becomes stale", async () => {
@@ -481,9 +516,10 @@ describe("providerEditorOAuthActions", () => {
     await handleOAuthDisconnect(ctx);
     await handleOAuthDisconnect(ctx);
 
-    expect(ctx.setOauthStatus).toHaveBeenCalledWith(makeStatus({ expires_at: 456 }));
-    expect(ctx.writeOauthStatusCache).toHaveBeenCalledWith(makeStatus({ expires_at: 456 }), 7);
+    expect(ctx.setOauthStatus).toHaveBeenCalledWith(makeStatus());
     expect(ctx.setOauthStatus).toHaveBeenCalledWith(null);
+    expect(ctx.writeOauthStatusCache).toHaveBeenCalledWith(null, 7);
+    expect(ctx.writeOauthStatusCache).toHaveBeenCalledTimes(1);
     expect(toast).toHaveBeenCalledWith("Token 刷新成功");
     expect(toast).toHaveBeenCalledWith("Token 刷新失败");
     expect(toast).toHaveBeenCalledWith("Token 刷新失败：Error: refresh down");

--- a/src/pages/providers/providerEditorActionContext.ts
+++ b/src/pages/providers/providerEditorActionContext.ts
@@ -30,6 +30,12 @@ export type AuthActionContext = {
   oauthStatus: OAuthStatusValue;
   setOauthStatus: (v: OAuthStatusValue) => void;
   refreshOauthStatus: (providerId?: number | null) => Promise<OAuthStatusValue>;
+  /**
+   * Keep React Query oauthStatus cache aligned with local editor state.
+   * Without this, `useProviderEditorEffects` re-applies a stale snapshot and
+   * the "到期" timestamp appears unchanged after refresh/login.
+   */
+  writeOauthStatusCache: (status: OAuthStatusValue, providerId?: number | null) => void;
   oauthLoading: boolean;
   setOauthLoading: (v: boolean) => void;
   oauthDeviceFlow: ProviderOAuthDeviceCodeStartResult | null;
@@ -121,6 +127,7 @@ export type OAuthActionContext = ProviderActionContext &
     | "oauthStatus"
     | "setOauthStatus"
     | "refreshOauthStatus"
+    | "writeOauthStatusCache"
     | "setOauthLoading"
     | "oauthDeviceFlow"
     | "setOauthDeviceFlow"

--- a/src/pages/providers/providerEditorActionContext.ts
+++ b/src/pages/providers/providerEditorActionContext.ts
@@ -30,11 +30,7 @@ export type AuthActionContext = {
   oauthStatus: OAuthStatusValue;
   setOauthStatus: (v: OAuthStatusValue) => void;
   refreshOauthStatus: (providerId?: number | null) => Promise<OAuthStatusValue>;
-  /**
-   * Keep React Query oauthStatus cache aligned with local editor state.
-   * Without this, `useProviderEditorEffects` re-applies a stale snapshot and
-   * the "到期" timestamp appears unchanged after refresh/login.
-   */
+  /** 将 OAuth 状态直接写入 React Query 缓存，保持编辑器快照与本地状态一致。 */
   writeOauthStatusCache: (status: OAuthStatusValue, providerId?: number | null) => void;
   oauthLoading: boolean;
   setOauthLoading: (v: boolean) => void;

--- a/src/pages/providers/providerEditorOAuthActions.ts
+++ b/src/pages/providers/providerEditorOAuthActions.ts
@@ -8,10 +8,52 @@ import {
   providerOAuthRefresh,
   providerOAuthDisconnect,
   providerOAuthFetchLimits,
+  type ProviderOAuthStatusResult,
 } from "../../services/providers/providers";
 import type { OAuthActionContext } from "./providerEditorActionContext";
 import { presentProviderEditorPayloadBuildError } from "./providerEditorFeedback";
 import { buildProviderEditorUpsertInput } from "./providerEditorSubmitModel";
+
+/** Prefer the later absolute expiry when both sides have a value. */
+function pickFresherExpiresAt(
+  a: number | null | undefined,
+  b: number | null | undefined
+): number | null {
+  if (a != null && Number.isFinite(a) && b != null && Number.isFinite(b)) {
+    return Math.max(a, b);
+  }
+  if (a != null && Number.isFinite(a)) return a;
+  if (b != null && Number.isFinite(b)) return b;
+  return null;
+}
+
+/**
+ * Prefer freshly minted auth timestamps over a sticky/stale status snapshot.
+ *
+ * Important: after "刷新 Token", the IPC result carries the new `expires_at`
+ * while a status re-fetch (or React Query snapshot) can still briefly hold the
+ * pre-refresh value. Always take the newer absolute timestamp.
+ */
+function mergeOAuthStatusAfterAuth(
+  status: ProviderOAuthStatusResult | null | undefined,
+  auth: { provider_type?: string | null; expires_at?: number | null; email?: string | null }
+): ProviderOAuthStatusResult {
+  if (status?.connected) {
+    return {
+      ...status,
+      expires_at: pickFresherExpiresAt(auth.expires_at, status.expires_at),
+      provider_type: auth.provider_type ?? status.provider_type,
+      email: auth.email ?? status.email,
+    };
+  }
+  return {
+    connected: true,
+    provider_type: auth.provider_type ?? status?.provider_type ?? null,
+    email: auth.email ?? status?.email ?? null,
+    expires_at: pickFresherExpiresAt(auth.expires_at, status?.expires_at),
+    has_refresh_token: status?.has_refresh_token ?? true,
+  };
+}
 
 class OAuthAttemptStaleError extends Error {
   constructor() {
@@ -144,8 +186,13 @@ export async function handleOAuthLogin(ctx: OAuthActionContext) {
           ctx.refreshOauthStatus(targetProviderId),
           isCurrentAttempt
         );
-        status = nextStatus;
+        // Prefer server status; if expires_at is missing/stale, trust login result.
+        status = mergeOAuthStatusAfterAuth(nextStatus, {
+          provider_type: result.provider_type,
+          expires_at: result.expires_at,
+        });
         ctx.setOauthStatus(status);
+        ctx.writeOauthStatusCache(status, targetProviderId);
       } catch (statusErr) {
         if (isOAuthAttemptStaleError(statusErr)) {
           return;
@@ -153,6 +200,13 @@ export async function handleOAuthLogin(ctx: OAuthActionContext) {
         if (!isCurrentAttempt()) {
           return;
         }
+        // Status fetch failed but tokens were saved — still show login result expiry.
+        status = mergeOAuthStatusAfterAuth(null, {
+          provider_type: result.provider_type,
+          expires_at: result.expires_at,
+        });
+        ctx.setOauthStatus(status);
+        ctx.writeOauthStatusCache(status, targetProviderId);
         toast("OAuth 登录成功，但读取连接状态失败，可稍后重试");
         logToConsole(
           "warn",
@@ -355,11 +409,16 @@ export async function handleOAuthDeviceLogin(ctx: OAuthActionContext) {
         ctx.setOauthDeviceFlow(null);
         ctx.setOauthDeviceError(null);
 
-        const status = await whenOAuthAttemptCurrent(
+        const nextStatus = await whenOAuthAttemptCurrent(
           ctx.refreshOauthStatus(targetProviderId),
           isCurrentAttempt
         );
-        ctx.setOauthStatus(status);
+        const mergedStatus = mergeOAuthStatusAfterAuth(nextStatus, {
+          provider_type: result.provider_type,
+          expires_at: result.expires_at,
+        });
+        ctx.setOauthStatus(mergedStatus);
+        ctx.writeOauthStatusCache(mergedStatus, targetProviderId);
 
         try {
           await whenOAuthAttemptCurrent(
@@ -442,12 +501,18 @@ export async function handleOAuthRefresh(ctx: OAuthActionContext) {
   try {
     const result = await providerOAuthRefresh(ctx.editingProviderId);
     if (result.success) {
-      const status = await ctx.refreshOauthStatus(ctx.editingProviderId);
-      ctx.setOauthStatus(status);
+      const nextStatus = await ctx.refreshOauthStatus(ctx.editingProviderId);
+      const mergedStatus = mergeOAuthStatusAfterAuth(nextStatus, {
+        expires_at: result.expires_at,
+      });
+      // Write cache first so the oauthStatusQuery effect cannot re-apply a stale
+      // pre-refresh expires_at after setOauthStatus.
+      ctx.writeOauthStatusCache(mergedStatus, ctx.editingProviderId);
+      ctx.setOauthStatus(mergedStatus);
       toast("Token 刷新成功");
       logToConsole("info", `OAuth Token 刷新成功：${ctx.form.getValues().name}`, {
         provider_id: ctx.editingProviderId,
-        expires_at: result.expires_at,
+        expires_at: mergedStatus.expires_at,
       });
     } else {
       toast("Token 刷新失败");
@@ -472,7 +537,11 @@ export async function handleOAuthDisconnect(ctx: OAuthActionContext) {
   try {
     const result = await providerOAuthDisconnect(ctx.editingProviderId);
     if (result.success) {
-      ctx.setOauthStatus(null);
+      // Force cache + UI to disconnected (avoid sticky pre-disconnect snapshot).
+      const status = await ctx.refreshOauthStatus(ctx.editingProviderId);
+      const disconnected = status?.connected ? null : status;
+      ctx.writeOauthStatusCache(disconnected, ctx.editingProviderId);
+      ctx.setOauthStatus(disconnected);
       toast("已断开 OAuth 连接");
       logToConsole("info", `OAuth 已断开连接：${ctx.form.getValues().name}`, {
         provider_id: ctx.editingProviderId,

--- a/src/pages/providers/providerEditorOAuthActions.ts
+++ b/src/pages/providers/providerEditorOAuthActions.ts
@@ -8,52 +8,10 @@ import {
   providerOAuthRefresh,
   providerOAuthDisconnect,
   providerOAuthFetchLimits,
-  type ProviderOAuthStatusResult,
 } from "../../services/providers/providers";
 import type { OAuthActionContext } from "./providerEditorActionContext";
 import { presentProviderEditorPayloadBuildError } from "./providerEditorFeedback";
 import { buildProviderEditorUpsertInput } from "./providerEditorSubmitModel";
-
-/** Prefer the later absolute expiry when both sides have a value. */
-function pickFresherExpiresAt(
-  a: number | null | undefined,
-  b: number | null | undefined
-): number | null {
-  if (a != null && Number.isFinite(a) && b != null && Number.isFinite(b)) {
-    return Math.max(a, b);
-  }
-  if (a != null && Number.isFinite(a)) return a;
-  if (b != null && Number.isFinite(b)) return b;
-  return null;
-}
-
-/**
- * Prefer freshly minted auth timestamps over a sticky/stale status snapshot.
- *
- * Important: after "刷新 Token", the IPC result carries the new `expires_at`
- * while a status re-fetch (or React Query snapshot) can still briefly hold the
- * pre-refresh value. Always take the newer absolute timestamp.
- */
-function mergeOAuthStatusAfterAuth(
-  status: ProviderOAuthStatusResult | null | undefined,
-  auth: { provider_type?: string | null; expires_at?: number | null; email?: string | null }
-): ProviderOAuthStatusResult {
-  if (status?.connected) {
-    return {
-      ...status,
-      expires_at: pickFresherExpiresAt(auth.expires_at, status.expires_at),
-      provider_type: auth.provider_type ?? status.provider_type,
-      email: auth.email ?? status.email,
-    };
-  }
-  return {
-    connected: true,
-    provider_type: auth.provider_type ?? status?.provider_type ?? null,
-    email: auth.email ?? status?.email ?? null,
-    expires_at: pickFresherExpiresAt(auth.expires_at, status?.expires_at),
-    has_refresh_token: status?.has_refresh_token ?? true,
-  };
-}
 
 class OAuthAttemptStaleError extends Error {
   constructor() {
@@ -186,13 +144,8 @@ export async function handleOAuthLogin(ctx: OAuthActionContext) {
           ctx.refreshOauthStatus(targetProviderId),
           isCurrentAttempt
         );
-        // Prefer server status; if expires_at is missing/stale, trust login result.
-        status = mergeOAuthStatusAfterAuth(nextStatus, {
-          provider_type: result.provider_type,
-          expires_at: result.expires_at,
-        });
+        status = nextStatus;
         ctx.setOauthStatus(status);
-        ctx.writeOauthStatusCache(status, targetProviderId);
       } catch (statusErr) {
         if (isOAuthAttemptStaleError(statusErr)) {
           return;
@@ -200,11 +153,15 @@ export async function handleOAuthLogin(ctx: OAuthActionContext) {
         if (!isCurrentAttempt()) {
           return;
         }
-        // Status fetch failed but tokens were saved — still show login result expiry.
-        status = mergeOAuthStatusAfterAuth(null, {
+        // Token 已保存成功，只是状态读取失败：用登录结果兜底展示，
+        // 并同步写入缓存，避免编辑器 effect 用旧快照盖回去。
+        status = {
+          connected: true,
           provider_type: result.provider_type,
+          email: null,
           expires_at: result.expires_at,
-        });
+          has_refresh_token: null,
+        };
         ctx.setOauthStatus(status);
         ctx.writeOauthStatusCache(status, targetProviderId);
         toast("OAuth 登录成功，但读取连接状态失败，可稍后重试");
@@ -409,16 +366,11 @@ export async function handleOAuthDeviceLogin(ctx: OAuthActionContext) {
         ctx.setOauthDeviceFlow(null);
         ctx.setOauthDeviceError(null);
 
-        const nextStatus = await whenOAuthAttemptCurrent(
+        const status = await whenOAuthAttemptCurrent(
           ctx.refreshOauthStatus(targetProviderId),
           isCurrentAttempt
         );
-        const mergedStatus = mergeOAuthStatusAfterAuth(nextStatus, {
-          provider_type: result.provider_type,
-          expires_at: result.expires_at,
-        });
-        ctx.setOauthStatus(mergedStatus);
-        ctx.writeOauthStatusCache(mergedStatus, targetProviderId);
+        ctx.setOauthStatus(status);
 
         try {
           await whenOAuthAttemptCurrent(
@@ -501,18 +453,12 @@ export async function handleOAuthRefresh(ctx: OAuthActionContext) {
   try {
     const result = await providerOAuthRefresh(ctx.editingProviderId);
     if (result.success) {
-      const nextStatus = await ctx.refreshOauthStatus(ctx.editingProviderId);
-      const mergedStatus = mergeOAuthStatusAfterAuth(nextStatus, {
-        expires_at: result.expires_at,
-      });
-      // Write cache first so the oauthStatusQuery effect cannot re-apply a stale
-      // pre-refresh expires_at after setOauthStatus.
-      ctx.writeOauthStatusCache(mergedStatus, ctx.editingProviderId);
-      ctx.setOauthStatus(mergedStatus);
+      const status = await ctx.refreshOauthStatus(ctx.editingProviderId);
+      ctx.setOauthStatus(status);
       toast("Token 刷新成功");
       logToConsole("info", `OAuth Token 刷新成功：${ctx.form.getValues().name}`, {
         provider_id: ctx.editingProviderId,
-        expires_at: mergedStatus.expires_at,
+        expires_at: result.expires_at,
       });
     } else {
       toast("Token 刷新失败");
@@ -537,11 +483,9 @@ export async function handleOAuthDisconnect(ctx: OAuthActionContext) {
   try {
     const result = await providerOAuthDisconnect(ctx.editingProviderId);
     if (result.success) {
-      // Force cache + UI to disconnected (avoid sticky pre-disconnect snapshot).
-      const status = await ctx.refreshOauthStatus(ctx.editingProviderId);
-      const disconnected = status?.connected ? null : status;
-      ctx.writeOauthStatusCache(disconnected, ctx.editingProviderId);
-      ctx.setOauthStatus(disconnected);
+      ctx.setOauthStatus(null);
+      // 缓存也写为未连接：否则 5 分钟内重开弹窗会命中"仍已连接"的旧快照。
+      ctx.writeOauthStatusCache(null, ctx.editingProviderId);
       toast("已断开 OAuth 连接");
       logToConsole("info", `OAuth 已断开连接：${ctx.form.getValues().name}`, {
         provider_id: ctx.editingProviderId,

--- a/src/pages/providers/useProviderEditorEffects.ts
+++ b/src/pages/providers/useProviderEditorEffects.ts
@@ -44,7 +44,7 @@ export type EffectDeps = {
   setStreamIdleTimeoutSeconds: (v: string) => void;
   setAuthMode: (v: "api_key" | "oauth" | "cx2cc") => void;
   setCx2ccSourceValue: (v: string) => void;
-  setOauthStatus: React.Dispatch<React.SetStateAction<ProviderOAuthStatusResult | null>>;
+  setOauthStatus: (v: ProviderOAuthStatusResult | null) => void;
   setOauthLoading: (v: boolean) => void;
   setCx2ccFallbackModels: (
     v: {
@@ -249,22 +249,7 @@ export function useProviderEditorEffects(d: EffectDeps) {
     if (!open || editProvider?.auth_mode !== "oauth") return;
     if (oauthStatusSnapshot === undefined) return;
     oauthStatusErrorRef.current = null;
-    // Never regress a fresher access-token expiry that login/refresh just wrote
-    // into local state while React Query still holds a pre-refresh snapshot.
-    setOauthStatus((prev) => {
-      if (
-        prev?.connected &&
-        oauthStatusSnapshot?.connected &&
-        prev.expires_at != null &&
-        Number.isFinite(prev.expires_at) &&
-        oauthStatusSnapshot.expires_at != null &&
-        Number.isFinite(oauthStatusSnapshot.expires_at) &&
-        prev.expires_at > oauthStatusSnapshot.expires_at
-      ) {
-        return { ...oauthStatusSnapshot, expires_at: prev.expires_at };
-      }
-      return oauthStatusSnapshot;
-    });
+    setOauthStatus(oauthStatusSnapshot);
   }, [editProvider?.auth_mode, oauthStatusSnapshot, open, setOauthStatus]);
 
   useEffect(() => {

--- a/src/pages/providers/useProviderEditorEffects.ts
+++ b/src/pages/providers/useProviderEditorEffects.ts
@@ -44,7 +44,7 @@ export type EffectDeps = {
   setStreamIdleTimeoutSeconds: (v: string) => void;
   setAuthMode: (v: "api_key" | "oauth" | "cx2cc") => void;
   setCx2ccSourceValue: (v: string) => void;
-  setOauthStatus: (v: ProviderOAuthStatusResult | null) => void;
+  setOauthStatus: React.Dispatch<React.SetStateAction<ProviderOAuthStatusResult | null>>;
   setOauthLoading: (v: boolean) => void;
   setCx2ccFallbackModels: (
     v: {
@@ -249,7 +249,22 @@ export function useProviderEditorEffects(d: EffectDeps) {
     if (!open || editProvider?.auth_mode !== "oauth") return;
     if (oauthStatusSnapshot === undefined) return;
     oauthStatusErrorRef.current = null;
-    setOauthStatus(oauthStatusSnapshot);
+    // Never regress a fresher access-token expiry that login/refresh just wrote
+    // into local state while React Query still holds a pre-refresh snapshot.
+    setOauthStatus((prev) => {
+      if (
+        prev?.connected &&
+        oauthStatusSnapshot?.connected &&
+        prev.expires_at != null &&
+        Number.isFinite(prev.expires_at) &&
+        oauthStatusSnapshot.expires_at != null &&
+        Number.isFinite(oauthStatusSnapshot.expires_at) &&
+        prev.expires_at > oauthStatusSnapshot.expires_at
+      ) {
+        return { ...oauthStatusSnapshot, expires_at: prev.expires_at };
+      }
+      return oauthStatusSnapshot;
+    });
   }, [editProvider?.auth_mode, oauthStatusSnapshot, open, setOauthStatus]);
 
   useEffect(() => {

--- a/src/pages/providers/useProviderEditorForm.ts
+++ b/src/pages/providers/useProviderEditorForm.ts
@@ -20,6 +20,7 @@ import type {
 } from "./providerEditorActionContext";
 import {
   fetchProviderOAuthStatus,
+  writeProviderOAuthStatusCache,
   useProviderDeleteMutation,
   useProviderOAuthStatusQuery,
   useProviderUpsertMutation,
@@ -411,6 +412,13 @@ export function useProviderEditorForm(props: ProviderEditorDialogProps) {
     [editingProviderId, queryClient]
   );
 
+  const writeOauthStatusCache = useCallback(
+    (status: OAuthStatusValue, providerId?: number | null) => {
+      writeProviderOAuthStatusCache(queryClient, providerId ?? editingProviderId, status);
+    },
+    [editingProviderId, queryClient]
+  );
+
   const cancelOAuthDeviceFlow = useCallback((flowId: string) => {
     void providerOAuthCancelDeviceFlow(flowId).catch((err) => {
       logToConsole("warn", "取消设备码登录失败", { error: String(err) });
@@ -622,6 +630,7 @@ export function useProviderEditorForm(props: ProviderEditorDialogProps) {
       oauthStatus,
       setOauthStatus,
       refreshOauthStatus,
+      writeOauthStatusCache,
       setOauthLoading,
       oauthDeviceFlow,
       setOauthDeviceFlow,
@@ -651,6 +660,7 @@ export function useProviderEditorForm(props: ProviderEditorDialogProps) {
       oauthDevicePolling,
       oauthDeviceError,
       refreshOauthStatus,
+      writeOauthStatusCache,
       providerUpsertMutation,
       providerDeleteMutation,
       beginOAuthLoginAttempt,

--- a/src/query/__tests__/providers.test.tsx
+++ b/src/query/__tests__/providers.test.tsx
@@ -1,6 +1,10 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
-import type { ProviderSummary } from "../../services/providers/providers";
+import type {
+  ProviderOAuthStatusResult,
+  ProviderSummary,
+} from "../../services/providers/providers";
 import {
   providerOAuthFetchLimits,
   providerOAuthResetCodexQuota,
@@ -17,6 +21,7 @@ import {
 import { gatewayCircuitResetProvider } from "../../services/gateway/gateway";
 import {
   fetchProviderOAuthStatus,
+  writeProviderOAuthStatusCache,
   readProviderOAuthLimitsCache,
   refreshProviderOAuthLimits,
   resetProviderOAuthCodexQuota,
@@ -239,31 +244,84 @@ describe("query/providers", () => {
     expect(client.getQueryState(providersKeys.oauthStatus(Number.NaN))).toBeUndefined();
   });
 
-  it("fetchProviderOAuthStatus always hits network and overwrites stale expires_at cache", async () => {
+  it("fetchProviderOAuthStatus refetches from network even when cache is fresh by staleTime", async () => {
     setTauriRuntime();
 
-    const stale = {
+    // 还原生产配置：全局 staleTime 5 分钟（见 src/query/queryClient.ts）。
+    // 旧实现的 fetchQuery 会直接返回刷新前的缓存，导致「到期」时间不更新。
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 5 * 60 * 1000 } },
+    });
+    const stale: ProviderOAuthStatusResult = {
       connected: true,
       provider_type: "grok_oauth",
-      email: "old@example.com",
+      email: "user@example.com",
       expires_at: 1_700_000_000,
       has_refresh_token: true,
     };
-    const fresh = {
+    const fresh: ProviderOAuthStatusResult = { ...stale, expires_at: 1_800_000_000 };
+    client.setQueryData(providersKeys.oauthStatus(9), stale);
+    vi.mocked(providerOAuthStatus).mockResolvedValue(fresh);
+
+    await expect(fetchProviderOAuthStatus(client, 9)).resolves.toEqual(fresh);
+    expect(providerOAuthStatus).toHaveBeenCalledWith(9);
+    expect(client.getQueryData(providersKeys.oauthStatus(9))).toEqual(fresh);
+  });
+
+  it("fetchProviderOAuthStatus cancels an in-flight request so a stale late response cannot overwrite", async () => {
+    setTauriRuntime();
+
+    const client = createTestQueryClient();
+    const queryKey = providersKeys.oauthStatus(9);
+    const stale: ProviderOAuthStatusResult = {
       connected: true,
       provider_type: "grok_oauth",
-      email: "new@example.com",
+      email: "user@example.com",
+      expires_at: 1_700_000_000,
+      has_refresh_token: true,
+    };
+    const fresh: ProviderOAuthStatusResult = { ...stale, expires_at: 1_800_000_000 };
+
+    let resolveStale!: (value: ProviderOAuthStatusResult) => void;
+    vi.mocked(providerOAuthStatus)
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveStale = resolve)))
+      .mockResolvedValueOnce(fresh);
+
+    // 模拟一个刷新前就已发出、迟迟未返回的 status 请求（例如后台 refetch）。
+    const inflight = client
+      .fetchQuery({ queryKey, queryFn: () => providerOAuthStatus(9) })
+      .catch(() => null); // 被取消时以 CancelledError 拒绝
+
+    await expect(fetchProviderOAuthStatus(client, 9)).resolves.toEqual(fresh);
+
+    // 旧请求这时才带着刷新前的数据返回——不应覆盖新数据。
+    resolveStale(stale);
+    await inflight;
+    expect(client.getQueryData(queryKey)).toEqual(fresh);
+  });
+
+  it("writeProviderOAuthStatusCache writes status, clears with null, and skips null providerId", () => {
+    const client = createTestQueryClient();
+    const status: ProviderOAuthStatusResult = {
+      connected: true,
+      provider_type: "grok_oauth",
+      email: "user@example.com",
       expires_at: 1_800_000_000,
       has_refresh_token: true,
     };
 
-    const client = createTestQueryClient();
-    client.setQueryData(providersKeys.oauthStatus(9), stale);
-    vi.mocked(providerOAuthStatus).mockResolvedValue(fresh);
+    writeProviderOAuthStatusCache(client, 9, status);
+    expect(client.getQueryData(providersKeys.oauthStatus(9))).toEqual(status);
 
-    await expect(fetchProviderOAuthStatus(client as never, 9)).resolves.toEqual(fresh);
-    expect(providerOAuthStatus).toHaveBeenCalledWith(9);
-    expect(client.getQueryData(providersKeys.oauthStatus(9))).toEqual(fresh);
+    writeProviderOAuthStatusCache(client, 9, null);
+    expect(client.getQueryData(providersKeys.oauthStatus(9))).toBeNull();
+
+    writeProviderOAuthStatusCache(client, null, status);
+    expect(client.getQueryCache().getAll()).toHaveLength(1);
+
+    expect(() => writeProviderOAuthStatusCache(client, Number.NaN, status)).toThrow(
+      "SEC_INVALID_INPUT"
+    );
   });
 
   it("normalizes OAuth limits providerId before cache reads, refreshes, and query calls", async () => {

--- a/src/query/__tests__/providers.test.tsx
+++ b/src/query/__tests__/providers.test.tsx
@@ -239,6 +239,33 @@ describe("query/providers", () => {
     expect(client.getQueryState(providersKeys.oauthStatus(Number.NaN))).toBeUndefined();
   });
 
+  it("fetchProviderOAuthStatus always hits network and overwrites stale expires_at cache", async () => {
+    setTauriRuntime();
+
+    const stale = {
+      connected: true,
+      provider_type: "grok_oauth",
+      email: "old@example.com",
+      expires_at: 1_700_000_000,
+      has_refresh_token: true,
+    };
+    const fresh = {
+      connected: true,
+      provider_type: "grok_oauth",
+      email: "new@example.com",
+      expires_at: 1_800_000_000,
+      has_refresh_token: true,
+    };
+
+    const client = createTestQueryClient();
+    client.setQueryData(providersKeys.oauthStatus(9), stale);
+    vi.mocked(providerOAuthStatus).mockResolvedValue(fresh);
+
+    await expect(fetchProviderOAuthStatus(client as never, 9)).resolves.toEqual(fresh);
+    expect(providerOAuthStatus).toHaveBeenCalledWith(9);
+    expect(client.getQueryData(providersKeys.oauthStatus(9))).toEqual(fresh);
+  });
+
   it("normalizes OAuth limits providerId before cache reads, refreshes, and query calls", async () => {
     setTauriRuntime();
 

--- a/src/query/providers.ts
+++ b/src/query/providers.ts
@@ -70,16 +70,33 @@ export function useProviderOAuthStatusQuery(
   });
 }
 
+/**
+ * Always hit the network for OAuth connection status (email / expires_at).
+ *
+ * Do **not** use `fetchQuery` alone here: after login/refresh the cache often
+ * still holds the pre-login `expires_at`, so the editor keeps showing a stale
+ * "到期" time even though the DB was updated.
+ */
 export async function fetchProviderOAuthStatus(
-  queryClient: ReturnType<typeof useQueryClient>,
+  queryClient: QueryClient,
   providerId: number | null
 ) {
   if (providerId == null) return null;
   const normalizedProviderId = validateProviderId(providerId);
-  return queryClient.fetchQuery({
-    queryKey: providersKeys.oauthStatus(normalizedProviderId),
-    queryFn: () => providerOAuthStatus(normalizedProviderId),
-  });
+  const status = await providerOAuthStatus(normalizedProviderId);
+  queryClient.setQueryData(providersKeys.oauthStatus(normalizedProviderId), status);
+  return status;
+}
+
+/** Write OAuth status into the React Query cache (keeps editor effects in sync). */
+export function writeProviderOAuthStatusCache(
+  queryClient: QueryClient,
+  providerId: number | null,
+  status: Awaited<ReturnType<typeof providerOAuthStatus>> | null
+) {
+  if (providerId == null) return;
+  const normalizedProviderId = validateProviderId(providerId);
+  queryClient.setQueryData(providersKeys.oauthStatus(normalizedProviderId), status);
 }
 
 const EMPTY_OAUTH_LIMITS_RESULT: OAuthLimitsResult = {

--- a/src/query/providers.ts
+++ b/src/query/providers.ts
@@ -70,33 +70,35 @@ export function useProviderOAuthStatusQuery(
   });
 }
 
-/**
- * Always hit the network for OAuth connection status (email / expires_at).
- *
- * Do **not** use `fetchQuery` alone here: after login/refresh the cache often
- * still holds the pre-login `expires_at`, so the editor keeps showing a stale
- * "到期" time even though the DB was updated.
- */
 export async function fetchProviderOAuthStatus(
   queryClient: QueryClient,
   providerId: number | null
 ) {
   if (providerId == null) return null;
   const normalizedProviderId = validateProviderId(providerId);
-  const status = await providerOAuthStatus(normalizedProviderId);
-  queryClient.setQueryData(providersKeys.oauthStatus(normalizedProviderId), status);
-  return status;
+  const queryKey = providersKeys.oauthStatus(normalizedProviderId);
+  // 登录/刷新 Token 后必须拿到服务端最新状态：全局 staleTime 为 5 分钟，
+  // 默认 fetchQuery 会直接返回刷新前的缓存。先取消在途请求（它可能带着
+  // 旧 expires_at 稍后落地覆盖缓存），再以 staleTime: 0 强制重新拉取。
+  await queryClient.cancelQueries({ queryKey });
+  return queryClient.fetchQuery({
+    queryKey,
+    queryFn: () => providerOAuthStatus(normalizedProviderId),
+    staleTime: 0,
+  });
 }
 
-/** Write OAuth status into the React Query cache (keeps editor effects in sync). */
+/** 将 OAuth 状态直接写入缓存（断开连接、登录后状态读取失败等本地已知结论的场景）。 */
 export function writeProviderOAuthStatusCache(
   queryClient: QueryClient,
   providerId: number | null,
   status: Awaited<ReturnType<typeof providerOAuthStatus>> | null
 ) {
   if (providerId == null) return;
-  const normalizedProviderId = validateProviderId(providerId);
-  queryClient.setQueryData(providersKeys.oauthStatus(normalizedProviderId), status);
+  const queryKey = providersKeys.oauthStatus(validateProviderId(providerId));
+  // 同样先取消在途请求，避免旧响应稍后覆盖这次写入。
+  void queryClient.cancelQueries({ queryKey });
+  queryClient.setQueryData(queryKey, status);
 }
 
 const EMPTY_OAUTH_LIMITS_RESULT: OAuthLimitsResult = {


### PR DESCRIPTION
## Summary

修复供应商 OAuth 编辑页在「刷新 Token」/登录成功后，**到期时间 UI 不更新** 的问题。后端续约与落库逻辑本身正常，问题在前端 status 缓存与 editor effect 把旧 `expires_at` 盖回去。

Fixes #352

## 改动要点

- `fetchProviderOAuthStatus`：始终走网络拉 status，再 `setQueryData` 覆盖缓存
- 新增 `writeProviderOAuthStatusCache`：登录/刷新/断开后写回与 UI 一致的 status
- `mergeOAuthStatusAfterAuth`：合并 IPC 结果与 status，取较新的 `expires_at`
- `useProviderEditorEffects`：禁止用更旧的 snapshot 回退本地到期时间

## 影响范围

所有走 Provider 编辑弹窗 OAuth 流程的供应商（Grok / Codex / Claude / Gemini 等），非协议层改动。

## Test plan

- [x] `vitest`：`providerEditorOAuthActions` + `query/providers` 相关用例
- [x] pre-commit：lint / typecheck / no-instant-now-sub
- [ ] 手动：打开任意 OAuth 供应商 → 点「刷新 Token」→ 成功 toast 后「到期」应变为约「现在 + access TTL」
- [ ] 手动：OAuth 登录成功后「到期」与后端 `expires_at` 一致
- [ ] 手动：断开连接后 UI 回到未连接状态，无粘住旧账号/到期