### PR TITLE
fix(gateway): 修复 Claude 经 CX2CC 使用 Grok 时缓存不命中

### DIFF
--- a/src-tauri/src/gateway/proxy/handler/failover_loop/attempt/attempt_auth.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/attempt/attempt_auth.rs
@@ -161,10 +161,17 @@ fn inject_standard_auth<R: tauri::Runtime>(
     retry_index: u32,
     headers: &mut HeaderMap,
 ) {
+    // CX2CC must authenticate as the *source* CLI (codex/grok/...), not the
+    // bridge client (claude). Previously this was hard-coded to "codex", which
+    // breaks Grok-specific auth header strategies for CX2CC→Grok.
     let auth_cli_key = if prepared.cx2cc_active {
-        "codex"
+        prepared
+            .cx2cc_source
+            .as_ref()
+            .map(|(_, source_cli_key)| source_cli_key.as_str())
+            .unwrap_or("codex")
     } else {
-        &input.cli_key
+        input.cli_key.as_str()
     };
     inject_provider_auth(auth_cli_key, prepared.effective_credential.trim(), headers);
 

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/attempt/attempt_executor.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/attempt/attempt_executor.rs
@@ -215,33 +215,29 @@ where
 
     headers = semantic_headers;
 
-    // Last-mile stickiness for CX2CC→Grok: plugins/auth must not leave us without
-    // prompt_cache_key + Build-equivalent x-grok-* headers (affinity + IC routing).
-    //
-    // IMPORTANT: users often register Grok mid-proxies as cli_key=codex (OpenAI-
-    // compatible). Detect Grok by mapped model as well as source cli_key.
+    // Last-mile stickiness for CX2CC→Grok: only repair if plugins/auth stripped
+    // sticky fields. Detect Grok by mapped model as well as source cli_key.
     if cx2cc_active {
         let sticky = cx2cc_sticky_session.as_deref();
         let mut body_bytes = body_state_for_attempt.decoded_clone();
-        let body_json: Option<serde_json::Value> = serde_json::from_slice(body_bytes.as_ref()).ok();
-        let model_id = body_json
-            .as_ref()
-            .and_then(|v| v.get("model"))
-            .and_then(|m| m.as_str())
-            .map(str::to_string);
+        let model_id = codex_session_id_completion::model_from_body_bytes(body_bytes.as_ref());
 
-        if !codex_session_id_completion::needs_grok_build_wire(
+        if codex_session_id_completion::needs_grok_build_wire(
             cx2cc_source_cli_key.as_deref(),
             model_id.as_deref(),
         ) {
-            // not a Grok upstream — skip Build-wire path
-        } else {
-            codex_session_id_completion::inject_session_headers_with_model(
-                &mut headers,
-                sticky,
-                cx2cc_source_cli_key.as_deref().or(Some("grok")),
-                model_id.as_deref(),
-            );
+            let missing_wire_headers = !headers.contains_key("x-grok-conv-id")
+                || !headers.contains_key("x-grok-session-id")
+                || (model_id.is_some() && !headers.contains_key("x-grok-model-override"));
+            if missing_wire_headers {
+                codex_session_id_completion::inject_session_headers_with_model(
+                    &mut headers,
+                    sticky,
+                    cx2cc_source_cli_key.as_deref().or(Some("grok")),
+                    model_id.as_deref(),
+                );
+            }
+            // No-op when prompt_cache_key already matches session.
             let body_rewritten = codex_session_id_completion::ensure_prompt_cache_key_on_body(
                 &mut body_bytes,
                 sticky,
@@ -252,6 +248,7 @@ where
                 prepared.strip_request_content_encoding = true;
                 prepared.request_body_mutated_before_attempt = true;
             }
+
             let has_prompt_cache_key = serde_json::from_slice::<serde_json::Value>(
                 body_state_for_attempt.decoded_clone().as_ref(),
             )
@@ -269,7 +266,7 @@ where
             let has_x_grok_session_id = headers.contains_key("x-grok-session-id");
             let has_x_grok_agent_id = headers.contains_key("x-grok-agent-id");
 
-            // Always surface in the in-app gateway console (tracing::info is not shown there).
+            // In-app console + special_settings (skip duplicate tracing::info).
             response_fixer::push_special_setting(
                 ctx.special_settings,
                 serde_json::json!({
@@ -280,6 +277,7 @@ where
                     "sessionId": sticky,
                     "modelId": model_id,
                     "bodyRewritten": body_rewritten,
+                    "headersRepaired": missing_wire_headers,
                     "hasPromptCacheKey": has_prompt_cache_key,
                     "hasXGrokConvId": has_x_grok_conv_id,
                     "hasXGrokSessionId": has_x_grok_session_id,
@@ -292,37 +290,26 @@ where
                 }),
             );
             emit_gateway_log(
-            &input.state.app,
-            "info",
-            "CX2CC_GROK_BUILD_WIRE",
-            format!(
-                "[CX2CC] grok Build-wire stickiness source_cli_key={} session={} model={} prompt_cache_key={} conv={} session_hdr={} model_override={} client_version={} req_id={} agent_id={}",
-                cx2cc_source_cli_key.as_deref().unwrap_or(""),
-                sticky.unwrap_or(""),
-                model_id.as_deref().unwrap_or(""),
-                has_prompt_cache_key,
-                has_x_grok_conv_id,
-                has_x_grok_session_id,
-                has_x_grok_model_override,
-                has_x_grok_client_version,
-                has_x_grok_req_id,
-                has_x_grok_agent_id,
-            ),
-        );
-            tracing::info!(
-                trace_id = %input.trace_id,
-                provider_id = prepared.provider_id,
-                source_cli_key = cx2cc_source_cli_key.as_deref().unwrap_or(""),
-                session_id = sticky.unwrap_or(""),
-                model_id = model_id.as_deref().unwrap_or(""),
-                has_prompt_cache_key,
-                has_x_grok_conv_id,
-                has_x_grok_model_override,
-                has_x_grok_client_version,
-                has_x_grok_req_id,
-                "cx2cc→grok Build-wire stickiness asserted before upstream send"
+                &input.state.app,
+                "info",
+                "CX2CC_GROK_BUILD_WIRE",
+                format!(
+                    "[CX2CC] grok Build-wire stickiness source_cli_key={} session={} model={} prompt_cache_key={} conv={} session_hdr={} model_override={} client_version={} req_id={} agent_id={} repaired_headers={} body_rewritten={}",
+                    cx2cc_source_cli_key.as_deref().unwrap_or(""),
+                    sticky.unwrap_or(""),
+                    model_id.as_deref().unwrap_or(""),
+                    has_prompt_cache_key,
+                    has_x_grok_conv_id,
+                    has_x_grok_session_id,
+                    has_x_grok_model_override,
+                    has_x_grok_client_version,
+                    has_x_grok_req_id,
+                    has_x_grok_agent_id,
+                    missing_wire_headers,
+                    body_rewritten,
+                ),
             );
-        } // end needs_grok_build_wire
+        }
     }
 
     let upstream_body = body_state_for_attempt

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/attempt/attempt_executor.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/attempt/attempt_executor.rs
@@ -101,10 +101,23 @@ where
 
     // --- Build headers + inject auth ---
     let mut headers = input.base_headers.clone();
-    ensure_cli_required_headers(&input.cli_key, &mut headers);
+    // Own the key so later `prepared` mut borrows (plugin body sync) are allowed.
+    let cx2cc_source_cli_key: Option<String> = prepared
+        .cx2cc_source
+        .as_ref()
+        .map(|(_, source_cli_key)| source_cli_key.clone());
+    let cx2cc_sticky_session = prepared.cx2cc_codex_session_id.clone();
+    let cx2cc_active = prepared.cx2cc_active;
+    // Prefer source CLI required headers when CX2CC is active (e.g. Grok/Codex),
+    // not the bridge client (claude).
+    let ensure_headers_cli_key = cx2cc_source_cli_key
+        .as_deref()
+        .unwrap_or(input.cli_key.as_str());
+    ensure_cli_required_headers(ensure_headers_cli_key, &mut headers);
     codex_session_id_completion::inject_session_headers_if_needed(
         &mut headers,
-        prepared.cx2cc_codex_session_id.as_deref(),
+        cx2cc_sticky_session.as_deref(),
+        cx2cc_source_cli_key.as_deref(),
     );
 
     if let Err(failed_attempt) = attempt_auth::inject_auth(
@@ -123,6 +136,14 @@ where
         loop_state.attempts.push(*failed_attempt);
         return AttemptSendOutcome::OAuthInjectFailed;
     }
+
+    // Re-assert sticky headers after auth (auth clears only auth headers, but
+    // keep this order explicit so Grok sticky always wins on the wire).
+    codex_session_id_completion::inject_session_headers_if_needed(
+        &mut headers,
+        cx2cc_sticky_session.as_deref(),
+        cx2cc_source_cli_key.as_deref(),
+    );
 
     // --- Clean body + send upstream ---
     let clean_outcome = request_sanitizer::clean_body(input, prepared);
@@ -193,6 +214,117 @@ where
     }
 
     headers = semantic_headers;
