### PR TITLE
feat(providers): 调用顺序支持定位供应商卡片

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,7 @@ overrides:
   lodash: ^4.18.1
   minimatch@3.1.2: 3.1.4
   minimatch@9.0.5: 9.0.7
-  nanoid@3.3.16: 3.3.18
-  nanoid@3.3.17: 3.3.18
+  nanoid@3.3.16: 3.3.17
   picomatch@2.3.1: 2.3.2
   picomatch@4.0.3: 4.0.4
   react-router: 8.3.0
@@ -3191,8 +3190,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.18:
-    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7491,7 +7490,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.18: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -7609,7 +7608,7 @@ snapshots:
 
   postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.18
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,8 @@ overrides:
   lodash: ^4.18.1
   minimatch@3.1.2: 3.1.4
   minimatch@9.0.5: 9.0.7
-  nanoid@3.3.16: 3.3.17
+  nanoid@3.3.16: 3.3.18
+  nanoid@3.3.17: 3.3.18
   picomatch@2.3.1: 2.3.2
   picomatch@4.0.3: 4.0.4
   react-router: 8.3.0
@@ -3190,8 +3191,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7490,7 +7491,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -7608,7 +7609,7 @@ snapshots:
 
   postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,11 +5,6 @@ packages:
 minimumReleaseAge: 10080
 trustPolicy: no-downgrade
 
-# nanoid 3.3.18（GHSA-2v37-7h3g-55p8 修复版）发布不足 7 天，被 minimumReleaseAge 拦截，
-# 临时豁免以允许升级；满 7 天后可移除该豁免。
-minimumReleaseAgeExclude:
-  - nanoid
-
 allowBuilds:
   es5-ext: false
   esbuild: true
@@ -26,8 +21,7 @@ overrides:
   lodash: ^4.18.1
   minimatch@3.1.2: 3.1.4
   minimatch@9.0.5: 9.0.7
-  nanoid@3.3.16: 3.3.18
-  nanoid@3.3.17: 3.3.18
+  nanoid@3.3.16: 3.3.17
   picomatch@2.3.1: 2.3.2
   picomatch@4.0.3: 4.0.4
   react-router: 8.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,11 @@ packages:
 minimumReleaseAge: 10080
 trustPolicy: no-downgrade
 
+# nanoid 3.3.18（GHSA-2v37-7h3g-55p8 修复版）发布不足 7 天，被 minimumReleaseAge 拦截，
+# 临时豁免以允许升级；满 7 天后可移除该豁免。
+minimumReleaseAgeExclude:
+  - nanoid
+
 allowBuilds:
   es5-ext: false
   esbuild: true
@@ -21,7 +26,8 @@ overrides:
   lodash: ^4.18.1
   minimatch@3.1.2: 3.1.4
   minimatch@9.0.5: 9.0.7
-  nanoid@3.3.16: 3.3.17
+  nanoid@3.3.16: 3.3.18
+  nanoid@3.3.17: 3.3.18
   picomatch@2.3.1: 2.3.2
   picomatch@4.0.3: 4.0.4
   react-router: 8.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,8 @@ overrides:
   lodash: ^4.18.1
   minimatch@3.1.2: 3.1.4
   minimatch@9.0.5: 9.0.7
-  nanoid@3.3.16: 3.3.17
+  nanoid@3.3.16: 3.3.18
+  nanoid@3.3.17: 3.3.18
   picomatch@2.3.1: 2.3.2
   picomatch@4.0.3: 4.0.4
   react-router: 8.3.0

--- a/src/pages/providers/ProvidersView.tsx
+++ b/src/pages/providers/ProvidersView.tsx
@@ -1,7 +1,7 @@
 // Usage: Rendered by ProvidersPage when `view === "providers"`.
 
 import { memo, useCallback, useEffect, useRef, useState, type RefObject } from "react";
-import { Search } from "lucide-react";
+import { LocateFixed, Search } from "lucide-react";
 import { DndContext, closestCenter } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CLIS } from "../../constants/clis";
