### PR TITLE
fix(cli-proxy): 重启后重连代理时刷新 Claude 直连备份，避免关闭期间切换的供应商被覆盖丢失

### DIFF
--- a/src-tauri/src/infra/cli_proxy/claude.rs
+++ b/src-tauri/src/infra/cli_proxy/claude.rs
@@ -146,12 +146,18 @@ pub(super) fn is_proxy_config_applied<R: tauri::Runtime>(
     base == format!("{base_origin}/claude")
 }
 
-/// Whether `settings.json` currently carries our proxy marker token, regardless
-/// of which gateway port `ANTHROPIC_BASE_URL` points at. Unlike
+/// Whether `settings.json` currently looks like a file we wrote, regardless of
+/// which gateway port `ANTHROPIC_BASE_URL` points at. Unlike
 /// [`is_proxy_config_applied`] (which requires an exact port match), this stays
 /// true across a gateway port change, so it can be used to tell "still under
 /// our management" apart from "reverted to the user's direct config" (e.g. the
 /// file was restored on exit, or hand-edited while the app was closed).
+///
+/// Either marker is enough. The token alone would miss a file whose
+/// `ANTHROPIC_AUTH_TOKEN` was hand-edited while the proxy was running (a user
+/// swapping the placeholder for their real key): that file still points at the
+/// gateway, and treating it as a direct config would snapshot the gateway
+/// address as the user's "direct" backup and lose their real one for good.
 pub(super) fn is_proxy_managed<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
     let path = match claude_settings_path(app) {
         Ok(p) => p,
@@ -168,5 +174,19 @@ pub(super) fn is_proxy_managed<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> 
     let Some(env) = value.get("env").and_then(|v| v.as_object()) else {
         return false;
     };
-    env.get("ANTHROPIC_AUTH_TOKEN").and_then(|v| v.as_str()) == Some(PLACEHOLDER_KEY)
+    let token_is_ours =
+        env.get("ANTHROPIC_AUTH_TOKEN").and_then(|v| v.as_str()) == Some(PLACEHOLDER_KEY);
+    let url_is_ours = env
+        .get("ANTHROPIC_BASE_URL")
+        .and_then(|v| v.as_str())
+        .is_some_and(is_local_gateway_claude_url);
+
+    token_is_ours || url_is_ours
+}
+
+/// Whether a URL is one of our own gateway endpoints. The gateway always
+/// publishes `http://127.0.0.1:<port>` (see `settings_service`), so a loopback
+/// `/claude` URL cannot be a real upstream.
+fn is_local_gateway_claude_url(url: &str) -> bool {
+    url.starts_with("http://127.0.0.1:") && url.ends_with("/claude")
 }

--- a/src-tauri/src/infra/cli_proxy/claude.rs
+++ b/src-tauri/src/infra/cli_proxy/claude.rs
@@ -145,3 +145,28 @@ pub(super) fn is_proxy_config_applied<R: tauri::Runtime>(
     };
     base == format!("{base_origin}/claude")
 }
+
+/// Whether `settings.json` currently carries our proxy marker token, regardless
+/// of which gateway port `ANTHROPIC_BASE_URL` points at. Unlike
+/// [`is_proxy_config_applied`] (which requires an exact port match), this stays
+/// true across a gateway port change, so it can be used to tell "still under
+/// our management" apart from "reverted to the user's direct config" (e.g. the
+/// file was restored on exit, or hand-edited while the app was closed).
+pub(super) fn is_proxy_managed<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
+    let path = match claude_settings_path(app) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let bytes = match read_cli_proxy_file(&path) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    let value = match serde_json::from_slice::<serde_json::Value>(&bytes) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let Some(env) = value.get("env").and_then(|v| v.as_object()) else {
+        return false;
+    };
+    env.get("ANTHROPIC_AUTH_TOKEN").and_then(|v| v.as_str()) == Some(PLACEHOLDER_KEY)
+}