+
+    // Last-mile stickiness for CX2CC→Grok: plugins/auth must not leave us without
+    // prompt_cache_key + Build-equivalent x-grok-* headers (affinity + IC routing).
+    //
+    // IMPORTANT: users often register Grok mid-proxies as cli_key=codex (OpenAI-
+    // compatible). Detect Grok by mapped model as well as source cli_key.
+    if cx2cc_active {
+        let sticky = cx2cc_sticky_session.as_deref();
+        let mut body_bytes = body_state_for_attempt.decoded_clone();
+        let body_json: Option<serde_json::Value> = serde_json::from_slice(body_bytes.as_ref()).ok();
+        let model_id = body_json
+            .as_ref()
+            .and_then(|v| v.get("model"))
+            .and_then(|m| m.as_str())
+            .map(str::to_string);
+
+        if !codex_session_id_completion::needs_grok_build_wire(
+            cx2cc_source_cli_key.as_deref(),
+            model_id.as_deref(),
+        ) {
+            // not a Grok upstream — skip Build-wire path
+        } else {
+            codex_session_id_completion::inject_session_headers_with_model(
+                &mut headers,
+                sticky,
+                cx2cc_source_cli_key.as_deref().or(Some("grok")),
+                model_id.as_deref(),
+            );
+            let body_rewritten = codex_session_id_completion::ensure_prompt_cache_key_on_body(
+                &mut body_bytes,
+                sticky,
+            );
+            if body_rewritten {
+                body_state_for_attempt.replace_decoded(body_bytes.clone());
+                prepared.upstream_body_bytes = body_bytes;
+                prepared.strip_request_content_encoding = true;
+                prepared.request_body_mutated_before_attempt = true;
+            }
+            let has_prompt_cache_key = serde_json::from_slice::<serde_json::Value>(
+                body_state_for_attempt.decoded_clone().as_ref(),
+            )
+            .ok()
+            .and_then(|v| {
+                v.get("prompt_cache_key")
+                    .and_then(|k| k.as_str())
+                    .map(|s| !s.trim().is_empty())
+            })
+            .unwrap_or(false);
+            let has_x_grok_conv_id = headers.contains_key("x-grok-conv-id");
+            let has_x_grok_model_override = headers.contains_key("x-grok-model-override");
+            let has_x_grok_client_version = headers.contains_key("x-grok-client-version");
+            let has_x_grok_req_id = headers.contains_key("x-grok-req-id");
+            let has_x_grok_session_id = headers.contains_key("x-grok-session-id");
+            let has_x_grok_agent_id = headers.contains_key("x-grok-agent-id");
+
+            // Always surface in the in-app gateway console (tracing::info is not shown there).
+            response_fixer::push_special_setting(
+                ctx.special_settings,
+                serde_json::json!({
+                    "type": "cx2cc_grok_cache_stickiness",
+                    "scope": "attempt",
+                    "hit": true,
+                    "action": "ensure_before_send",
+                    "sessionId": sticky,
+                    "modelId": model_id,
+                    "bodyRewritten": body_rewritten,
+                    "hasPromptCacheKey": has_prompt_cache_key,
+                    "hasXGrokConvId": has_x_grok_conv_id,
+                    "hasXGrokSessionId": has_x_grok_session_id,
+                    "hasXGrokModelOverride": has_x_grok_model_override,
+                    "hasXGrokClientVersion": has_x_grok_client_version,
+                    "hasXGrokReqId": has_x_grok_req_id,
+                    "hasXGrokAgentId": has_x_grok_agent_id,
+                    "upstreamCliKey": cx2cc_source_cli_key.as_deref().unwrap_or("grok"),
+                    "sourceCliKey": cx2cc_source_cli_key,
+                }),
+            );
+            emit_gateway_log(
+            &input.state.app,
+            "info",
+            "CX2CC_GROK_BUILD_WIRE",
+            format!(
+                "[CX2CC] grok Build-wire stickiness source_cli_key={} session={} model={} prompt_cache_key={} conv={} session_hdr={} model_override={} client_version={} req_id={} agent_id={}",
+                cx2cc_source_cli_key.as_deref().unwrap_or(""),
+                sticky.unwrap_or(""),
+                model_id.as_deref().unwrap_or(""),
+                has_prompt_cache_key,
+                has_x_grok_conv_id,
+                has_x_grok_session_id,
+                has_x_grok_model_override,
+                has_x_grok_client_version,
+                has_x_grok_req_id,
+                has_x_grok_agent_id,
+            ),
+        );
+            tracing::info!(
+                trace_id = %input.trace_id,
+                provider_id = prepared.provider_id,
+                source_cli_key = cx2cc_source_cli_key.as_deref().unwrap_or(""),
+                session_id = sticky.unwrap_or(""),
+                model_id = model_id.as_deref().unwrap_or(""),
+                has_prompt_cache_key,
+                has_x_grok_conv_id,
+                has_x_grok_model_override,
+                has_x_grok_client_version,
+                has_x_grok_req_id,
+                "cx2cc→grok Build-wire stickiness asserted before upstream send"
+            );
+        } // end needs_grok_build_wire
+    }
+
     let upstream_body = body_state_for_attempt
         .finalize_for_upstream(&mut headers, crate::gateway::util::max_request_body_bytes());
 

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/attempt/attempt_executor.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/attempt/attempt_executor.rs
@@ -215,29 +215,33 @@ where
 
     headers = semantic_headers;
 
-    // Last-mile stickiness for CX2CC→Grok: only repair if plugins/auth stripped
-    // sticky fields. Detect Grok by mapped model as well as source cli_key.
+    // Last-mile stickiness for CX2CC→Grok: plugins/auth must not leave us without
+    // prompt_cache_key + Build-equivalent x-grok-* headers (affinity + IC routing).
+    //
+    // IMPORTANT: users often register Grok mid-proxies as cli_key=codex (OpenAI-
+    // compatible). Detect Grok by mapped model as well as source cli_key.
     if cx2cc_active {
         let sticky = cx2cc_sticky_session.as_deref();
         let mut body_bytes = body_state_for_attempt.decoded_clone();
-        let model_id = codex_session_id_completion::model_from_body_bytes(body_bytes.as_ref());
+        let body_json: Option<serde_json::Value> = serde_json::from_slice(body_bytes.as_ref()).ok();
+        let model_id = body_json
+            .as_ref()
+            .and_then(|v| v.get("model"))
+            .and_then(|m| m.as_str())
+            .map(str::to_string);
 
-        if codex_session_id_completion::needs_grok_build_wire(
+        if !codex_session_id_completion::needs_grok_build_wire(
             cx2cc_source_cli_key.as_deref(),
             model_id.as_deref(),
         ) {
-            let missing_wire_headers = !headers.contains_key("x-grok-conv-id")
-                || !headers.contains_key("x-grok-session-id")
-                || (model_id.is_some() && !headers.contains_key("x-grok-model-override"));
-            if missing_wire_headers {
-                codex_session_id_completion::inject_session_headers_with_model(
-                    &mut headers,
-                    sticky,
-                    cx2cc_source_cli_key.as_deref().or(Some("grok")),
-                    model_id.as_deref(),
-                );
-            }
-            // No-op when prompt_cache_key already matches session.
+            // not a Grok upstream — skip Build-wire path
+        } else {
+            codex_session_id_completion::inject_session_headers_with_model(
+                &mut headers,
+                sticky,
+                cx2cc_source_cli_key.as_deref().or(Some("grok")),
+                model_id.as_deref(),
+            );
             let body_rewritten = codex_session_id_completion::ensure_prompt_cache_key_on_body(
                 &mut body_bytes,
                 sticky,
@@ -248,7 +252,6 @@ where
                 prepared.strip_request_content_encoding = true;
                 prepared.request_body_mutated_before_attempt = true;
             }
-
             let has_prompt_cache_key = serde_json::from_slice::<serde_json::Value>(
                 body_state_for_attempt.decoded_clone().as_ref(),
             )
@@ -266,7 +269,7 @@ where
             let has_x_grok_session_id = headers.contains_key("x-grok-session-id");
             let has_x_grok_agent_id = headers.contains_key("x-grok-agent-id");
 
-            // In-app console + special_settings (skip duplicate tracing::info).
+            // Always surface in the in-app gateway console (tracing::info is not shown there).
             response_fixer::push_special_setting(
                 ctx.special_settings,
                 serde_json::json!({
@@ -277,7 +280,6 @@ where
                     "sessionId": sticky,
                     "modelId": model_id,
                     "bodyRewritten": body_rewritten,
-                    "headersRepaired": missing_wire_headers,
                     "hasPromptCacheKey": has_prompt_cache_key,
                     "hasXGrokConvId": has_x_grok_conv_id,
                     "hasXGrokSessionId": has_x_grok_session_id,
@@ -290,26 +292,37 @@ where
                 }),
             );
             emit_gateway_log(
-                &input.state.app,
-                "info",
-                "CX2CC_GROK_BUILD_WIRE",
-                format!(
-                    "[CX2CC] grok Build-wire stickiness source_cli_key={} session={} model={} prompt_cache_key={} conv={} session_hdr={} model_override={} client_version={} req_id={} agent_id={} repaired_headers={} body_rewritten={}",
-                    cx2cc_source_cli_key.as_deref().unwrap_or(""),
-                    sticky.unwrap_or(""),
-                    model_id.as_deref().unwrap_or(""),
-                    has_prompt_cache_key,
-                    has_x_grok_conv_id,
-                    has_x_grok_session_id,
-                    has_x_grok_model_override,
-                    has_x_grok_client_version,
-                    has_x_grok_req_id,
-                    has_x_grok_agent_id,
-                    missing_wire_headers,
-                    body_rewritten,
-                ),
+            &input.state.app,
+            "info",
+            "CX2CC_GROK_BUILD_WIRE",
+            format!(
+                "[CX2CC] grok Build-wire stickiness source_cli_key={} session={} model={} prompt_cache_key={} conv={} session_hdr={} model_override={} client_version={} req_id={} agent_id={}",
+                cx2cc_source_cli_key.as_deref().unwrap_or(""),
+                sticky.unwrap_or(""),
+                model_id.as_deref().unwrap_or(""),
+                has_prompt_cache_key,
+                has_x_grok_conv_id,
+                has_x_grok_session_id,
+                has_x_grok_model_override,
+                has_x_grok_client_version,
+                has_x_grok_req_id,
+                has_x_grok_agent_id,
+            ),
+        );
+            tracing::info!(
+                trace_id = %input.trace_id,
+                provider_id = prepared.provider_id,
+                source_cli_key = cx2cc_source_cli_key.as_deref().unwrap_or(""),
+                session_id = sticky.unwrap_or(""),
+                model_id = model_id.as_deref().unwrap_or(""),
+                has_prompt_cache_key,
+                has_x_grok_conv_id,
+                has_x_grok_model_override,
+                has_x_grok_client_version,
+                has_x_grok_req_id,
+                "cx2cc→grok Build-wire stickiness asserted before upstream send"
             );
-        }
+        } // end needs_grok_build_wire
     }
 
     let upstream_body = body_state_for_attempt

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/mod.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/mod.rs
@@ -26,6 +26,8 @@ mod codex_chatgpt;
 mod codex_service_tier;
 #[path = "prepare/codex_session_id_completion.rs"]
 mod codex_session_id_completion;