@@ -75,6 +75,7 @@ const RouteOrderItemTrailing = memo(function RouteOrderItemTrailing({
   providerLabel,
   onSetRouteProviderEnabled,
   onRemoveProviderFromCurrentRoute,
+  onLocateProvider,
 }: {
   providerId: number;
   enabled: boolean;
@@ -83,6 +84,7 @@ const RouteOrderItemTrailing = memo(function RouteOrderItemTrailing({
   providerLabel: string;
   onSetRouteProviderEnabled: (providerId: number, checked: boolean) => void | Promise<void>;
   onRemoveProviderFromCurrentRoute: (providerId: number) => void;
+  onLocateProvider: (providerId: number) => void;
 }) {
   const handleToggle = useCallback(
     (checked: boolean) => {
@@ -93,9 +95,24 @@ const RouteOrderItemTrailing = memo(function RouteOrderItemTrailing({
   const handleRemove = useCallback(() => {
     onRemoveProviderFromCurrentRoute(providerId);
   }, [onRemoveProviderFromCurrentRoute, providerId]);
+  const handleLocate = useCallback(() => {
+    onLocateProvider(providerId);
+  }, [onLocateProvider, providerId]);
 
   return (
     <div className="flex shrink-0 items-center gap-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 w-7 px-0 text-muted-foreground hover:text-foreground"
+        title="定位到供应商卡片"
+        aria-label={`定位 ${providerLabel} 到供应商卡片`}
+        disabled={disabled || providerMissing}
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={handleLocate}
+      >
+        <LocateFixed className="h-3.5 w-3.5" />
+      </Button>
       <div
         className="flex shrink-0 items-center"
         onPointerDown={(event) => event.stopPropagation()}
@@ -348,7 +365,13 @@ function ProvidersPool({
   );
 }
 
-function ProvidersRouteSidebar({ model }: { model: ProvidersViewModel }) {
+function ProvidersRouteSidebar({
+  model,
+  onLocateProvider,
+}: {
+  model: ProvidersViewModel;
+  onLocateProvider: (providerId: number) => void;
+}) {
   const {
     providers,
     sortModes,
@@ -503,6 +526,7 @@ function ProvidersRouteSidebar({ model }: { model: ProvidersViewModel }) {
                         providerLabel={providerLabel}
                         onSetRouteProviderEnabled={setRouteProviderEnabled}
                         onRemoveProviderFromCurrentRoute={removeProviderFromCurrentRoute}
+                        onLocateProvider={onLocateProvider}
                       />
                     </SortableProviderOrderItem>
                   );
@@ -790,9 +814,17 @@ function PendingRouteActivationDialog({
 
 export function ProvidersView({ activeCli }: ProvidersViewProps) {
   const model = useProvidersViewDataModel(activeCli);
-  const { providers, providersLoading, filteredProviders, setDeleteTarget } = model;
+  const {
+    providers,
+    providersLoading,
+    filteredProviders,
+    setDeleteTarget,
+    setProviderSearch,
+    setSelectedTags,
+  } = model;
   const providersListScrollRef = useRef<HTMLDivElement | null>(null);
   const pendingProvidersScrollRestoreRef = useRef<PendingProvidersScrollRestore | null>(null);
+  const pendingLocateProviderIdRef = useRef<number | null>(null);
   const selectedCliName = CLIS.find((cli) => cli.key === activeCli)?.name ?? activeCli;
   const [clearUsageStatsOnDelete, setClearUsageStatsOnDelete] = useState(false);
 
@@ -835,6 +867,24 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
     };
   }
 
+  function handleLocateProvider(providerId: number) {
+    // 目标可能正被搜索/标签过滤隐藏：先清空过滤条件，再滚动定位。
+    setProviderSearch("");
+    setSelectedTags(new Set());
+    pendingLocateProviderIdRef.current = providerId;
+  }
+
+  useEffect(() => {
+    const targetId = pendingLocateProviderIdRef.current;
+    if (targetId == null) return;
+    if (!filteredProviders.some((provider) => provider.id === targetId)) return;
+
+    const providersListElement = providersListScrollRef.current;
+    const targetElement = providersListElement?.querySelector(`[data-provider-id="${targetId}"]`);
+    targetElement?.scrollIntoView({ behavior: "smooth", block: "center" });
+    pendingLocateProviderIdRef.current = null;
+  }, [filteredProviders]);
+
   function openDeleteDialog(provider: (typeof providers)[number]) {
     setClearUsageStatsOnDelete(false);
     setDeleteTarget(provider);
@@ -856,7 +906,7 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
             scrollRef={providersListScrollRef}
             onDeleteProvider={openDeleteDialog}
           />
-          <ProvidersRouteSidebar model={model} />
+          <ProvidersRouteSidebar model={model} onLocateProvider={handleLocateProvider} />
         </div>
       </div>
 

--- a/src/pages/providers/ProvidersView.tsx
+++ b/src/pages/providers/ProvidersView.tsx
@@ -824,9 +824,9 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
   } = model;
   const providersListScrollRef = useRef<HTMLDivElement | null>(null);
   const pendingProvidersScrollRestoreRef = useRef<PendingProvidersScrollRestore | null>(null);
-  const pendingLocateProviderIdRef = useRef<number | null>(null);
   const selectedCliName = CLIS.find((cli) => cli.key === activeCli)?.name ?? activeCli;
   const [clearUsageStatsOnDelete, setClearUsageStatsOnDelete] = useState(false);
+  const [locateTargetId, setLocateTargetId] = useState<number | null>(null);
 
   useEffect(() => {
     const pendingRestore = pendingProvidersScrollRestoreRef.current;
@@ -871,20 +871,23 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
     // 目标可能正被搜索/标签过滤隐藏：先清空过滤条件，再滚动定位。
     setProviderSearch("");
     setSelectedTags(new Set());
-    pendingLocateProviderIdRef.current = providerId;
+    // 用 state 而非 ref 记录待定位目标：这三次更新会被批处理成同一轮渲染，
+    // 由 locateTargetId 自身的变化驱动下面的 effect，不依赖 filteredProviders 是否恰好换了引用。
+    setLocateTargetId(providerId);
   }
 
   useEffect(() => {
-    const targetId = pendingLocateProviderIdRef.current;
-    if (targetId == null) return;
-    if (!filteredProviders.some((provider) => provider.id === targetId)) return;
+    if (locateTargetId == null) return;
 
     const providersListElement = providersListScrollRef.current;
-    const targetElement = providersListElement?.querySelector(`[data-provider-id="${targetId}"]`);
+    const targetElement = providersListElement?.querySelector(
+      `[data-provider-id="${locateTargetId}"]`
+    );
     // 定位到列表可视区顶部（第一个位置），而非居中，便于查看该卡片及其后序卡片。
     targetElement?.scrollIntoView({ behavior: "smooth", block: "start" });
-    pendingLocateProviderIdRef.current = null;
-  }, [filteredProviders]);
+    // 目标已被并发删除时同样清空，避免残留意图在后续列表变化时触发意外滚动。
+    setLocateTargetId(null);
+  }, [locateTargetId]);
 
   function openDeleteDialog(provider: (typeof providers)[number]) {
     setClearUsageStatsOnDelete(false);

--- a/src/pages/providers/ProvidersView.tsx
+++ b/src/pages/providers/ProvidersView.tsx
@@ -881,7 +881,8 @@ export function ProvidersView({ activeCli }: ProvidersViewProps) {
 
     const providersListElement = providersListScrollRef.current;
     const targetElement = providersListElement?.querySelector(`[data-provider-id="${targetId}"]`);
-    targetElement?.scrollIntoView({ behavior: "smooth", block: "center" });
+    // 定位到列表可视区顶部（第一个位置），而非居中，便于查看该卡片及其后序卡片。
+    targetElement?.scrollIntoView({ behavior: "smooth", block: "start" });
     pendingLocateProviderIdRef.current = null;
   }, [filteredProviders]);
 

--- a/src/pages/providers/SortableProviderCard.tsx
+++ b/src/pages/providers/SortableProviderCard.tsx
@@ -630,7 +630,7 @@ export const SortableProviderCard = memo(function SortableProviderCard(
   const dragHandleProps = useMemo(() => ({ ...attributes, ...listeners }), [attributes, listeners]);
 
   return (
-    <div ref={setNodeRef} style={style} className="relative">
+    <div ref={setNodeRef} style={style} className="relative" data-provider-id={props.provider.id}>
       <ProviderCard
         {...props}
         className={cn(isDragging && "z-10 scale-[1.02] shadow-lg ring-2 ring-accent/30")}

--- a/src/pages/providers/__tests__/ProvidersView.test.tsx
+++ b/src/pages/providers/__tests__/ProvidersView.test.tsx
@@ -178,6 +178,10 @@ function dragProviderPool(event: any) {
   dndContextDragHandlers[0]?.(event);
 }
 
+// jsdom 未实现 scrollIntoView：集中打桩一次，由 afterEach 清计数，避免跨用例累积调用记录。
+const scrollIntoViewMock = vi.fn();
+Element.prototype.scrollIntoView = scrollIntoViewMock;
+
 beforeEach(() => {
   dndContextDragHandlers = [];
   vi.mocked(copyText).mockResolvedValue(undefined);
@@ -235,6 +239,7 @@ afterEach(() => {
   cleanup();
   vi.useRealTimers();
   sortableIsDragging = false;
+  scrollIntoViewMock.mockClear();
 });
 
 describe("pages/providers/ProvidersView", () => {
@@ -1135,37 +1140,36 @@ describe("pages/providers/ProvidersView", () => {
     expect(screen.getByText("共 2 / 2 条")).toBeInTheDocument();
   });
 
-  it("locates a provider card from the route order, clearing filters first", async () => {
-    const scrollIntoView = vi.fn();
-    Element.prototype.scrollIntoView = scrollIntoView;
+  const LOCATE_PROVIDERS = [
+    {
+      id: 1,
+      cli_key: "claude",
+      name: "Alpha Relay",
+      enabled: true,
+      base_urls: ["https://a"],
+      base_url_mode: "order",
+      cost_multiplier: 1,
+      claude_models: {},
+      tags: ["prod"],
+    },
+    {
+      id: 2,
+      cli_key: "claude",
+      name: "Beta Gateway",
+      enabled: true,
+      base_urls: ["https://b"],
+      base_url_mode: "ping",
+      cost_multiplier: 1,
+      claude_models: {},
+      tags: ["prod"],
+    },
+  ] as any[];
 
-    const providers = [
-      {
-        id: 1,
-        cli_key: "claude",
-        name: "Alpha Relay",
-        enabled: true,
-        base_urls: ["https://a"],
-        base_url_mode: "order",
-        cost_multiplier: 1,
-        claude_models: {},
-        tags: ["prod"],
-      },
-      {
-        id: 2,
-        cli_key: "claude",
-        name: "Beta Gateway",
-        enabled: true,
-        base_urls: ["https://b"],
-        base_url_mode: "ping",
-        cost_multiplier: 1,
-        claude_models: {},
-        tags: ["prod"],
-      },
-    ] as any[];
-
+  function renderLocateScenario(
+    routeRows: Array<{ provider_id: number }> = [{ provider_id: 1 }, { provider_id: 2 }]
+  ) {
     vi.mocked(useProvidersListQuery).mockReturnValue({
-      data: providers,
+      data: LOCATE_PROVIDERS,
       isFetching: false,
     } as any);
     vi.mocked(useGatewayCircuitStatusQuery).mockReturnValue({
@@ -1177,7 +1181,7 @@ describe("pages/providers/ProvidersView", () => {
     vi.mocked(useProviderDeleteMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
     vi.mocked(useProvidersReorderMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
     vi.mocked(useDefaultRouteProvidersQuery).mockReturnValue({
-      data: [{ provider_id: 1 }, { provider_id: 2 }],
+      data: routeRows,
       isFetching: false,
     } as any);
     vi.mocked(useGatewayCircuitResetProviderMutation).mockReturnValue({
@@ -1186,6 +1190,10 @@ describe("pages/providers/ProvidersView", () => {
     vi.mocked(useGatewayCircuitResetCliMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
 
     renderWithQuery(<ProvidersView activeCli="claude" setActiveCli={vi.fn()} />);
+  }
+
+  it("locates a provider card from the route order, clearing filters first", async () => {
+    renderLocateScenario();
 
     // Filtering hides Alpha Relay from the pool list (only the route sidebar copy remains).
     fireEvent.change(screen.getByRole("textbox", { name: "搜索供应商名称" }), {
@@ -1200,8 +1208,44 @@ describe("pages/providers/ProvidersView", () => {
     await waitFor(() => expect(screen.getByText("共 2 / 2 条")).toBeInTheDocument());
     await waitFor(() => expect(screen.getAllByText("Alpha Relay").length).toBeGreaterThan(1));
     await waitFor(() =>
-      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" })
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "start" })
     );
+  });
+
+  it("locates a provider card even when no filter is active", async () => {
+    renderLocateScenario();
+
+    // 无过滤时清空过滤不改变过滤结果，定位仍必须滚动：守住「靠 filteredProviders 换引用才生效」的回归。
+    expect(screen.getByText("共 2 / 2 条")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "定位 Alpha Relay 到供应商卡片" }));
+
+    await waitFor(() =>
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "start" })
+    );
+  });
+
+  it("disables the locate button when the route row provider is missing", () => {
+    renderLocateScenario([{ provider_id: 1 }, { provider_id: 3 }]);
+
+    expect(
+      screen.getByRole("button", { name: "定位 未知 Provider #3 到供应商卡片" })
+    ).toBeDisabled();
+  });
+
+  it("does not scroll again when the list changes after a locate", async () => {
+    renderLocateScenario();
+
+    fireEvent.click(screen.getByRole("button", { name: "定位 Alpha Relay 到供应商卡片" }));
+    await waitFor(() => expect(scrollIntoViewMock).toHaveBeenCalledTimes(1));
+    scrollIntoViewMock.mockClear();
+
+    // 定位意图已被消费：后续过滤变化不得再触发滚动。
+    fireEvent.change(screen.getByRole("textbox", { name: "搜索供应商名称" }), {
+      target: { value: "alpha" },
+    });
+    await waitFor(() => expect(screen.getByText("共 1 / 2 条")).toBeInTheDocument());
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
   });
 
   it("lets sort mode providers be re-enabled from the route order switch", async () => {

--- a/src/pages/providers/__tests__/ProvidersView.test.tsx
+++ b/src/pages/providers/__tests__/ProvidersView.test.tsx
@@ -1199,7 +1199,9 @@ describe("pages/providers/ProvidersView", () => {
 
     await waitFor(() => expect(screen.getByText("共 2 / 2 条")).toBeInTheDocument());
     await waitFor(() => expect(screen.getAllByText("Alpha Relay").length).toBeGreaterThan(1));
-    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" })
+    );
   });
 
   it("lets sort mode providers be re-enabled from the route order switch", async () => {

--- a/src/pages/providers/__tests__/ProvidersView.test.tsx
+++ b/src/pages/providers/__tests__/ProvidersView.test.tsx
@@ -1135,6 +1135,73 @@ describe("pages/providers/ProvidersView", () => {
     expect(screen.getByText("共 2 / 2 条")).toBeInTheDocument();
   });
 
+  it("locates a provider card from the route order, clearing filters first", async () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    const providers = [
+      {
+        id: 1,
+        cli_key: "claude",
+        name: "Alpha Relay",
+        enabled: true,
+        base_urls: ["https://a"],
+        base_url_mode: "order",
+        cost_multiplier: 1,
+        claude_models: {},
+        tags: ["prod"],
+      },
+      {
+        id: 2,
+        cli_key: "claude",
+        name: "Beta Gateway",
+        enabled: true,
+        base_urls: ["https://b"],
+        base_url_mode: "ping",
+        cost_multiplier: 1,
+        claude_models: {},
+        tags: ["prod"],
+      },
+    ] as any[];
+
+    vi.mocked(useProvidersListQuery).mockReturnValue({
+      data: providers,
+      isFetching: false,
+    } as any);
+    vi.mocked(useGatewayCircuitStatusQuery).mockReturnValue({
+      data: [],
+      isFetching: false,
+      refetch: vi.fn(),
+    } as any);
+    vi.mocked(useProviderSetEnabledMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
+    vi.mocked(useProviderDeleteMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
+    vi.mocked(useProvidersReorderMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
+    vi.mocked(useDefaultRouteProvidersQuery).mockReturnValue({
+      data: [{ provider_id: 1 }, { provider_id: 2 }],
+      isFetching: false,
+    } as any);
+    vi.mocked(useGatewayCircuitResetProviderMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+    } as any);
+    vi.mocked(useGatewayCircuitResetCliMutation).mockReturnValue({ mutateAsync: vi.fn() } as any);
+
+    renderWithQuery(<ProvidersView activeCli="claude" setActiveCli={vi.fn()} />);
+
+    // Filtering hides Alpha Relay from the pool list (only the route sidebar copy remains).
+    fireEvent.change(screen.getByRole("textbox", { name: "搜索供应商名称" }), {
+      target: { value: "beta" },
+    });
+    expect(screen.getByText("共 1 / 2 条")).toBeInTheDocument();
+    expect(screen.getAllByText("Alpha Relay")).toHaveLength(1);
+
+    // Locate from the route order: clears the search filter and scrolls to the card.
+    fireEvent.click(screen.getByRole("button", { name: "定位 Alpha Relay 到供应商卡片" }));
+
+    await waitFor(() => expect(screen.getByText("共 2 / 2 条")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText("Alpha Relay").length).toBeGreaterThan(1));
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+  });
+
   it("lets sort mode providers be re-enabled from the route order switch", async () => {
     const providers = [
       {


### PR DESCRIPTION
Fixes #372

## Summary

「调用顺序」侧栏每项新增**定位图标**（LocateFixed）。点击后清空当前搜索 / 标签过滤条件，列表恢复全部供应商，并**平滑滚动定位**到对应的供应商卡片处，方便快速查看与编辑配置。

## 改动要点

- `ProvidersView.tsx`：`RouteOrderItemTrailing` 新增定位按钮；`handleLocateProvider` 先清空 `setProviderSearch` / `setSelectedTags`，再滚动到 `data-provider-id` 对应卡片
- `SortableProviderCard.tsx`：卡片容器增加 `data-provider-id` 属性，供定位查询
- 定位滚动对齐到列表**可视区顶部**（`block: "start"`），而非居中，便于查看目标卡片及其后序卡片

## 影响范围

仅供应商页「调用顺序」侧栏与供应商卡片列表，不涉及协议层 / 后端改动。

## Test plan

- [x] `vitest`：`ProvidersView` 36 个用例全过（含新增定位用例，断言 `scrollIntoView` 收到 `{ behavior: "smooth", block: "start" }`）
- [x] pre-commit / pre-push：lint / typecheck / 15 项门禁全过（含覆盖率分片、tauri test、clippy）
- [x] 本地打包：`tauri build --target aarch64-apple-darwin` 构建 `.app`，内嵌含定位功能的 dist
- [x] 手动验证：搜索框过滤掉某个卡片 → 点击该卡片在调用顺序侧栏的定位图标 → 过滤清空、列表恢复全部、平滑滚动定位到该卡片（可视区顶部）