--- a/src-tauri/src/infra/cli_proxy/mod.rs
+++ b/src-tauri/src/infra/cli_proxy/mod.rs
@@ -716,6 +716,46 @@ fn ensure_manifest_has_current_targets<R: tauri::Runtime>(
     Ok(true)
 }
 
+/// Re-capture the backup snapshot for every already-tracked target from
+/// whatever is currently on disk. Used when resuming an already-enabled proxy
+/// (manifest `enabled` survives app exit so the proxy silently re-applies on
+/// next launch) and the on-disk file is no longer proxy-managed — i.e. the
+/// app's own exit-cleanup restored the direct config, and it may have been
+/// hand-edited (or edited by another tool) while the app was closed. Without
+/// this, `apply_proxy_config` would immediately overwrite that edit with our
+/// gateway address, discarding it forever since the original backup (from the
+/// very first enable) never reflected it.
+fn refresh_backup_from_direct_state<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    cli_key: &str,
+    manifest: &mut CliProxyManifest,
+) -> crate::shared::error::AppResult<()> {
+    let root = cli_proxy_root_dir(app, cli_key)?;
+    let files_dir = cli_proxy_files_dir(&root);
+    std::fs::create_dir_all(&files_dir)
+        .map_err(|e| format!("failed to create {}: {e}", files_dir.display()))?;
+
+    for target in target_files(app, cli_key)? {
+        let Some(entry) = manifest.files.iter_mut().find(|entry| entry.kind == target.kind)
+        else {
+            continue;
+        };
+
+        let read_bytes =
+            read_optional_cli_proxy_file_with_max_len(&target.path, target.max_bytes)?;
+        entry.existed = read_bytes.is_some();
+        entry.backup_rel = if let Some(bytes) = read_bytes {
+            let backup_path = files_dir.join(target.backup_name);
+            write_cli_proxy_file_atomic_with_max_len(&backup_path, &bytes, target.max_bytes)?;
+            Some(target.backup_name.to_string())
+        } else {
+            None
+        };
+    }
+
+    Ok(())
+}
+
 fn capture_current_target_state<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     cli_key: &str,
@@ -1309,6 +1349,26 @@ pub fn sync_enabled<R: tauri::Runtime>(
                 Some(base_origin.to_string()),
             ));
             continue;