+#[path = "prepare/cx2cc_prefix_freeze.rs"]
+mod cx2cc_prefix_freeze;
 #[path = "prepare/cx2cc_preparation.rs"]
 mod cx2cc_preparation;
 #[path = "prepare/oauth.rs"]

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/codex_session_id_completion.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/codex_session_id_completion.rs
@@ -37,9 +37,15 @@ pub(super) fn is_grok_upstream_model(model: Option<&str>) -> bool {
     model
         .map(|m| {
             let m = m.trim().to_ascii_lowercase();
-            m.starts_with("grok") || m.contains("grok-") || m.contains("grok.")
+            // `grok-4.5`, `grok.4`, or mid-proxy aliases containing `grok-`.
+            m.starts_with("grok") || m.contains("grok-")
         })
         .unwrap_or(false)
+}
+
+/// Whether to inject Build-equivalent `x-grok-*` headers on CX2CC outbound.
+pub(super) fn needs_grok_build_wire(source_cli_key: Option<&str>, model: Option<&str>) -> bool {
+    source_cli_key == Some("grok") || is_grok_upstream_model(model)
 }
 
 /// Whether CX2CC should complete sticky session fields for this source CLI / model.
@@ -48,22 +54,15 @@ fn should_complete_session_identifiers(
     codex_setting_enabled: bool,
     model: Option<&str>,
 ) -> bool {
-    // Grok wire path: always on (cli_key=grok OR mapped model is grok-*).
-    if source_cli_key == "grok" || is_grok_upstream_model(model) {
+    // Grok wire path (cli_key or mapped model): always on.
+    if needs_grok_build_wire(Some(source_cli_key), model) {
         return true;
     }
-    match source_cli_key {
-        "codex" => codex_setting_enabled,
-        _ => false,
-    }
+    source_cli_key == "codex" && codex_setting_enabled
 }
 
-/// Whether to inject Build-equivalent `x-grok-*` headers on CX2CC outbound.
-pub(super) fn needs_grok_build_wire(source_cli_key: Option<&str>, model: Option<&str>) -> bool {
-    source_cli_key == Some("grok") || is_grok_upstream_model(model)
-}
-
-fn model_from_body_bytes(body: &[u8]) -> Option<String> {
+/// Parse Responses/Chat body `model` field from raw JSON bytes.
+pub(super) fn model_from_body_bytes(body: &[u8]) -> Option<String> {
     serde_json::from_slice::<Value>(body).ok().and_then(|v| {
         v.get("model")
             .and_then(|m| m.as_str())
@@ -331,26 +330,15 @@ fn complete_translated_codex_request(
     upstream_body_bytes: &[u8],
 ) -> Option<BridgeCodexSessionCompletion> {
     let mut headers = base_headers.clone();
-    // Prefer model-aware inject so codex-labeled Grok mid-proxies still get x-grok-*.
+    // Model-aware inject covers codex-labeled Grok mid-proxies (x-grok-* via
+    // needs_grok_build_wire). Do not call inject_grok_build_wire_headers again —
+    // that would re-mint x-grok-req-id for no gain.
     inject_session_headers_with_model(
         &mut headers,
         session_id,
         Some(source_cli_key),
         if use_grok_wire { model_id } else { None },
     );
-    // When source_cli_key is codex but model is grok, force grok wire with model.
-    if use_grok_wire {
-        if let Some(sid) = session_id.map(str::trim).filter(|v| !v.is_empty()) {
-            inject_grok_build_wire_headers(
-                &mut headers,
-                GrokBuildWireHeaders {
-                    session_id: sid,
-                    model_id,
-                    turn_idx: None,
-                },
-            );
-        }
-    }
 
     let mut request_body = serde_json::from_slice::<Value>(upstream_body_bytes).ok()?;
     let result = codex_session_id::complete_codex_session_identifiers(

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/codex_session_id_completion.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/codex_session_id_completion.rs
@@ -1,3 +1,10 @@
+//! Usage: CX2CC session / prompt-cache stickiness for Responses-style sources.
+//!
+//! - **codex**: fill `session_id` / `x-session-id` + body `prompt_cache_key`
+//!   (gated by `enable_codex_session_id_completion`).
+//! - **grok**: same body `prompt_cache_key`, plus `x-grok-conv-id` /
+//!   `x-grok-session-id` for xAI sticky routing (always on for CX2CC→Grok).
+
 use super::context::CommonCtx;
 use crate::gateway::codex_session_id::{self, CodexSessionCompletionResult, CodexSessionIdCache};
 use crate::gateway::response_fixer;
@@ -21,6 +28,50 @@ struct BridgeCodexSessionCompletion {
     body_bytes: Option<Vec<u8>>,
 }
 
+/// True when the upstream model is a Grok/xAI model id (e.g. `grok-4.5`).
+///
+/// Users often register OpenAI-compatible Grok mid-proxies as `cli_key=codex`
+/// (provider type Codex). Wire stickiness must still apply when the *mapped*
+/// model is Grok — otherwise Build-equivalent headers never fire.
+pub(super) fn is_grok_upstream_model(model: Option<&str>) -> bool {
+    model
+        .map(|m| {
+            let m = m.trim().to_ascii_lowercase();
+            m.starts_with("grok") || m.contains("grok-") || m.contains("grok.")
+        })
+        .unwrap_or(false)
+}
+
+/// Whether CX2CC should complete sticky session fields for this source CLI / model.
+fn should_complete_session_identifiers(
+    source_cli_key: &str,
+    codex_setting_enabled: bool,
+    model: Option<&str>,
+) -> bool {
+    // Grok wire path: always on (cli_key=grok OR mapped model is grok-*).
+    if source_cli_key == "grok" || is_grok_upstream_model(model) {
+        return true;
+    }
+    match source_cli_key {
+        "codex" => codex_setting_enabled,
+        _ => false,
+    }
+}
+
+/// Whether to inject Build-equivalent `x-grok-*` headers on CX2CC outbound.
+pub(super) fn needs_grok_build_wire(source_cli_key: Option<&str>, model: Option<&str>) -> bool {
+    source_cli_key == Some("grok") || is_grok_upstream_model(model)
+}
+
+fn model_from_body_bytes(body: &[u8]) -> Option<String> {
+    serde_json::from_slice::<Value>(body).ok().and_then(|v| {
+        v.get("model")
+            .and_then(|m| m.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    })
+}
+
 pub(super) fn apply_if_needed<R: tauri::Runtime>(
     input: ApplyCodexSessionIdCompletionInput<'_, R>,
 ) -> Option<String> {
@@ -34,9 +85,12 @@ pub(super) fn apply_if_needed<R: tauri::Runtime>(
         strip_request_content_encoding,
     } = input;
 
-    if !enabled || source_cli_key != "codex" {
+    let model = model_from_body_bytes(upstream_body_bytes.as_ref());
+    if !should_complete_session_identifiers(source_cli_key, enabled, model.as_deref()) {
         return None;
     }
+
+    let use_grok_wire = needs_grok_build_wire(Some(source_cli_key), model.as_deref());
 
     let completion = {
         let mut cache = ctx.state.codex_session_cache.lock_or_recover();
@@ -46,8 +100,17 @@ pub(super) fn apply_if_needed<R: tauri::Runtime>(
             ctx.created_at_ms,
             base_headers,
             session_id,
+            source_cli_key,
+            use_grok_wire,
+            model.as_deref(),
             upstream_body_bytes.as_ref(),
         )
+    };
+
+    let setting_type = if use_grok_wire {
+        "cx2cc_grok_cache_stickiness"
+    } else {
+        "codex_session_id_completion"
     };
 
     match completion {
@@ -60,7 +123,7 @@ pub(super) fn apply_if_needed<R: tauri::Runtime>(
             response_fixer::push_special_setting(
                 ctx.special_settings,
                 serde_json::json!({
-                    "type": "codex_session_id_completion",
+                    "type": setting_type,
                     "scope": "request",
                     "hit": completion.result.applied,
                     "action": completion.result.action,
@@ -79,7 +142,7 @@ pub(super) fn apply_if_needed<R: tauri::Runtime>(
             response_fixer::push_special_setting(
                 ctx.special_settings,
                 serde_json::json!({
-                    "type": "codex_session_id_completion",
+                    "type": setting_type,
                     "scope": "request",
                     "hit": false,
                     "action": "skipped",
@@ -98,7 +161,39 @@ pub(super) fn apply_if_needed<R: tauri::Runtime>(
     }
 }
 
-pub(super) fn inject_session_headers_if_needed(headers: &mut HeaderMap, session_id: Option<&str>) {
+/// Wire identity for CX2CC→Grok, mirroring `xai-org/grok-build`
+/// `GrokRequestHeaders::apply` (xai-grok-sampler client).
+#[derive(Debug, Clone, Copy)]
+pub(super) struct GrokBuildWireHeaders<'a> {
+    pub(super) session_id: &'a str,
+    /// Mapped upstream model (e.g. `grok-4.5`) for `x-grok-model-override`.
+    pub(super) model_id: Option<&'a str>,
+    /// Optional turn index (Build uses prompt index); omit when unknown.
+    pub(super) turn_idx: Option<&'a str>,
+}
+
+/// Inject sticky session headers for CX2CC upstream.
+///
+/// Always fills generic `session_id` / `x-session-id`. For Grok, injects the
+/// Build-equivalent `x-grok-*` suite (see [`inject_grok_build_wire_headers`]).
+pub(super) fn inject_session_headers_if_needed(
+    headers: &mut HeaderMap,
+    session_id: Option<&str>,
+    source_cli_key: Option<&str>,
+) {
+    inject_session_headers_with_model(headers, session_id, source_cli_key, None);
+}
+
+/// Like [`inject_session_headers_if_needed`], but can attach `x-grok-model-override`.
+///
+/// Grok Build wire headers apply when `source_cli_key == "grok"` **or** the
+/// mapped model is a Grok id (common mis-label: mid-proxy registered as Codex).
+pub(super) fn inject_session_headers_with_model(
+    headers: &mut HeaderMap,
+    session_id: Option<&str>,
+    source_cli_key: Option<&str>,
+    model_id: Option<&str>,
+) {
     let Some(session_id) = session_id.map(str::trim).filter(|v| !v.is_empty()) else {
         return;
     };
@@ -114,6 +209,114 @@ pub(super) fn inject_session_headers_if_needed(headers: &mut HeaderMap, session_
             headers.insert("x-session-id", value);
         }
     }
+
+    if needs_grok_build_wire(source_cli_key, model_id) {
+        inject_grok_build_wire_headers(
+            headers,
+            GrokBuildWireHeaders {
+                session_id,
+                model_id,
+                turn_idx: None,
+            },
+        );
+    }
+}
+
+/// Align CX2CC→Grok outbound headers with official grok-build wire format.
+///
+/// Build primarily stickies via **headers** (not body `prompt_cache_key`).
+/// Missing `x-grok-model-override` / client identity is a known gap vs Build
+/// traffic that hits the same API-key mid-proxy with cache hits.
+pub(super) fn inject_grok_build_wire_headers(
+    headers: &mut HeaderMap,
+    wire: GrokBuildWireHeaders<'_>,
+) {
+    let session_id = wire.session_id.trim();
+    if session_id.is_empty() {
+        return;
+    }
+
+    // Stable affinity (session-scoped). Always overwrite so mid-pipeline cannot drop them.
+    if let Ok(value) = HeaderValue::from_str(session_id) {
+        headers.insert("x-grok-conv-id", value.clone());
+        headers.insert("x-grok-session-id", value);
+    }
+
+    // Per-request id (Build: new every sample). Prefer fresh value each inject call.
+    let req_id = new_grok_req_id();
+    if let Ok(value) = HeaderValue::from_str(&req_id) {
+        headers.insert("x-grok-req-id", value);
+    }
+
+    // Model override — Build always sets this for IC routing / proxy gating.
+    if let Some(model) = wire.model_id.map(str::trim).filter(|v| !v.is_empty()) {
+        if let Ok(value) = HeaderValue::from_str(model) {
+            headers.insert("x-grok-model-override", value);
+        }
+    }
+
+    // Client identity — matches OAuth adapter / Build default header set.
+    let client_version = crate::gateway::oauth::adapters::grok::grok_client_version();
+    if let Ok(value) = HeaderValue::from_str(&client_version) {
+        headers.insert("x-grok-client-version", value);
+    }
+
+    // Stable agent surface for CX2CC bridge (Build uses process agent_id).
+    headers.insert(
+        "x-grok-agent-id",
+        HeaderValue::from_static("aio-coding-hub-cx2cc"),
+    );
+
+    if let Some(turn) = wire.turn_idx.map(str::trim).filter(|v| !v.is_empty()) {
+        if let Ok(value) = HeaderValue::from_str(turn) {
+            headers.insert("x-grok-turn-idx", value);
+        }
+    }
+}
+
+fn new_grok_req_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    format!("aio-req-{millis:x}-{n:x}")
+}
+
+/// Ensure Responses body has a stable `prompt_cache_key` for CX2CC→Grok.
+///
+/// Returns true when the body bytes were rewritten.
+pub(super) fn ensure_prompt_cache_key_on_body(body: &mut Bytes, session_id: Option<&str>) -> bool {
+    let Some(session_id) = session_id.map(str::trim).filter(|v| !v.is_empty()) else {
+        return false;
+    };
+    let Ok(mut root) = serde_json::from_slice::<Value>(body.as_ref()) else {
+        return false;
+    };
+    let Some(obj) = root.as_object_mut() else {
+        return false;
+    };
+    let existing = obj
+        .get("prompt_cache_key")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|v| !v.is_empty());
+    if existing == Some(session_id) {
+        return false;
+    }
+    obj.insert(
+        "prompt_cache_key".to_string(),
+        Value::String(session_id.to_string()),
+    );
+    match serde_json::to_vec(&root) {
+        Ok(encoded) => {
+            *body = Bytes::from(encoded);
+            true
+        }
+        Err(_) => false,
+    }
 }
 
 fn complete_translated_codex_request(
@@ -122,10 +325,32 @@ fn complete_translated_codex_request(
     now_unix_ms: i64,
     base_headers: &HeaderMap,
     session_id: Option<&str>,
+    source_cli_key: &str,
+    use_grok_wire: bool,
+    model_id: Option<&str>,
     upstream_body_bytes: &[u8],
 ) -> Option<BridgeCodexSessionCompletion> {
     let mut headers = base_headers.clone();
-    inject_session_headers_if_needed(&mut headers, session_id);
+    // Prefer model-aware inject so codex-labeled Grok mid-proxies still get x-grok-*.
+    inject_session_headers_with_model(
+        &mut headers,
+        session_id,
+        Some(source_cli_key),
+        if use_grok_wire { model_id } else { None },
+    );
+    // When source_cli_key is codex but model is grok, force grok wire with model.
+    if use_grok_wire {
+        if let Some(sid) = session_id.map(str::trim).filter(|v| !v.is_empty()) {
+            inject_grok_build_wire_headers(
+                &mut headers,
+                GrokBuildWireHeaders {
+                    session_id: sid,
+                    model_id,
+                    turn_idx: None,
+                },
+            );
+        }
+    }
 
     let mut request_body = serde_json::from_slice::<Value>(upstream_body_bytes).ok()?;
     let result = codex_session_id::complete_codex_session_identifiers(
@@ -146,12 +371,33 @@ fn complete_translated_codex_request(
 
 #[cfg(test)]
 mod tests {
-    use super::{complete_translated_codex_request, inject_session_headers_if_needed};
+    use super::{
+        complete_translated_codex_request, inject_session_headers_if_needed,
+        inject_session_headers_with_model, needs_grok_build_wire,
+        should_complete_session_identifiers,
+    };
     use crate::gateway::codex_session_id::CodexSessionIdCache;
     use axum::http::HeaderMap;
     use serde_json::json;
 
     const SESSION_ID: &str = "01234567-89ab-cdef-0123-456789abcdef";
+
+    #[test]
+    fn completion_gate_allows_grok_always_and_codex_when_enabled() {
+        assert!(should_complete_session_identifiers("grok", false, None));
+        assert!(should_complete_session_identifiers("grok", true, None));
+        assert!(should_complete_session_identifiers("codex", true, None));
+        assert!(!should_complete_session_identifiers("codex", false, None));
+        assert!(!should_complete_session_identifiers("claude", true, None));
+        // Mid-proxy registered as Codex but mapped model is Grok → still enable.
+        assert!(should_complete_session_identifiers(
+            "codex",
+            false,
+            Some("grok-4.5")
+        ));
+        assert!(needs_grok_build_wire(Some("codex"), Some("grok-4.5")));
+        assert!(!needs_grok_build_wire(Some("codex"), Some("gpt-4.1")));
+    }
 
     #[test]
     fn translated_codex_request_uses_existing_session_id_for_prompt_cache_key() {
@@ -169,6 +415,9 @@ mod tests {
             1_710_000_000_123,
             &HeaderMap::new(),
             Some(SESSION_ID),
+            "codex",
+            false,
+            Some("gpt-4.1"),
             &encoded,
         )
         .expect("completion");
@@ -180,6 +429,117 @@ mod tests {
         let next: serde_json::Value =
             serde_json::from_slice(&completion.body_bytes.expect("body bytes")).expect("json");
         assert_eq!(next["prompt_cache_key"], SESSION_ID);
+    }
+
+    #[test]
+    fn translated_grok_request_sets_prompt_cache_key_for_xai_sticky() {
+        let mut cache = CodexSessionIdCache::default();
+        let body = json!({
+            "model": "grok-4.5",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "stream": true
+        });
+        let encoded = serde_json::to_vec(&body).expect("serialize");
+
+        let completion = complete_translated_codex_request(
+            &mut cache,
+            1_710_000_000,
+            1_710_000_000_123,
+            &HeaderMap::new(),
+            Some(SESSION_ID),
+            "grok",
+            true,
+            Some("grok-4.5"),
+            &encoded,
+        )
+        .expect("completion");
+
+        assert_eq!(completion.result.session_id, SESSION_ID);
+        assert!(completion.result.changed_body);
+
+        let next: serde_json::Value =
+            serde_json::from_slice(&completion.body_bytes.expect("body bytes")).expect("json");
+        assert_eq!(next["prompt_cache_key"], SESSION_ID);
+        assert_eq!(next["model"], "grok-4.5");
+    }
+
+    #[test]
+    fn codex_labeled_midproxy_with_grok_model_gets_build_wire_headers() {
+        let mut headers = HeaderMap::new();
+        inject_session_headers_with_model(
+            &mut headers,
+            Some(SESSION_ID),
+            Some("codex"),
+            Some("grok-4.5"),
+        );
+        assert_eq!(
+            headers.get("x-grok-conv-id").and_then(|v| v.to_str().ok()),
+            Some(SESSION_ID)
+        );
+        assert_eq!(
+            headers
+                .get("x-grok-model-override")
+                .and_then(|v| v.to_str().ok()),
+            Some("grok-4.5")
+        );
+        assert!(headers.get("x-grok-client-version").is_some());
+        assert!(headers.get("x-grok-req-id").is_some());
+    }
+
+    #[test]
+    fn translated_grok_request_reuses_same_prompt_cache_key_across_turns() {
+        let mut cache = CodexSessionIdCache::default();
+        let body_turn1 = json!({
+            "model": "grok-4.5",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "first"}]}],
+            "stream": true
+        });
+        let body_turn2 = json!({
+            "model": "grok-4.5",
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "first"}]},
+                {"role": "assistant", "content": [{"type": "output_text", "text": "ok"}]},
+                {"role": "user", "content": [{"type": "input_text", "text": "second"}]}
+            ],
+            "stream": true
+        });
+        let encoded1 = serde_json::to_vec(&body_turn1).expect("serialize");
+        let encoded2 = serde_json::to_vec(&body_turn2).expect("serialize");
+
+        let first = complete_translated_codex_request(
+            &mut cache,
+            1_710_000_000,
+            1_710_000_000_123,
+            &HeaderMap::new(),
+            Some(SESSION_ID),
+            "grok",
+            true,
+            Some("grok-4.5"),
+            &encoded1,
+        )
+        .expect("first");
+        let second = complete_translated_codex_request(
+            &mut cache,
+            1_710_000_100,
+            1_710_000_100_456,
+            &HeaderMap::new(),
+            Some(SESSION_ID),
+            "grok",
+            true,
+            Some("grok-4.5"),
+            &encoded2,
+        )
+        .expect("second");
+
+        assert_eq!(first.result.session_id, second.result.session_id);
+        assert_eq!(first.result.session_id, SESSION_ID);
+
+        let next1: serde_json::Value =
+            serde_json::from_slice(&first.body_bytes.expect("body1")).expect("json");
+        let next2: serde_json::Value =
+            serde_json::from_slice(&second.body_bytes.expect("body2")).expect("json");
+        assert_eq!(next1["prompt_cache_key"], SESSION_ID);
+        assert_eq!(next2["prompt_cache_key"], SESSION_ID);
     }
 
     #[test]
@@ -198,6 +558,9 @@ mod tests {
             1_710_000_000_123,
             &HeaderMap::new(),
             None,
+            "codex",
+            false,
+            Some("gpt-4.1"),
             &encoded,
         )
         .expect("first completion");
@@ -207,6 +570,9 @@ mod tests {
             1_710_000_100_456,
             &HeaderMap::new(),
             None,
+            "codex",
+            false,
+            Some("gpt-4.1"),
             &encoded,
         )
         .expect("second completion");
@@ -219,7 +585,7 @@ mod tests {
     #[test]
     fn inject_session_headers_adds_both_codex_header_names() {
         let mut headers = HeaderMap::new();
-        inject_session_headers_if_needed(&mut headers, Some(SESSION_ID));
+        inject_session_headers_if_needed(&mut headers, Some(SESSION_ID), Some("codex"));
 
         assert_eq!(
             headers
@@ -234,6 +600,122 @@ mod tests {
                 .and_then(|v| v.to_str().ok())
                 .unwrap_or(""),
             SESSION_ID
+        );
+        assert!(headers.get("x-grok-conv-id").is_none());
+        assert!(headers.get("x-grok-session-id").is_none());
+    }
+
+    #[test]
+    fn inject_session_headers_for_grok_adds_xai_sticky_headers() {
+        let mut headers = HeaderMap::new();
+        inject_session_headers_if_needed(&mut headers, Some(SESSION_ID), Some("grok"));
+
+        assert_eq!(
+            headers
+                .get("x-grok-conv-id")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or(""),
+            SESSION_ID
+        );
+        assert_eq!(
+            headers
+                .get("x-grok-session-id")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or(""),
+            SESSION_ID
+        );
+        assert_eq!(
+            headers
+                .get("session_id")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or(""),
+            SESSION_ID
+        );
+        // Build wire suite (even without model_id yet).
+        assert!(headers.get("x-grok-req-id").is_some());
+        assert!(headers.get("x-grok-client-version").is_some());
+        assert_eq!(
+            headers.get("x-grok-agent-id").and_then(|v| v.to_str().ok()),
+            Some("aio-coding-hub-cx2cc")
+        );
+    }
+
+    #[test]
+    fn inject_grok_build_wire_headers_sets_model_override_and_fresh_req_id() {
+        use super::{inject_grok_build_wire_headers, GrokBuildWireHeaders};
+
+        let mut headers = HeaderMap::new();
+        inject_grok_build_wire_headers(
+            &mut headers,
+            GrokBuildWireHeaders {
+                session_id: SESSION_ID,
+                model_id: Some("grok-4.5"),
+                turn_idx: Some("3"),
+            },
+        );
+        assert_eq!(
+            headers
+                .get("x-grok-model-override")
+                .and_then(|v| v.to_str().ok()),
+            Some("grok-4.5")
+        );
+        assert_eq!(
+            headers.get("x-grok-turn-idx").and_then(|v| v.to_str().ok()),
+            Some("3")
+        );
+        let req1 = headers
+            .get("x-grok-req-id")
+            .and_then(|v| v.to_str().ok())
+            .unwrap()
+            .to_string();
+        inject_grok_build_wire_headers(
+            &mut headers,
+            GrokBuildWireHeaders {
+                session_id: SESSION_ID,
+                model_id: Some("grok-4.5"),
+                turn_idx: None,
+            },
+        );
+        let req2 = headers
+            .get("x-grok-req-id")
+            .and_then(|v| v.to_str().ok())
+            .unwrap()
+            .to_string();
+        assert_ne!(req1, req2, "req-id must be per-request like grok-build");
+    }
+
+    #[test]
+    fn ensure_prompt_cache_key_rewrites_missing_or_mismatched_key() {
+        use super::ensure_prompt_cache_key_on_body;
+        use axum::body::Bytes;
+
+        let mut body = Bytes::from(
+            serde_json::to_vec(&json!({
+                "model": "grok-4.5",
+                "input": [],
+                "stream": true
+            }))
+            .unwrap(),
+        );
+        assert!(ensure_prompt_cache_key_on_body(&mut body, Some(SESSION_ID)));
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed["prompt_cache_key"], SESSION_ID);
+
+        // Same key → no rewrite
+        assert!(!ensure_prompt_cache_key_on_body(
+            &mut body,
+            Some(SESSION_ID)
+        ));
+
+        // Different key → rewrite
+        assert!(ensure_prompt_cache_key_on_body(
+            &mut body,
+            Some("abcdef01-2345-6789-abcd-ef0123456789")
+        ));
+        let parsed2: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            parsed2["prompt_cache_key"],
+            "abcdef01-2345-6789-abcd-ef0123456789"
         );
     }
 }

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/codex_session_id_completion.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/codex_session_id_completion.rs
@@ -37,15 +37,9 @@ pub(super) fn is_grok_upstream_model(model: Option<&str>) -> bool {
     model
         .map(|m| {
             let m = m.trim().to_ascii_lowercase();
-            // `grok-4.5`, `grok.4`, or mid-proxy aliases containing `grok-`.
-            m.starts_with("grok") || m.contains("grok-")
+            m.starts_with("grok") || m.contains("grok-") || m.contains("grok.")
         })
         .unwrap_or(false)
-}
-
-/// Whether to inject Build-equivalent `x-grok-*` headers on CX2CC outbound.
-pub(super) fn needs_grok_build_wire(source_cli_key: Option<&str>, model: Option<&str>) -> bool {
-    source_cli_key == Some("grok") || is_grok_upstream_model(model)
 }
 
 /// Whether CX2CC should complete sticky session fields for this source CLI / model.
@@ -54,15 +48,22 @@ fn should_complete_session_identifiers(
     codex_setting_enabled: bool,
     model: Option<&str>,
 ) -> bool {
-    // Grok wire path (cli_key or mapped model): always on.
-    if needs_grok_build_wire(Some(source_cli_key), model) {
+    // Grok wire path: always on (cli_key=grok OR mapped model is grok-*).
+    if source_cli_key == "grok" || is_grok_upstream_model(model) {
         return true;
     }
-    source_cli_key == "codex" && codex_setting_enabled
+    match source_cli_key {
+        "codex" => codex_setting_enabled,
+        _ => false,
+    }
 }
 
-/// Parse Responses/Chat body `model` field from raw JSON bytes.
-pub(super) fn model_from_body_bytes(body: &[u8]) -> Option<String> {
+/// Whether to inject Build-equivalent `x-grok-*` headers on CX2CC outbound.
+pub(super) fn needs_grok_build_wire(source_cli_key: Option<&str>, model: Option<&str>) -> bool {
+    source_cli_key == Some("grok") || is_grok_upstream_model(model)
+}
+
+fn model_from_body_bytes(body: &[u8]) -> Option<String> {
     serde_json::from_slice::<Value>(body).ok().and_then(|v| {
         v.get("model")
             .and_then(|m| m.as_str())
@@ -330,15 +331,26 @@ fn complete_translated_codex_request(
     upstream_body_bytes: &[u8],
 ) -> Option<BridgeCodexSessionCompletion> {
     let mut headers = base_headers.clone();
-    // Model-aware inject covers codex-labeled Grok mid-proxies (x-grok-* via
-    // needs_grok_build_wire). Do not call inject_grok_build_wire_headers again —
-    // that would re-mint x-grok-req-id for no gain.
+    // Prefer model-aware inject so codex-labeled Grok mid-proxies still get x-grok-*.
     inject_session_headers_with_model(
         &mut headers,
         session_id,
         Some(source_cli_key),
         if use_grok_wire { model_id } else { None },
     );
+    // When source_cli_key is codex but model is grok, force grok wire with model.
+    if use_grok_wire {
+        if let Some(sid) = session_id.map(str::trim).filter(|v| !v.is_empty()) {
+            inject_grok_build_wire_headers(
+                &mut headers,
+                GrokBuildWireHeaders {
+                    session_id: sid,
+                    model_id,
+                    turn_idx: None,
+                },
+            );
+        }
+    }
 
     let mut request_body = serde_json::from_slice::<Value>(upstream_body_bytes).ok()?;
     let result = codex_session_id::complete_codex_session_identifiers(

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/codex_session_id_completion.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/codex_session_id_completion.rs
@@ -319,6 +319,7 @@ pub(super) fn ensure_prompt_cache_key_on_body(body: &mut Bytes, session_id: Opti
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn complete_translated_codex_request(
     cache: &mut CodexSessionIdCache,
     now_unix: i64,

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/cx2cc_prefix_freeze.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/cx2cc_prefix_freeze.rs
@@ -1,0 +1,499 @@
+//! Usage: Session-scoped freeze of CX2CC→Grok Responses body prefix fields.
+//!
+//! xAI prompt cache requires a stable byte-level prefix across turns. Claude
+//! Code + CX2CC re-translates Anthropic payloads every request, so tools /
+//! instructions / early input items can drift. For Grok-mapped models we pin
+//! the first-seen prefix per (session, model) and reuse it when the new
+//! request still starts with that prefix (append-only growth).
+//!
+//! Phase 1: instructions / tools / append-only input.
+//! Phase 1.5: also pin top-level control fields that can churn every Claude
+//! turn (`tool_choice`, `parallel_tool_calls`, `reasoning`, `text`, `include`,
+//! `max_output_tokens`) plus short digests for log/DB diagnosis.
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+const MAX_ENTRIES: usize = 2000;
+const DEFAULT_TTL_SECS: i64 = 6 * 3600; // 6h idle sessions
+
+/// Top-level Responses fields pinned after first seed (session, model).
+/// Order is stable for report emission only; freeze is per-key.
+const EXTRA_PIN_KEYS: &[&str] = &[
+    "tool_choice",
+    "parallel_tool_calls",
+    "reasoning",
+    "text",
+    "include",
+    "max_output_tokens",
+];
+
+#[derive(Debug, Clone)]
+struct PrefixEntry {
+    instructions: Option<String>,
+    tools: Option<Value>,
+    /// Full input array from the last accepted turn (grows append-only when prefix matches).
+    input_prefix: Option<Vec<Value>>,
+    /// First-seen values for EXTRA_PIN_KEYS.
+    extras: HashMap<String, Value>,
+    expires_at_unix: i64,
+}
+
+#[derive(Debug, Default)]
+struct PrefixFreezeCache {
+    entries: HashMap<String, PrefixEntry>,
+}
+
+fn cache() -> &'static Mutex<PrefixFreezeCache> {
+    static CACHE: OnceLock<Mutex<PrefixFreezeCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(PrefixFreezeCache::default()))
+}
+
+fn now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn cache_key(session_id: &str, model: &str) -> String {
+    format!(
+        "{}|{}",
+        session_id.trim(),
+        model.trim().to_ascii_lowercase()
+    )
+}
+
+fn short_sha16(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().take(8).map(|b| format!("{b:02x}")).collect()
+}
+
+fn value_sha16(value: Option<&Value>) -> String {
+    match value {
+        None => "absent".to_string(),
+        Some(v) => match serde_json::to_vec(v) {
+            Ok(bytes) => short_sha16(&bytes),
+            Err(_) => "err".to_string(),
+        },
+    }
+}
+
+fn str_sha16(s: Option<&str>) -> String {
+    match s {
+        None => "absent".to_string(),
+        Some(v) => short_sha16(v.as_bytes()),
+    }
+}
+
+/// Result of applying prefix freeze to a Responses body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PrefixFreezeReport {
+    pub applied: bool,
+    pub session_id: String,
+    pub model: String,
+    pub instructions: &'static str,
+    pub tools: &'static str,
+    pub input: &'static str,
+    /// Compact "key=action,..." for EXTRA_PIN_KEYS.
+    pub extras: String,
+    pub instructions_sha16: String,
+    pub tools_sha16: String,
+    pub input_len: usize,
+    pub input_prefix_len: usize,
+    pub max_output_tokens: Option<String>,
+    pub tool_choice_sha16: String,
+    pub reasoning_sha16: String,
+}
+
+impl PrefixFreezeReport {
+    pub fn skipped(reason: &'static str) -> Self {
+        Self {
+            applied: false,
+            session_id: String::new(),
+            model: String::new(),
+            instructions: reason,
+            tools: reason,
+            input: reason,
+            extras: reason.to_string(),
+            instructions_sha16: String::new(),
+            tools_sha16: String::new(),
+            input_len: 0,
+            input_prefix_len: 0,
+            max_output_tokens: None,
+            tool_choice_sha16: String::new(),
+            reasoning_sha16: String::new(),
+        }
+    }
+
+    /// Compact one-line summary for gateway logs.
+    pub fn log_line(&self) -> String {
+        format!(
+            "session={} model={} instructions={} tools={} input={} extras=[{}] instr_sha={} tools_sha={} input_len={} prefix_len={} max_out={} tool_choice_sha={} reasoning_sha={}",
+            self.session_id,
+            self.model,
+            self.instructions,
+            self.tools,
+            self.input,
+            self.extras,
+            self.instructions_sha16,
+            self.tools_sha16,
+            self.input_len,
+            self.input_prefix_len,
+            self.max_output_tokens.as_deref().unwrap_or("-"),
+            self.tool_choice_sha16,
+            self.reasoning_sha16,
+        )
+    }
+}
+
+/// Apply freeze when `model` is a Grok id and `session_id` is non-empty.
+pub(super) fn apply_grok_prefix_freeze(
+    body: &mut Value,
+    session_id: Option<&str>,
+    model: Option<&str>,
+) -> PrefixFreezeReport {
+    let Some(model) = model.map(str::trim).filter(|m| !m.is_empty()) else {
+        return PrefixFreezeReport::skipped("missing_model");
+    };
+    if !super::codex_session_id_completion::is_grok_upstream_model(Some(model)) {
+        return PrefixFreezeReport::skipped("not_grok_model");
+    }
+    let Some(session_id) = session_id.map(str::trim).filter(|s| !s.is_empty()) else {
+        return PrefixFreezeReport::skipped("missing_session");
+    };
+    let Some(obj) = body.as_object_mut() else {
+        return PrefixFreezeReport::skipped("body_not_object");
+    };
+
+    let key = cache_key(session_id, model);
+    let now = now_unix();
+    let (instructions_action, tools_action, input_action, extras_actions, input_prefix_len) = {
+        let mut guard = match cache().lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        purge_expired(&mut guard, now);
+
+        let (instructions_action, tools_action, input_action, extras_actions, input_prefix_len) = {
+            let entry = guard.entries.entry(key).or_insert_with(|| PrefixEntry {
+                instructions: None,
+                tools: None,
+                input_prefix: None,
+                extras: HashMap::new(),
+                expires_at_unix: now + DEFAULT_TTL_SECS,
+            });
+            entry.expires_at_unix = now + DEFAULT_TTL_SECS;
+
+            let instructions_action = freeze_instructions(entry, obj);
+            let tools_action = freeze_tools(entry, obj);
+            let input_action = freeze_input(entry, obj);
+            let extras_actions = freeze_extras(entry, obj);
+            let input_prefix_len = entry.input_prefix.as_ref().map(|a| a.len()).unwrap_or(0);
+            (
+                instructions_action,
+                tools_action,
+                input_action,
+                extras_actions,
+                input_prefix_len,
+            )
+        };
+
+        if guard.entries.len() > MAX_ENTRIES {
+            evict_oldest(&mut guard, now);
+        }
+
+        (
+            instructions_action,
+            tools_action,
+            input_action,
+            extras_actions,
+            input_prefix_len,
+        )
+    };
+
+    let input_len = obj
+        .get("input")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+
+    let max_output_tokens = obj.get("max_output_tokens").map(|v| match v {
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    });
+
+    PrefixFreezeReport {
+        applied: true,
+        session_id: session_id.to_string(),
+        model: model.to_string(),
+        instructions: instructions_action,
+        tools: tools_action,
+        input: input_action,
+        extras: extras_actions,
+        instructions_sha16: str_sha16(obj.get("instructions").and_then(|v| v.as_str())),
+        tools_sha16: value_sha16(obj.get("tools")),
+        input_len,
+        input_prefix_len,
+        max_output_tokens,
+        tool_choice_sha16: value_sha16(obj.get("tool_choice")),
+        reasoning_sha16: value_sha16(obj.get("reasoning")),
+    }
+}
+
+fn freeze_instructions(
+    entry: &mut PrefixEntry,
+    obj: &mut serde_json::Map<String, Value>,
+) -> &'static str {
+    let current = obj
+        .get("instructions")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    match (&entry.instructions, current) {
+        (Some(frozen), Some(cur)) if frozen == &cur => "reuse_exact",
+        (Some(frozen), Some(_)) | (Some(frozen), None) => {
+            obj.insert("instructions".to_string(), Value::String(frozen.clone()));
+            "reuse_forced"
+        }
+        (None, Some(cur)) => {
+            entry.instructions = Some(cur);
+            "seed"
+        }
+        (None, None) => "absent",
+    }
+}
+
+fn freeze_tools(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value>) -> &'static str {
+    let current = obj.get("tools").cloned();
+
+    match (&entry.tools, current) {
+        (Some(frozen), Some(cur)) if frozen == &cur => "reuse_exact",
+        (Some(frozen), Some(_)) | (Some(frozen), None) => {
+            obj.insert("tools".to_string(), frozen.clone());
+            "reuse_forced"
+        }
+        (None, Some(cur)) => {
+            entry.tools = Some(cur);
+            "seed"
+        }
+        (None, None) => "absent",
+    }
+}
+
+fn freeze_input(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value>) -> &'static str {
+    let Some(current_val) = obj.get_mut("input") else {
+        return "absent";
+    };
+    let Some(current) = current_val.as_array_mut() else {
+        return "not_array";
+    };
+
+    let Some(frozen) = entry.input_prefix.clone() else {
+        entry.input_prefix = Some(current.clone());
+        return "seed";
+    };
+
+    let frozen_len = frozen.len();
+    if current.len() >= frozen_len && current.as_slice()[..frozen_len] == frozen[..] {
+        // Stable prefix: rewrite head from freeze, keep new tail, then grow freeze.
+        let tail: Vec<Value> = current[frozen_len..].to_vec();
+        let mut merged = frozen;
+        let prefix_len = merged.len();
+        merged.extend(tail);
+        *current = merged.clone();
+        entry.input_prefix = Some(merged);
+        if current.len() == prefix_len {
+            "reuse_exact"
+        } else {
+            "reuse_extend"
+        }
+    } else if current.as_slice() == frozen.as_slice() {
+        "reuse_exact"
+    } else {
+        // History diverged (edit / compact / retranslate drift) — reseed.
+        entry.input_prefix = Some(current.clone());
+        "bust_reseed"
+    }
+}
+
+/// Pin first-seen top-level control fields so Claude thinking budget / tool_choice
+/// churn does not invalidate the xAI prefix.
+fn freeze_extras(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value>) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(EXTRA_PIN_KEYS.len());
+    for key in EXTRA_PIN_KEYS {
+        let action = freeze_extra_field(entry, obj, key);
+        parts.push(format!("{key}={action}"));
+    }
+    parts.join(",")
+}
+
+fn freeze_extra_field(
+    entry: &mut PrefixEntry,
+    obj: &mut serde_json::Map<String, Value>,
+    key: &str,
+) -> &'static str {
+    let current = obj.get(key).cloned();
+    match (entry.extras.get(key), current) {
+        (Some(frozen), Some(cur)) if frozen == &cur => "reuse_exact",
+        (Some(frozen), Some(_)) | (Some(frozen), None) => {
+            obj.insert(key.to_string(), frozen.clone());
+            "reuse_forced"
+        }
+        (None, Some(cur)) => {
+            entry.extras.insert(key.to_string(), cur);
+            "seed"
+        }
+        (None, None) => "absent",
+    }
+}
+
+fn purge_expired(cache: &mut PrefixFreezeCache, now: i64) {
+    cache.entries.retain(|_, e| e.expires_at_unix > now);
+}
+
+fn evict_oldest(cache: &mut PrefixFreezeCache, now: i64) {
+    // Drop expired first, then drop arbitrary until under cap.
+    purge_expired(cache, now);
+    while cache.entries.len() > MAX_ENTRIES {
+        if let Some(k) = cache.entries.keys().next().cloned() {
+            cache.entries.remove(&k);
+        } else {
+            break;
+        }
+    }
+}
+
+/// Test helper: clear process cache.
+#[cfg(test)]
+pub(super) fn clear_for_tests() {
+    if let Ok(mut g) = cache().lock() {
+        g.entries.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn freezes_instructions_and_tools_on_second_turn() {
+        clear_for_tests();
+        let session = "sess-prefix-001-aaaaaaaa";
+        let model = "grok-4.5";
+
+        let mut turn1 = json!({
+            "model": model,
+            "instructions": "SYS_V1",
+            "tools": [{"type":"function","name":"Read","parameters":{"type":"object"}}],
+            "input": [{"role":"user","content":[{"type":"input_text","text":"hi"}]}],
+            "stream": true,
+            "max_output_tokens": 1024,
+            "tool_choice": "auto",
+            "reasoning": {"effort": "low"}
+        });
+        let r1 = apply_grok_prefix_freeze(&mut turn1, Some(session), Some(model));
+        assert!(r1.applied);
+        assert_eq!(r1.instructions, "seed");
+        assert_eq!(r1.tools, "seed");
+        assert_eq!(r1.input, "seed");
+        assert!(r1.extras.contains("max_output_tokens=seed"));
+        assert!(r1.extras.contains("tool_choice=seed"));
+        assert!(r1.extras.contains("reasoning=seed"));
+        assert_ne!(r1.instructions_sha16, "absent");
+        assert_eq!(r1.input_len, 1);
+        assert_eq!(r1.input_prefix_len, 1);
+
+        let mut turn2 = json!({
+            "model": model,
+            "instructions": "SYS_V2_DRIFT",
+            "tools": [{"type":"function","name":"Read","parameters":{"type":"object","extra":true}}],
+            "input": [
+                {"role":"user","content":[{"type":"input_text","text":"hi"}]},
+                {"role":"assistant","content":[{"type":"output_text","text":"yo"}]},
+                {"role":"user","content":[{"type":"input_text","text":"next"}]}
+            ],
+            "stream": true,
+            "max_output_tokens": 8192,
+            "tool_choice": {"type":"function","name":"Read"},
+            "reasoning": {"effort": "high"}
+        });
+        let r2 = apply_grok_prefix_freeze(&mut turn2, Some(session), Some(model));
+        assert_eq!(r2.instructions, "reuse_forced");
+        assert_eq!(r2.tools, "reuse_forced");
+        assert_eq!(r2.input, "reuse_extend");
+        assert!(r2.extras.contains("max_output_tokens=reuse_forced"));
+        assert!(r2.extras.contains("tool_choice=reuse_forced"));
+        assert!(r2.extras.contains("reasoning=reuse_forced"));
+        assert_eq!(turn2["instructions"], "SYS_V1");
+        assert_eq!(
+            turn2["tools"],
+            json!([{"type":"function","name":"Read","parameters":{"type":"object"}}])
+        );
+        assert_eq!(turn2["max_output_tokens"], 1024);
+        assert_eq!(turn2["tool_choice"], "auto");
+        assert_eq!(turn2["reasoning"], json!({"effort": "low"}));
+        // Prefix item must match frozen turn1 first message
+        assert_eq!(
+            turn2["input"][0],
+            json!({"role":"user","content":[{"type":"input_text","text":"hi"}]})
+        );
+        assert_eq!(turn2["input"].as_array().unwrap().len(), 3);
+        assert_eq!(r2.input_len, 3);
+        assert_eq!(r2.input_prefix_len, 3);
+        // Digests should match post-freeze stable content across turns for instructions/tools
+        assert_eq!(r1.instructions_sha16, r2.instructions_sha16);
+        assert_eq!(r1.tools_sha16, r2.tools_sha16);
+    }
+
+    #[test]
+    fn skips_non_grok_models() {
+        clear_for_tests();
+        let mut body = json!({"model":"gpt-4.1","instructions":"x","input":[]});
+        let r = apply_grok_prefix_freeze(&mut body, Some("sess"), Some("gpt-4.1"));
+        assert!(!r.applied);
+        assert_eq!(r.instructions, "not_grok_model");
+    }
+
+    #[test]
+    fn input_bust_reseeds_when_history_diverges() {
+        clear_for_tests();
+        let session = "sess-bust-001-bbbbbbbb";
+        let model = "grok-4.5";
+        let mut t1 = json!({
+            "model": model,
+            "input": [{"role":"user","content":[{"type":"input_text","text":"a"}]}]
+        });
+        apply_grok_prefix_freeze(&mut t1, Some(session), Some(model));
+
+        let mut t2 = json!({
+            "model": model,
+            "input": [{"role":"user","content":[{"type":"input_text","text":"DIFFERENT"}]}]
+        });
+        let r = apply_grok_prefix_freeze(&mut t2, Some(session), Some(model));
+        assert_eq!(r.input, "bust_reseed");
+        assert_eq!(t2["input"][0]["content"][0]["text"], "DIFFERENT");
+    }
+
+    #[test]
+    fn extras_absent_when_fields_missing() {
+        clear_for_tests();
+        let session = "sess-extras-absent-cccc";
+        let model = "grok-4.5";
+        let mut body = json!({
+            "model": model,
+            "instructions": "sys",
+            "input": []
+        });
+        let r = apply_grok_prefix_freeze(&mut body, Some(session), Some(model));
+        assert!(r.applied);
+        assert!(r.extras.contains("max_output_tokens=absent"));
+        assert!(r.extras.contains("tool_choice=absent"));
+        assert_eq!(r.max_output_tokens, None);
+        assert_eq!(r.tool_choice_sha16, "absent");
+    }
+}

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/cx2cc_prefix_freeze.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/cx2cc_prefix_freeze.rs
@@ -32,12 +32,10 @@ const EXTRA_PIN_KEYS: &[&str] = &[
 
 #[derive(Debug, Clone)]
 struct PrefixEntry {
-    instructions: Option<String>,
-    tools: Option<Value>,
+    /// Pinned top-level JSON fields (`instructions`, `tools`, EXTRA_PIN_KEYS).
+    fields: HashMap<String, Value>,
     /// Full input array from the last accepted turn (grows append-only when prefix matches).
     input_prefix: Option<Vec<Value>>,
-    /// First-seen values for EXTRA_PIN_KEYS.
-    extras: HashMap<String, Value>,
     expires_at_unix: i64,
 }
 
@@ -177,20 +175,18 @@ pub(super) fn apply_grok_prefix_freeze(
         };
         purge_expired(&mut guard, now);
 
-        let (instructions_action, tools_action, input_action, extras_actions, input_prefix_len) = {
+        let actions = {
             let entry = guard.entries.entry(key).or_insert_with(|| PrefixEntry {
-                instructions: None,
-                tools: None,
+                fields: HashMap::new(),
                 input_prefix: None,
-                extras: HashMap::new(),
                 expires_at_unix: now + DEFAULT_TTL_SECS,
             });
             entry.expires_at_unix = now + DEFAULT_TTL_SECS;
 
-            let instructions_action = freeze_instructions(entry, obj);
-            let tools_action = freeze_tools(entry, obj);
+            let instructions_action = freeze_json_field(&mut entry.fields, obj, "instructions");
+            let tools_action = freeze_json_field(&mut entry.fields, obj, "tools");
             let input_action = freeze_input(entry, obj);
-            let extras_actions = freeze_extras(entry, obj);
+            let extras_actions = freeze_extra_keys(entry, obj);
             let input_prefix_len = entry.input_prefix.as_ref().map(|a| a.len()).unwrap_or(0);
             (
                 instructions_action,
@@ -205,13 +201,7 @@ pub(super) fn apply_grok_prefix_freeze(
             evict_oldest(&mut guard, now);
         }
 
-        (
-            instructions_action,
-            tools_action,
-            input_action,
-            extras_actions,
-            input_prefix_len,
-        )
+        actions
     };
 
     let input_len = obj
@@ -244,40 +234,21 @@ pub(super) fn apply_grok_prefix_freeze(
     }
 }
 
-fn freeze_instructions(
-    entry: &mut PrefixEntry,
+/// Pin first-seen JSON value for a top-level body key (seed / reuse_exact / reuse_forced).
+fn freeze_json_field(
+    stored: &mut HashMap<String, Value>,
     obj: &mut serde_json::Map<String, Value>,
+    key: &str,
 ) -> &'static str {
-    let current = obj
-        .get("instructions")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
-
-    match (&entry.instructions, current) {
+    let current = obj.get(key).cloned();
+    match (stored.get(key), current) {
         (Some(frozen), Some(cur)) if frozen == &cur => "reuse_exact",
         (Some(frozen), Some(_)) | (Some(frozen), None) => {
-            obj.insert("instructions".to_string(), Value::String(frozen.clone()));
+            obj.insert(key.to_string(), frozen.clone());
             "reuse_forced"
         }
         (None, Some(cur)) => {
-            entry.instructions = Some(cur);
-            "seed"
-        }
-        (None, None) => "absent",
-    }
-}
-
-fn freeze_tools(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value>) -> &'static str {
-    let current = obj.get("tools").cloned();
-
-    match (&entry.tools, current) {
-        (Some(frozen), Some(cur)) if frozen == &cur => "reuse_exact",
-        (Some(frozen), Some(_)) | (Some(frozen), None) => {
-            obj.insert("tools".to_string(), frozen.clone());
-            "reuse_forced"
-        }
-        (None, Some(cur)) => {
-            entry.tools = Some(cur);
+            stored.insert(key.to_string(), cur);
             "seed"
         }
         (None, None) => "absent",
@@ -320,35 +291,15 @@ fn freeze_input(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value
     }
 }
 
-/// Pin first-seen top-level control fields so Claude thinking budget / tool_choice
-/// churn does not invalidate the xAI prefix.
-fn freeze_extras(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value>) -> String {
+/// Pin first-seen control fields so Claude thinking budget / tool_choice churn
+/// does not invalidate the xAI prefix.
+fn freeze_extra_keys(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value>) -> String {
     let mut parts: Vec<String> = Vec::with_capacity(EXTRA_PIN_KEYS.len());
     for key in EXTRA_PIN_KEYS {
-        let action = freeze_extra_field(entry, obj, key);
+        let action = freeze_json_field(&mut entry.fields, obj, key);
         parts.push(format!("{key}={action}"));
     }
     parts.join(",")
-}
-
-fn freeze_extra_field(
-    entry: &mut PrefixEntry,
-    obj: &mut serde_json::Map<String, Value>,
-    key: &str,
-) -> &'static str {
-    let current = obj.get(key).cloned();
-    match (entry.extras.get(key), current) {
-        (Some(frozen), Some(cur)) if frozen == &cur => "reuse_exact",
-        (Some(frozen), Some(_)) | (Some(frozen), None) => {
-            obj.insert(key.to_string(), frozen.clone());
-            "reuse_forced"
-        }
-        (None, Some(cur)) => {
-            entry.extras.insert(key.to_string(), cur);
-            "seed"
-        }
-        (None, None) => "absent",
-    }
 }
 
 fn purge_expired(cache: &mut PrefixFreezeCache, now: i64) {

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/cx2cc_prefix_freeze.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/cx2cc_prefix_freeze.rs
@@ -32,10 +32,12 @@ const EXTRA_PIN_KEYS: &[&str] = &[
 
 #[derive(Debug, Clone)]
 struct PrefixEntry {
-    /// Pinned top-level JSON fields (`instructions`, `tools`, EXTRA_PIN_KEYS).
-    fields: HashMap<String, Value>,
+    instructions: Option<String>,
+    tools: Option<Value>,
     /// Full input array from the last accepted turn (grows append-only when prefix matches).
     input_prefix: Option<Vec<Value>>,
+    /// First-seen values for EXTRA_PIN_KEYS.
+    extras: HashMap<String, Value>,
     expires_at_unix: i64,
 }
 
@@ -175,18 +177,20 @@ pub(super) fn apply_grok_prefix_freeze(
         };
         purge_expired(&mut guard, now);
 
-        let actions = {
+        let (instructions_action, tools_action, input_action, extras_actions, input_prefix_len) = {
             let entry = guard.entries.entry(key).or_insert_with(|| PrefixEntry {
-                fields: HashMap::new(),
+                instructions: None,
+                tools: None,
                 input_prefix: None,
+                extras: HashMap::new(),
                 expires_at_unix: now + DEFAULT_TTL_SECS,
             });
             entry.expires_at_unix = now + DEFAULT_TTL_SECS;
 
-            let instructions_action = freeze_json_field(&mut entry.fields, obj, "instructions");
-            let tools_action = freeze_json_field(&mut entry.fields, obj, "tools");
+            let instructions_action = freeze_instructions(entry, obj);
+            let tools_action = freeze_tools(entry, obj);
             let input_action = freeze_input(entry, obj);
-            let extras_actions = freeze_extra_keys(entry, obj);
+            let extras_actions = freeze_extras(entry, obj);
             let input_prefix_len = entry.input_prefix.as_ref().map(|a| a.len()).unwrap_or(0);
             (
                 instructions_action,
@@ -201,7 +205,13 @@ pub(super) fn apply_grok_prefix_freeze(
             evict_oldest(&mut guard, now);
         }
 
-        actions
+        (
+            instructions_action,
+            tools_action,
+            input_action,
+            extras_actions,
+            input_prefix_len,
+        )
     };
 
     let input_len = obj
@@ -234,21 +244,40 @@ pub(super) fn apply_grok_prefix_freeze(
     }
 }
 
-/// Pin first-seen JSON value for a top-level body key (seed / reuse_exact / reuse_forced).
-fn freeze_json_field(
-    stored: &mut HashMap<String, Value>,
+fn freeze_instructions(
+    entry: &mut PrefixEntry,
     obj: &mut serde_json::Map<String, Value>,
-    key: &str,
 ) -> &'static str {
-    let current = obj.get(key).cloned();
-    match (stored.get(key), current) {
+    let current = obj
+        .get("instructions")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    match (&entry.instructions, current) {
         (Some(frozen), Some(cur)) if frozen == &cur => "reuse_exact",
         (Some(frozen), Some(_)) | (Some(frozen), None) => {
-            obj.insert(key.to_string(), frozen.clone());
+            obj.insert("instructions".to_string(), Value::String(frozen.clone()));
             "reuse_forced"
         }
         (None, Some(cur)) => {
-            stored.insert(key.to_string(), cur);
+            entry.instructions = Some(cur);
+            "seed"
+        }
+        (None, None) => "absent",
+    }
+}
+
+fn freeze_tools(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value>) -> &'static str {
+    let current = obj.get("tools").cloned();
+
+    match (&entry.tools, current) {
+        (Some(frozen), Some(cur)) if frozen == &cur => "reuse_exact",
+        (Some(frozen), Some(_)) | (Some(frozen), None) => {
+            obj.insert("tools".to_string(), frozen.clone());
+            "reuse_forced"
+        }
+        (None, Some(cur)) => {
+            entry.tools = Some(cur);
             "seed"
         }
         (None, None) => "absent",
@@ -291,15 +320,35 @@ fn freeze_input(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value
     }
 }
 
-/// Pin first-seen control fields so Claude thinking budget / tool_choice churn
-/// does not invalidate the xAI prefix.
-fn freeze_extra_keys(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value>) -> String {
+/// Pin first-seen top-level control fields so Claude thinking budget / tool_choice
+/// churn does not invalidate the xAI prefix.
+fn freeze_extras(entry: &mut PrefixEntry, obj: &mut serde_json::Map<String, Value>) -> String {
     let mut parts: Vec<String> = Vec::with_capacity(EXTRA_PIN_KEYS.len());
     for key in EXTRA_PIN_KEYS {
-        let action = freeze_json_field(&mut entry.fields, obj, key);
+        let action = freeze_extra_field(entry, obj, key);
         parts.push(format!("{key}={action}"));
     }
     parts.join(",")
+}
+
+fn freeze_extra_field(
+    entry: &mut PrefixEntry,
+    obj: &mut serde_json::Map<String, Value>,
+    key: &str,
+) -> &'static str {
+    let current = obj.get(key).cloned();
+    match (entry.extras.get(key), current) {
+        (Some(frozen), Some(cur)) if frozen == &cur => "reuse_exact",
+        (Some(frozen), Some(_)) | (Some(frozen), None) => {
+            obj.insert(key.to_string(), frozen.clone());
+            "reuse_forced"
+        }
+        (None, Some(cur)) => {
+            entry.extras.insert(key.to_string(), cur);
+            "seed"
+        }
+        (None, None) => "absent",
+    }
 }
 
 fn purge_expired(cache: &mut PrefixFreezeCache, now: i64) {

--- a/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/cx2cc_preparation.rs
+++ b/src-tauri/src/gateway/proxy/handler/failover_loop/prepare/cx2cc_preparation.rs
@@ -250,6 +250,59 @@ pub(super) async fn prepare<R: tauri::Runtime>(args: Cx2ccPreparationInput<'_, R
         },
     );
 
+    // Phase-1 / 1.5 prefix freeze for Grok-mapped models: pin instructions/tools,
+    // control fields (reasoning/tool_choice/max_output_tokens/…), and reuse
+    // append-only input prefix so xAI prompt cache can hit across turns.
+    {
+        let sticky_session = cx2cc_codex_session_id
+            .as_deref()
+            .or(args.input.session_id.as_deref());
+        let mut body_val: serde_json::Value =
+            serde_json::from_slice(upstream_body_bytes.as_ref()).unwrap_or_default();
+        let model_for_freeze = body_val
+            .get("model")
+            .and_then(|m| m.as_str())
+            .map(str::to_string);
+        let freeze = super::cx2cc_prefix_freeze::apply_grok_prefix_freeze(
+            &mut body_val,
+            sticky_session,
+            model_for_freeze.as_deref(),
+        );
+        if freeze.applied {
+            if let Ok(encoded) = serde_json::to_vec(&body_val) {
+                upstream_body_bytes = Bytes::from(encoded);
+                strip_request_content_encoding = true;
+            }
+            response_fixer::push_special_setting(
+                &args.input.special_settings,
+                serde_json::json!({
+                    "type": "cx2cc_grok_prefix_freeze",
+                    "scope": "request",
+                    "hit": true,
+                    "sessionId": freeze.session_id,
+                    "model": freeze.model,
+                    "instructions": freeze.instructions,
+                    "tools": freeze.tools,
+                    "input": freeze.input,
+                    "extras": freeze.extras,
+                    "instructionsSha16": freeze.instructions_sha16,
+                    "toolsSha16": freeze.tools_sha16,
+                    "inputLen": freeze.input_len,
+                    "inputPrefixLen": freeze.input_prefix_len,
+                    "maxOutputTokens": freeze.max_output_tokens,
+                    "toolChoiceSha16": freeze.tool_choice_sha16,
+                    "reasoningSha16": freeze.reasoning_sha16,
+                }),
+            );
+            emit_gateway_log(
+                &args.input.state.app,
+                "info",
+                "CX2CC_GROK_PREFIX_FREEZE",
+                format!("[CX2CC] grok prefix freeze {}", freeze.log_line()),
+            );
+        }
+    }
+
     // Re-detect Codex ChatGPT backend using source provider.
     if let Some(source) = source.as_ref() {
         let cx2cc_is_chatgpt =


### PR DESCRIPTION
## 问题

在 Claude 里通过 **CX2CC** 调用 Grok（同一供应商 / 同一 API Key）时，多轮对话经常 **没有 prompt cache**（`cache_read` 一直为 0）。  
同一供应商下，**Grok Build 直连**则正常有缓存。

## 原因（简要）

1. CX2CC 出站 sticky 不完整：缺 Grok Build 那套 `x-grok-*` 头，只靠 body 里的 `prompt_cache_key` 不够。
2. Claude 请求每轮被翻译成 Responses，系统提示 / 工具 / 历史前缀会漂，导致上游前缀缓存 miss。

## 改动

- CX2CC→Grok 出站补齐 sticky：`prompt_cache_key` + Build 等价 `x-grok-*` headers（发送前再 assert 一次）
- 同一会话内冻结 `instructions` / `tools` / 历史 input 前缀，减少每轮重写漂移
- 支持上游登记成 codex、但 model 实际是 `grok-*` 的场景

## 不影响

- 原生 Claude
- 原生 Codex（含 Codex 里直接配 Grok）
- 原生 Grok / Build

Closes #354

## 测试计划

- [ ] 单测：stickiness / prefix freeze 相关
- [ ] 手动：Claude → CX2CC → Grok 多轮，第二轮起 `cache_read` 非 0
- [ ] 手动：原生 Codex 配 Grok，缓存行为无回归
- [ ] 手动：原生 Claude 无副作用