+        }
+
+        // The manifest says the proxy is enabled, but the on-disk file no
+        // longer carries our marker (e.g. exit-cleanup restored the direct
+        // config, and it may have since been edited while the app was
+        // closed). Snapshot that direct state as the new backup before we
+        // overwrite it below, so a later disable restores it instead of the
+        // stale snapshot from the first time the proxy was ever enabled.
+        if cli_key == "claude" && !claude::is_proxy_managed(app) {
+            if let Err(err) = refresh_backup_from_direct_state(app, cli_key, &mut manifest) {
+                out.push(CliProxyResult::failure(
+                    trace_id,
+                    cli_key,
+                    true,
+                    "CLI_PROXY_BACKUP_FAILED",
+                    err.to_string(),
+                    Some(base_origin.to_string()),
+                ));
+                continue;
+            }
         }
 
         match apply_proxy_config(app, cli_key, base_origin) {

--- a/src-tauri/src/infra/cli_proxy/mod.rs
+++ b/src-tauri/src/infra/cli_proxy/mod.rs
@@ -730,27 +730,19 @@ fn refresh_backup_from_direct_state<R: tauri::Runtime>(
     cli_key: &str,
     manifest: &mut CliProxyManifest,
 ) -> crate::shared::error::AppResult<()> {
-    let root = cli_proxy_root_dir(app, cli_key)?;
-    let files_dir = cli_proxy_files_dir(&root);
-    std::fs::create_dir_all(&files_dir)
-        .map_err(|e| format!("failed to create {}: {e}", files_dir.display()))?;
+    let captured = capture_current_target_state(app, cli_key)?;
+    write_captured_backups(app, cli_key, &captured)?;
 
-    for target in target_files(app, cli_key)? {
-        let Some(entry) = manifest.files.iter_mut().find(|entry| entry.kind == target.kind)
+    for entry in captured {
+        let Some(tracked) = manifest
+            .files
+            .iter_mut()
+            .find(|tracked| tracked.kind == entry.kind)
         else {
             continue;
         };
-
-        let read_bytes =
-            read_optional_cli_proxy_file_with_max_len(&target.path, target.max_bytes)?;
-        entry.existed = read_bytes.is_some();
-        entry.backup_rel = if let Some(bytes) = read_bytes {
-            let backup_path = files_dir.join(target.backup_name);
-            write_cli_proxy_file_atomic_with_max_len(&backup_path, &bytes, target.max_bytes)?;
-            Some(target.backup_name.to_string())
-        } else {
-            None
-        };
+        tracked.existed = entry.existed;
+        tracked.backup_rel = entry.existed.then(|| entry.backup_name.to_string());
     }
 
     Ok(())

--- a/src-tauri/src/infra/cli_proxy/tests.rs
+++ b/src-tauri/src/infra/cli_proxy/tests.rs
@@ -970,6 +970,81 @@ fn grok_proxy_reapplies_after_exit_restore_keeps_enabled_state() {
     assert_eq!(managed["models"]["session_summary"].as_str(), Some("aio"));
 }
 
+/// Regression test for the long-standing report that direct-config edits made
+/// while the app is closed get silently discarded: no matter what provider
+/// the user points Claude at while AIO isn't running, opening and closing it
+/// again always reverts to whichever provider was configured the very first
+/// time the proxy was ever enabled.
+///
+/// Root cause: exit cleanup restores the direct config but leaves the
+/// manifest's `enabled` flag set (so the proxy silently re-applies on next
+/// launch, per `sync_enabled`). That re-apply never refreshed the backup
+/// snapshot, so any edit made to the direct config between "exit" and
+/// "next launch" was overwritten by the gateway address without ever being
+/// captured — and a later disable restored the stale, original snapshot.
+#[test]
+fn claude_proxy_captures_direct_edit_made_while_app_was_closed() {
+    let test_app = CliProxyTestApp::new();
+    let handle = test_app.handle();
+    let settings_path = home_dir(&handle)
+        .expect("home dir")
+        .join(".claude")
+        .join("settings.json");
+    std::fs::create_dir_all(settings_path.parent().expect("settings parent"))
+        .expect("create .claude dir");
+    std::fs::write(
+        &settings_path,
+        br#"{ "env": { "ANTHROPIC_BASE_URL": "https://provider-a.example.com", "ANTHROPIC_AUTH_TOKEN": "token-a" } }"#,
+    )
+    .expect("write provider A direct config");
+
+    let base_origin = "http://127.0.0.1:37123";
+    let enabled = set_enabled(&handle, "claude", true, base_origin).expect("enable claude proxy");
+    assert!(enabled.ok, "{}", enabled.message);
+
+    // App exit: restores the direct config but keeps `enabled` in the manifest.
+    let restored = restore_enabled_keep_state(&handle).expect("exit restore");
+    let claude_restore = restored
+        .iter()
+        .find(|result| result.cli_key == "claude")
+        .expect("claude restore result");
+    assert!(claude_restore.ok, "{}", claude_restore.message);
+
+    // While the app is closed, the user points Claude at a different provider.
+    std::fs::write(
+        &settings_path,
+        br#"{ "env": { "ANTHROPIC_BASE_URL": "https://provider-b.example.com", "ANTHROPIC_AUTH_TOKEN": "token-b" } }"#,
+    )
+    .expect("write provider B direct config");
+
+    // App relaunch: gateway autostart re-syncs the still-enabled proxy.
+    let synced = sync_enabled(&handle, base_origin, true).expect("startup sync");
+    let claude_sync = synced
+        .iter()
+        .find(|result| result.cli_key == "claude")
+        .expect("claude sync result");
+    assert!(claude_sync.ok, "{}", claude_sync.message);
+
+    // Close the app again: should restore provider B, not the original provider A.
+    let disabled =
+        set_enabled(&handle, "claude", false, base_origin).expect("disable claude proxy");
+    assert!(disabled.ok, "{}", disabled.message);
+
+    let result: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&settings_path).expect("read settings")).unwrap();
+    let env = result.get("env").unwrap().as_object().unwrap();
+    assert_eq!(
+        env.get("ANTHROPIC_BASE_URL").unwrap().as_str(),
+        Some("https://provider-b.example.com"),
+        "should restore the provider set while the app was closed, not the original backup: {result}"
+    );
+    assert_eq!(
+        env.get("ANTHROPIC_AUTH_TOKEN").unwrap().as_str(),
+        Some("token-b"),
+        "should restore the provider set while the app was closed, not the original backup: {result}"
+    );
+}
+
 #[test]
 fn read_manifest_rejects_oversized_file() {
     let test_app = CliProxyTestApp::new();

--- a/src-tauri/src/infra/cli_proxy/tests.rs
+++ b/src-tauri/src/infra/cli_proxy/tests.rs
@@ -1045,6 +1045,157 @@ fn claude_proxy_captures_direct_edit_made_while_app_was_closed() {
     );
 }
 
+/// Write a direct Claude config and enable the proxy on `base_origin`.
+fn enable_claude_proxy_over_direct_config<R: tauri::Runtime>(
+    handle: &tauri::AppHandle<R>,
+    base_origin: &str,
+    direct_config: &[u8],
+) -> std::path::PathBuf {
+    let settings_path = home_dir(handle)
+        .expect("home dir")
+        .join(".claude")
+        .join("settings.json");
+    std::fs::create_dir_all(settings_path.parent().expect("settings parent"))
+        .expect("create .claude dir");
+    std::fs::write(&settings_path, direct_config).expect("write direct config");
+
+    let enabled = set_enabled(handle, "claude", true, base_origin).expect("enable claude proxy");
+    assert!(enabled.ok, "{}", enabled.message);
+
+    settings_path
+}
+
+/// The mirror image of the regression above: when the on-disk config is still
+/// ours, a gateway port change must NOT re-snapshot it. Refreshing here would
+/// write the gateway address into the backup and destroy the user's real
+/// direct config the next time the proxy is disabled.
+#[test]
+fn claude_proxy_keeps_original_backup_when_only_gateway_port_changed() {
+    let test_app = CliProxyTestApp::new();
+    let handle = test_app.handle();
+    let settings_path = enable_claude_proxy_over_direct_config(
+        &handle,
+        "http://127.0.0.1:37123",
+        br#"{ "env": { "ANTHROPIC_BASE_URL": "https://provider-a.example.com", "ANTHROPIC_AUTH_TOKEN": "token-a" } }"#,
+    );
+
+    let next_origin = "http://127.0.0.1:45999";
+    let synced = sync_enabled(&handle, next_origin, true).expect("sync to new port");
+    let claude_sync = synced
+        .iter()
+        .find(|result| result.cli_key == "claude")
+        .expect("claude sync result");
+    assert!(claude_sync.ok, "{}", claude_sync.message);
+
+    let disabled =
+        set_enabled(&handle, "claude", false, next_origin).expect("disable claude proxy");
+    assert!(disabled.ok, "{}", disabled.message);
+
+    let result: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&settings_path).expect("read settings")).unwrap();
+    let env = result.get("env").unwrap().as_object().unwrap();
+    assert_eq!(
+        env.get("ANTHROPIC_BASE_URL").unwrap().as_str(),
+        Some("https://provider-a.example.com"),
+        "a port change must not turn the gateway address into the direct backup: {result}"
+    );
+    assert_eq!(
+        env.get("ANTHROPIC_AUTH_TOKEN").unwrap().as_str(),
+        Some("token-a"),
+        "a port change must not turn the gateway address into the direct backup: {result}"
+    );
+}
+
+/// Same hazard, reached through the token instead of the port: a user who
+/// swaps our placeholder token for their own real key while the proxy is
+/// running leaves a file that still points at the gateway. It must not be
+/// mistaken for a direct config on the next port change.
+#[test]
+fn claude_proxy_keeps_backup_when_token_hand_edited_while_proxy_running() {
+    let test_app = CliProxyTestApp::new();
+    let handle = test_app.handle();
+    let settings_path = enable_claude_proxy_over_direct_config(
+        &handle,
+        "http://127.0.0.1:37123",
+        br#"{ "env": { "ANTHROPIC_BASE_URL": "https://provider-a.example.com", "ANTHROPIC_AUTH_TOKEN": "token-a" } }"#,
+    );
+
+    std::fs::write(
+        &settings_path,
+        br#"{ "env": { "ANTHROPIC_BASE_URL": "http://127.0.0.1:37123/claude", "ANTHROPIC_AUTH_TOKEN": "my-own-key" } }"#,
+    )
+    .expect("hand-edit the managed token");
+
+    let next_origin = "http://127.0.0.1:45999";
+    let synced = sync_enabled(&handle, next_origin, true).expect("sync to new port");
+    let claude_sync = synced
+        .iter()
+        .find(|result| result.cli_key == "claude")
+        .expect("claude sync result");
+    assert!(claude_sync.ok, "{}", claude_sync.message);
+
+    let disabled =
+        set_enabled(&handle, "claude", false, next_origin).expect("disable claude proxy");
+    assert!(disabled.ok, "{}", disabled.message);
+
+    let result: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&settings_path).expect("read settings")).unwrap();
+    let env = result.get("env").unwrap().as_object().unwrap();
+    assert_eq!(
+        env.get("ANTHROPIC_BASE_URL").unwrap().as_str(),
+        Some("https://provider-a.example.com"),
+        "an edited token must not make the gateway address look like a direct config: {result}"
+    );
+}
+
+/// Failure path: when the direct config cannot be snapshotted, the sync must
+/// report `CLI_PROXY_BACKUP_FAILED` and leave the file untouched rather than
+/// overwrite a config it failed to back up.
+#[test]
+fn claude_proxy_sync_reports_backup_failure_without_overwriting_direct_config() {
+    let test_app = CliProxyTestApp::new();
+    let handle = test_app.handle();
+    let base_origin = "http://127.0.0.1:37123";
+    let settings_path = enable_claude_proxy_over_direct_config(
+        &handle,
+        base_origin,
+        br#"{ "env": { "ANTHROPIC_BASE_URL": "https://provider-a.example.com", "ANTHROPIC_AUTH_TOKEN": "token-a" } }"#,
+    );
+
+    let restored = restore_enabled_keep_state(&handle).expect("exit restore");
+    assert!(
+        restored
+            .iter()
+            .find(|result| result.cli_key == "claude")
+            .expect("claude restore result")
+            .ok
+    );
+
+    // While the app is closed the direct config grows past the read limit, so
+    // it can no longer be captured as a backup.
+    let oversized = format!(
+        r#"{{ "padding": "{}", "env": {{ "ANTHROPIC_BASE_URL": "https://provider-b.example.com" }} }}"#,
+        "x".repeat(CLI_PROXY_FILE_MAX_BYTES)
+    );
+    std::fs::write(&settings_path, oversized.as_bytes()).expect("write oversized direct config");
+
+    let synced = sync_enabled(&handle, base_origin, true).expect("startup sync");
+    let claude_sync = synced
+        .iter()
+        .find(|result| result.cli_key == "claude")
+        .expect("claude sync result");
+    assert!(!claude_sync.ok, "sync should fail: {}", claude_sync.message);
+    assert_eq!(
+        claude_sync.error_code.as_deref(),
+        Some("CLI_PROXY_BACKUP_FAILED")
+    );
+    assert_eq!(
+        std::fs::read(&settings_path).expect("read settings"),
+        oversized.as_bytes(),
+        "a config we failed to back up must not be overwritten"
+    );
+}
+
 #[test]
 fn read_manifest_rejects_oversized_file() {
     let test_app = CliProxyTestApp::new();


### PR DESCRIPTION
## Summary

修复一个长期存在的 bug：AIO 关闭期间，无论怎么把 Claude Code 的供应商（`~/.claude/settings.json` 里的 `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`）改成别的，只要再打开一次 AIO 然后关闭，配置总会被还原成"很久以前第一次开启代理时"的那个供应商，而不是关闭前最后设置的那个。

### 根因

- 退出清理（`cleanup_before_exit` → `restore_enabled_keep_state`）会把直连配置还原回去，但**故意**保留 manifest 里的 `enabled = true`，这样下次启动时代理会自动重新接管（这是有意设计，不是 bug）。
- 下次启动时，`sync_enabled()` 发现 `enabled == true`，于是直接调用 `apply_proxy_config` 把当前 `settings.json` 的 `env` 覆盖成网关地址——但从始至终**没有刷新备份快照**。备份文件里存的，永远是第一次点开关代理时的那份原始配置。
- 于是：用户在 AIO 关闭期间手动把供应商改成 B，重新打开 AIO 时这个改动被静默覆盖且从未被记录；再次关闭 AIO 时，`merge_restore_claude_settings_json` 从那份陈旧备份里恢复，得到的还是最初的供应商 A，B 永远丢失。

复现步骤对应用户反馈：先开代理 → 关闭 AIO（配置复原为直连 A）→ 手动把 `settings.json` 改成供应商 B → 打开 AIO（代理重新接管，B 未被保存）→ 关闭 AIO → 配置变回 A，而不是 B。

翻了一遍现有 issue，#43（codex 运行中添加白名单目录重启后丢失）是同一类根因，但只针对 codex 的 config.toml，维护者认为已经修复；没有找到专门针对 Claude 供应商这个场景的重复反馈。

## 改动要点

- `claude.rs`：新增 `is_proxy_managed()`，只看 `ANTHROPIC_AUTH_TOKEN` 是否等于我们写入的占位符，不要求 `ANTHROPIC_BASE_URL` 精确匹配当前网关端口——这样网关端口变化时不会被误判为"直连状态"。
- `mod.rs`：新增 `refresh_backup_from_direct_state()`，在 `sync_enabled()` 里、对 Claude 调用 `apply_proxy_config` 覆盖之前，如果 `!is_proxy_managed()`（也就是当前文件不是我们管理的网关配置，而是直连配置），先把这份"当前直连配置"重新写入备份文件，再继续走原来的覆盖逻辑。这样备份快照就能跟上用户最后一次的直连配置，而不是永远停在第一次开启代理的那一刻。
- 只改了 `claude` 这一个 cli_key 的路径，没有动 codex / gemini / grok，避免影响它们各自更复杂的 rebind 逻辑。

## 影响范围

仅 Claude 的 cli-proxy 备份/恢复路径（`sync_enabled` 在 `cli_key == "claude"` 分支新增的一小段逻辑），不影响 codex / gemini / grok，也不影响手动通过 UI 开关代理的路径（那条路径本来就会正确刷新备份）。

## Test plan

- [x] 新增单元测试 `claude_proxy_captures_direct_edit_made_while_app_was_closed`（`src-tauri/src/infra/cli_proxy/tests.rs`）：完整模拟 开启代理 → 退出还原（keep-state）→ 关闭期间手动改成供应商 B → 启动时 `sync_enabled` 重连 → 再次关闭 → 断言恢复出的是供应商 B 而不是最初的供应商 A。已通过人工走读确认在有/无本次修复时分别应失败/通过。
- [ ] `cargo test`（本地沙箱环境没有 Rust 工具链，未能实际执行，请在 CI 中确认）
- [ ] 手动验证：开启 Claude 代理 → 关闭 AIO → 手改 `~/.claude/settings.json` 切换供应商 → 重新打开 AIO → 关闭 → 确认 `settings.json` 变为手改后的供应商

（这次改动是我在本地分析源码后定位并修复的，本地环境没有安装 Rust 工具链，无法运行 `cargo fmt` / `cargo clippy` / `cargo test`，麻烦 CI 或维护者复核一下格式和测试是否都能通过，谢谢！）
