### PR TITLE
feat(oauth): 上游代理同时作用于 OAuth 登录、令牌刷新与额度查询

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,42 +1,22 @@
-fn embed_windows_test_manifest() {
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").ok();
-    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").ok();
-    if target_os.as_deref() != Some("windows") || target_env.as_deref() != Some("msvc") {
-        return;
-    }
-
-    // Windows cargo test integration binaries do not get the Tauri app manifest by default.
-    // That leaves the test exe without a resource section, so desktop dependencies such as
-    // comctl32 may resolve the legacy Common Controls DLL and fail at process startup
-    // (STATUS_ENTRYPOINT_NOT_FOUND) before any Rust test code runs.
-    let manifest = r#"<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <dependency>
-    <dependentAssembly>
-      <assemblyIdentity
-        type="win32"
-        name="Microsoft.Windows.Common-Controls"
-        version="6.0.0.0"
-        processorArchitecture="*"
-        publicKeyToken="6595b64144ccf1df"
-        language="*"
-      />
-    </dependentAssembly>
-  </dependency>
-</assembly>
-"#;
-
-    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR"));
-    let manifest_path = out_dir.join("windows-test-manifest.xml");
-    std::fs::write(&manifest_path, manifest).expect("write windows test manifest");
-
-    println!("cargo:rustc-link-arg-tests=/MANIFEST:EMBED");
-    println!(
-        "cargo:rustc-link-arg-tests=/MANIFESTINPUT:{}",
-        manifest_path.display()
-    );
-}
-
 fn main() {
-    embed_windows_test_manifest();
-    tauri_build::build()
+    let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+
+    let attributes = if is_windows_msvc {
+        // tauri-build's resource manifest only reaches app binaries. Let the linker add the
+        // Common Controls v6 dependency to every artifact, including the lib test harness.
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!(
+            "cargo:rustc-link-arg=/MANIFESTDEPENDENCY:type='win32' \
+             name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
+             processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'"
+        );
+
+        tauri_build::Attributes::new()
+            .windows_attributes(tauri_build::WindowsAttributes::new_without_app_manifest())
+    } else {
+        tauri_build::Attributes::new()
+    };
+
+    tauri_build::try_build(attributes).expect("failed to run tauri build script");
 }

--- a/src-tauri/src/commands/providers/oauth.rs
+++ b/src-tauri/src/commands/providers/oauth.rs
@@ -394,7 +394,7 @@ pub(crate) async fn provider_oauth_start_flow(
     ensure_current_oauth_flow(&flow_id)?;
 
     // 8. Exchange code for tokens
-    let client = crate::gateway::oauth::build_default_oauth_http_client()?;
+    let client = crate::gateway::oauth::build_default_oauth_http_client(&app)?;
     let token_set = crate::gateway::oauth::token_exchange::exchange_authorization_code(
         &client,
         &crate::gateway::oauth::token_exchange::TokenExchangeRequest {
@@ -463,7 +463,7 @@ pub(crate) async fn provider_oauth_start_device_flow(
     db_state: tauri::State<'_, DbInitState>,
     provider_id: i64,
 ) -> Result<ProviderOAuthDeviceCodeStartResult, String> {
-    let db = ensure_db_ready(app, db_state.inner()).await?;
+    let db = ensure_db_ready(app.clone(), db_state.inner()).await?;
     let provider_cli_key =
         blocking::run("provider_oauth_start_device_flow_load_provider_cli_key", {
             let db = db.clone();
@@ -488,7 +488,7 @@ pub(crate) async fn provider_oauth_start_device_flow(
         .get_by_cli_key(&provider_cli_key)
         .ok_or_else(|| format!("no OAuth adapter for cli_key={provider_cli_key}"))?;
     let endpoints = adapter.endpoints();
-    let client = crate::gateway::oauth::build_default_oauth_http_client()?;
+    let client = crate::gateway::oauth::build_default_oauth_http_client(&app)?;
     let flow_id = crate::gateway::oauth::begin_flow_lifecycle().flow_id;
 
     if provider_cli_key == "grok" {
@@ -639,7 +639,7 @@ pub(crate) async fn provider_oauth_poll_device_flow(
         .get_by_cli_key(&provider_cli_key)
         .ok_or_else(|| format!("no OAuth adapter for cli_key={provider_cli_key}"))?;
     let endpoints = adapter.endpoints();
-    let client = crate::gateway::oauth::build_default_oauth_http_client()?;
+    let client = crate::gateway::oauth::build_default_oauth_http_client(&app)?;
 
     let oauth_token_set = if provider_cli_key == "grok" {
         match poll_grok_device_token(
@@ -873,7 +873,7 @@ pub(crate) async fn provider_oauth_refresh(
     db_state: tauri::State<'_, DbInitState>,
     provider_id: i64,
 ) -> Result<ProviderOAuthRefreshResult, String> {
-    let db = ensure_db_ready(app, db_state.inner()).await?;
+    let db = ensure_db_ready(app.clone(), db_state.inner()).await?;
 
     let details = blocking::run("provider_oauth_refresh_load", {
         let db = db.clone();
@@ -898,7 +898,7 @@ pub(crate) async fn provider_oauth_refresh(
         .ok_or("provider missing refresh_token")?
         .to_string();
 
-    let client = crate::gateway::oauth::build_default_oauth_http_client()?;
+    let client = crate::gateway::oauth::build_default_oauth_http_client(&app)?;
     let token_set = crate::gateway::oauth::refresh::refresh_provider_token_with_retry(
         &client,
         &token_uri,

--- a/src-tauri/src/commands/providers/oauth_limits.rs
+++ b/src-tauri/src/commands/providers/oauth_limits.rs
@@ -24,7 +24,7 @@ pub(crate) async fn provider_oauth_fetch_limits(
     db_state: tauri::State<'_, DbInitState>,
     provider_id: i64,
 ) -> Result<ProviderOAuthLimitsResult, String> {
-    let db = ensure_db_ready(app, db_state.inner()).await?;
+    let db = ensure_db_ready(app.clone(), db_state.inner()).await?;
     let mut details = blocking::run("provider_oauth_fetch_limits_load", {
         let db = db.clone();
         move || crate::providers::get_oauth_details(&db, provider_id)
@@ -36,6 +36,7 @@ pub(crate) async fn provider_oauth_fetch_limits(
         &format!("aio-coding-hub-oauth-command/{}", env!("CARGO_PKG_VERSION")),
         15,
         10,
+        crate::gateway::oauth::resolve_app_configured_proxy_url(&app).as_deref(),
     )?;
 
     if oauth_details_can_refresh(&details)

--- a/src-tauri/src/commands/providers/oauth_limits.rs
+++ b/src-tauri/src/commands/providers/oauth_limits.rs
@@ -33,10 +33,10 @@ pub(crate) async fn provider_oauth_fetch_limits(
     .map_err(Into::<String>::into)?;
     let adapter = crate::gateway::oauth::registry::resolve_oauth_adapter_for_details(&details)?;
     let client = crate::gateway::oauth::build_oauth_http_client(
+        &app,
         &format!("aio-coding-hub-oauth-command/{}", env!("CARGO_PKG_VERSION")),
         15,
         10,
-        crate::gateway::oauth::resolve_app_configured_proxy_url(&app).as_deref(),
     )?;
 
     if oauth_details_can_refresh(&details)

--- a/src-tauri/src/commands/providers/oauth_reset.rs
+++ b/src-tauri/src/commands/providers/oauth_reset.rs
@@ -268,7 +268,7 @@ pub(crate) async fn provider_oauth_reset_codex_quota(
 ) -> Result<ProviderOAuthResetCodexQuotaResult, String> {
     require_codex_reset_confirm(provider_id, confirm)?;
 
-    let db = ensure_db_ready(app, db_state.inner()).await?;
+    let db = ensure_db_ready(app.clone(), db_state.inner()).await?;
     let mut details = blocking::run("provider_oauth_reset_codex_quota_load", {
         let db = db.clone();
         move || crate::providers::get_oauth_details(&db, provider_id)
@@ -283,6 +283,7 @@ pub(crate) async fn provider_oauth_reset_codex_quota(
         &format!("aio-coding-hub-oauth-reset/{}", env!("CARGO_PKG_VERSION")),
         20,
         10,
+        crate::gateway::oauth::resolve_app_configured_proxy_url(&app).as_deref(),
     )?;
 
     if super::oauth::oauth_details_can_refresh(&details)

--- a/src-tauri/src/commands/providers/oauth_reset.rs
+++ b/src-tauri/src/commands/providers/oauth_reset.rs
@@ -280,10 +280,10 @@ pub(crate) async fn provider_oauth_reset_codex_quota(
 
     let adapter = crate::gateway::oauth::registry::resolve_oauth_adapter_for_details(&details)?;
     let client = crate::gateway::oauth::build_oauth_http_client(
+        &app,
         &format!("aio-coding-hub-oauth-reset/{}", env!("CARGO_PKG_VERSION")),
         20,
         10,
-        crate::gateway::oauth::resolve_app_configured_proxy_url(&app).as_deref(),
     )?;
 
     if super::oauth::oauth_details_can_refresh(&details)

--- a/src-tauri/src/gateway/background_tasks.rs
+++ b/src-tauri/src/gateway/background_tasks.rs
@@ -21,11 +21,11 @@ pub(super) struct GatewayBackgroundTasks {
 
 impl GatewayBackgroundTasks {
     pub(super) fn start<R: tauri::Runtime>(app: tauri::AppHandle<R>, db: db::Db) -> Self {
-        let (log_tx, log_task) = request_logs::start_buffered_writer(app, db.clone());
+        let (log_tx, log_task) = request_logs::start_buffered_writer(app.clone(), db.clone());
         let (circuit_persist_tx, circuit_task) =
             provider_circuit_breakers::start_buffered_writer(db.clone());
         let (oauth_refresh_shutdown, oauth_refresh_rx) = watch::channel(false);
-        let oauth_refresh_task = super::oauth::refresh_loop::spawn(db, oauth_refresh_rx);
+        let oauth_refresh_task = super::oauth::refresh_loop::spawn(app, db, oauth_refresh_rx);
 
         Self {
             log_tx,

--- a/src-tauri/src/gateway/http_client.rs
+++ b/src-tauri/src/gateway/http_client.rs
@@ -402,6 +402,23 @@ fn proxy_uses_socks5_local_dns(proxy_url: &str) -> bool {
         .is_some_and(|parsed| parsed.scheme() == "socks5")
 }
 
+/// Force IPv4-first DNS resolution when an explicit `socks5://` proxy is used.
+///
+/// `socks5://` (unlike `socks5h://`) resolves hostnames locally, and many local
+/// SOCKS5 clients cannot reach an AAAA result, so every client that installs an
+/// explicit proxy must apply this before adding the proxy — the gateway's
+/// outbound client and the OAuth clients in [`crate::gateway::oauth`] alike.
+pub(crate) fn apply_socks5_local_dns_workaround(
+    builder: reqwest::ClientBuilder,
+    proxy_url: &str,
+) -> reqwest::ClientBuilder {
+    if proxy_uses_socks5_local_dns(proxy_url) {
+        builder.dns_resolver2(Ipv4FirstResolver)
+    } else {
+        builder
+    }
+}
+
 fn proxy_test_url() -> String {
     #[cfg(test)]
     if let Some(lock) = TEST_PROXY_TEST_URL_OVERRIDE.get() {
@@ -648,7 +665,12 @@ pub fn is_proxy_enabled() -> bool {
     get_current_proxy_url().is_some()
 }
 
-fn effective_proxy_url(settings: &AppSettings) -> Result<Option<String>, String> {
+/// Resolve the effective upstream proxy URL (with credentials) from settings,
+/// or `None` when the upstream proxy toggle is disabled.
+///
+/// Shared by the gateway's outbound client and by OAuth login/refresh clients
+/// ([`crate::gateway::oauth`]) so a single "Upstream Proxy" setting covers both.
+pub(crate) fn effective_proxy_url(settings: &AppSettings) -> Result<Option<String>, String> {
     if !settings.upstream_proxy_enabled {
         return Ok(None);
     }
@@ -837,9 +859,7 @@ fn build_client_with_redirect(
 
     if let Some(url) = proxy_url {
         validate_proxy_url(url)?;
-        if proxy_uses_socks5_local_dns(url) {
-            builder = builder.dns_resolver2(Ipv4FirstResolver);
-        }
+        builder = apply_socks5_local_dns_workaround(builder, url);
         let proxy = reqwest::Proxy::all(url)
             .map_err(|e| format!("Invalid proxy URL '{}': {}", mask_url(url), e))?;
         builder = builder.proxy(proxy);

--- a/src-tauri/src/gateway/http_client.rs
+++ b/src-tauri/src/gateway/http_client.rs
@@ -674,6 +674,9 @@ pub(crate) fn effective_proxy_url(settings: &AppSettings) -> Result<Option<Strin
     if !settings.upstream_proxy_enabled {
         return Ok(None);
     }
+    if settings.upstream_proxy_url.trim().is_empty() {
+        return Err("Upstream proxy URL cannot be empty when proxy is enabled".to_string());
+    }
 
     build_effective_proxy_url(
         Some(settings.upstream_proxy_url.as_str()),
@@ -864,11 +867,8 @@ fn build_client_with_redirect(
             .map_err(|e| format!("Invalid proxy URL '{}': {}", mask_url(url), e))?;
         builder = builder.proxy(proxy);
         tracing::debug!("[HttpClient] Proxy configured: {}", mask_url(url));
-    } else if system_proxy_points_to_gateway() {
-        builder = builder.no_proxy();
-        tracing::warn!("[HttpClient] System proxy points to gateway, bypassing to avoid recursion");
     } else {
-        tracing::debug!("[HttpClient] Following system proxy (no explicit proxy configured)");
+        builder = apply_system_proxy_self_loop_guard(builder);
     }
 
     builder
@@ -893,6 +893,21 @@ fn system_proxy_points_to_gateway() -> bool {
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .any(|value| proxy_points_to_gateway_with_context(&value, &context))
+}
+
+/// Disable automatic system proxies when they point back at this gateway.
+/// Clients with an explicit proxy must not call this helper because an explicit
+/// proxy is an intentional override.
+pub(crate) fn apply_system_proxy_self_loop_guard(
+    builder: reqwest::ClientBuilder,
+) -> reqwest::ClientBuilder {
+    if system_proxy_points_to_gateway() {
+        tracing::warn!("[HttpClient] System proxy points to gateway, bypassing to avoid recursion");
+        builder.no_proxy()
+    } else {
+        tracing::debug!("[HttpClient] Following system proxy (no explicit proxy configured)");
+        builder
+    }
 }
 
 fn proxy_points_to_gateway_with_context(value: &str, context: &GatewaySelfCheckContext) -> bool {
@@ -928,6 +943,8 @@ pub fn mask_url(url: &str) -> String {
             Some(port) => format!("{}://{}:{}", parsed.scheme(), host, port),
             None => format!("{}://{}", parsed.scheme(), host),
         }
+    } else if url.contains('@') {
+        "[redacted]".to_string()
     } else if url.len() > 20 {
         format!("{}...", &url[..20])
     } else {
@@ -1271,6 +1288,19 @@ mod tests {
         let err = validate_proxy_for_settings(&settings)
             .expect_err("mixed credentials should be rejected");
         assert!(err.contains("either in proxy URL or username/password fields"));
+    }
+
+    #[test]
+    fn test_effective_proxy_url_rejects_enabled_proxy_without_url() {
+        let settings = AppSettings {
+            upstream_proxy_enabled: true,
+            upstream_proxy_url: "   ".to_string(),
+            ..AppSettings::default()
+        };
+
+        let err = effective_proxy_url(&settings)
+            .expect_err("enabled upstream proxy must require a proxy URL");
+        assert!(err.contains("cannot be empty"));
     }
 
     #[test]

--- a/src-tauri/src/gateway/oauth/mod.rs
+++ b/src-tauri/src/gateway/oauth/mod.rs
@@ -103,13 +103,49 @@ pub(crate) const DEFAULT_OAUTH_TIMEOUT_SECS: u64 = 30;
 /// Default connect timeout in seconds for OAuth HTTP requests.
 pub(crate) const DEFAULT_OAUTH_CONNECT_TIMEOUT_SECS: u64 = 15;
 
-/// Build an HTTP client with default OAuth settings.
-pub(crate) fn build_default_oauth_http_client() -> Result<reqwest::Client, String> {
+/// Build an HTTP client with default OAuth settings, honoring the app's
+/// configured upstream proxy (Settings → 上游代理) in addition to env overrides.
+pub(crate) fn build_default_oauth_http_client<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Result<reqwest::Client, String> {
     build_oauth_http_client(
         DEFAULT_OAUTH_USER_AGENT,
         DEFAULT_OAUTH_TIMEOUT_SECS,
         DEFAULT_OAUTH_CONNECT_TIMEOUT_SECS,
+        resolve_app_configured_proxy_url(app).as_deref(),
     )
+}
+
+/// Resolve the app's configured upstream proxy URL (Settings → 上游代理) for use
+/// by OAuth HTTP clients. Returns `None` (after logging) if settings can't be
+/// read or the configured proxy is invalid, so a local settings hiccup never
+/// hard-fails a login/refresh attempt — it just falls back to no explicit proxy.
+pub(crate) fn resolve_app_configured_proxy_url<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Option<String> {
+    let settings = match crate::settings::read(app) {
+        Ok(settings) => settings,
+        Err(err) => {
+            tracing::warn!("oauth: failed to read app settings for proxy resolution: {err}");
+            return None;
+        }
+    };
+
+    // Run the same validation the gateway applies when it installs the proxy
+    // (scheme/format plus the self-loop guard), so a hand-edited settings.json
+    // can never point OAuth traffic back at the gateway itself.
+    if let Err(err) = super::http_client::validate_proxy_for_settings(&settings) {
+        tracing::warn!("oauth: ignoring invalid configured upstream proxy: {err}");
+        return None;
+    }
+
+    match super::http_client::effective_proxy_url(&settings) {
+        Ok(url) => url,
+        Err(err) => {
+            tracing::warn!("oauth: ignoring invalid configured upstream proxy: {err}");
+            None
+        }
+    }
 }
 
 fn mask_oauth_proxy_env_value(value: &str) -> String {
@@ -125,34 +161,59 @@ fn mask_oauth_proxy_env_value(value: &str) -> String {
 
 /// Build an HTTP client suitable for OAuth token exchange and refresh requests.
 ///
-/// Respects standard proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`,
-/// `ALL_PROXY`) automatically via reqwest defaults.  Additionally, if the user
-/// has set `AIO_OAUTH_PROXY_URL`, that URL will be configured as an explicit
-/// "all traffic" proxy, which is useful in corporate environments where system
-/// proxy detection is insufficient.
+/// Proxy resolution order:
+/// 1. `AIO_OAUTH_PROXY_URL` env var — explicit override for advanced/dev setups.
+///    An empty/whitespace value counts as unset so it cannot silently shadow the
+///    app-configured proxy.
+/// 2. `configured_proxy_url` — the app's Settings → 上游代理 (Upstream Proxy),
+///    resolved via [`resolve_app_configured_proxy_url`]. This is the same proxy
+///    the gateway uses for upstream API calls (supports `http(s)://` and
+///    `socks5(h)://`), so enabling it also routes OAuth login/refresh/reset
+///    traffic — no separate proxy setup is needed to log in from behind a firewall.
+/// 3. Standard proxy env vars (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`), picked
+///    up automatically via reqwest defaults.
 pub(crate) fn build_oauth_http_client(
     user_agent: &str,
     timeout_secs: u64,
     connect_timeout_secs: u64,
+    configured_proxy_url: Option<&str>,
 ) -> Result<reqwest::Client, String> {
     let mut builder = reqwest::Client::builder()
         .user_agent(user_agent)
         .timeout(std::time::Duration::from_secs(timeout_secs))
         .connect_timeout(std::time::Duration::from_secs(connect_timeout_secs));
 
-    // Explicit proxy override from dedicated env var.
-    if let Ok(proxy_url) = std::env::var("AIO_OAUTH_PROXY_URL") {
-        let trimmed = proxy_url.trim();
-        if !trimmed.is_empty() {
-            let masked = mask_oauth_proxy_env_value(trimmed);
-            tracing::info!(
-                proxy_url = %masked,
-                "oauth: using explicit proxy from AIO_OAUTH_PROXY_URL"
-            );
-            let proxy = reqwest::Proxy::all(trimmed)
-                .map_err(|e| format!("invalid AIO_OAUTH_PROXY_URL={masked}: {e}"))?;
-            builder = builder.proxy(proxy);
-        }
+    // Explicit proxy override from dedicated env var. An empty value is treated
+    // as unset: otherwise `AIO_OAUTH_PROXY_URL=` (common in container/launcher
+    // setups) would fall into this branch and silently drop the configured proxy.
+    let env_override = std::env::var("AIO_OAUTH_PROXY_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    if let Some(proxy_url) = env_override.as_deref() {
+        let masked = mask_oauth_proxy_env_value(proxy_url);
+        tracing::info!(
+            proxy_url = %masked,
+            "oauth: using explicit proxy from AIO_OAUTH_PROXY_URL"
+        );
+        let proxy = reqwest::Proxy::all(proxy_url)
+            .map_err(|e| format!("invalid AIO_OAUTH_PROXY_URL={masked}: {e}"))?;
+        builder = super::http_client::apply_socks5_local_dns_workaround(builder, proxy_url);
+        builder = builder.proxy(proxy);
+    } else if let Some(proxy_url) = configured_proxy_url
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        let masked = mask_oauth_proxy_env_value(proxy_url);
+        tracing::info!(
+            proxy_url = %masked,
+            "oauth: using app-configured upstream proxy"
+        );
+        let proxy = reqwest::Proxy::all(proxy_url)
+            .map_err(|e| format!("invalid upstream proxy '{masked}': {e}"))?;
+        builder = super::http_client::apply_socks5_local_dns_workaround(builder, proxy_url);
+        builder = builder.proxy(proxy);
     } else {
         // Log which standard proxy env vars are active for diagnostics.
         for var in [
@@ -192,9 +253,15 @@ mod tests {
     }
 
     impl EnvVarRestore {
-        fn set(key: &'static str, value: &str) -> Self {
+        fn set(key: &'static str, value: impl Into<OsString>) -> Self {
             let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
+            std::env::set_var(key, value.into());
+            Self { key, previous }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::remove_var(key);
             Self { key, previous }
         }
     }
@@ -242,13 +309,110 @@ mod tests {
         let _env_lock = crate::test_support::test_env_lock();
         let _restore = EnvVarRestore::set("AIO_OAUTH_PROXY_URL", "http://user:super-secret@");
 
-        let err = build_oauth_http_client("test-agent", 1, 1)
+        let err = build_oauth_http_client("test-agent", 1, 1, None)
             .expect_err("invalid explicit proxy should fail")
             .to_string();
 
         assert!(err.contains("[redacted]"));
         assert!(!err.contains("super-secret"));
         assert!(!err.contains("user:"));
+    }
+
+    #[test]
+    fn configured_proxy_url_is_applied_when_no_env_override() {
+        let _env_lock = crate::test_support::test_env_lock();
+        let _restore = EnvVarRestore::unset("AIO_OAUTH_PROXY_URL");
+
+        let result = build_oauth_http_client("test-agent", 1, 1, Some("socks5://127.0.0.1:1080"));
+
+        assert!(
+            result.is_ok(),
+            "configured socks5 proxy should build a client"
+        );
+    }
+
+    #[test]
+    fn env_override_takes_priority_over_configured_proxy_url() {
+        let _env_lock = crate::test_support::test_env_lock();
+        let _restore = EnvVarRestore::set("AIO_OAUTH_PROXY_URL", "http://user:super-secret@");
+
+        // Even though a valid configured proxy is supplied, the (invalid) env
+        // override must still win so `AIO_OAUTH_PROXY_URL` stays authoritative.
+        let err = build_oauth_http_client("test-agent", 1, 1, Some("socks5://127.0.0.1:1080"))
+            .expect_err("invalid env override should fail even with a valid configured proxy");
+
+        assert!(err.contains("AIO_OAUTH_PROXY_URL"));
+    }
+
+    #[test]
+    fn empty_env_override_falls_through_to_configured_proxy() {
+        let _env_lock = crate::test_support::test_env_lock();
+        let _restore = EnvVarRestore::set("AIO_OAUTH_PROXY_URL", "   ");
+
+        // The configured proxy is invalid, so surfacing *its* error proves the
+        // blank env override did not shadow it into a silent direct connection.
+        let err = build_oauth_http_client("test-agent", 1, 1, Some("http://user:super-secret@"))
+            .expect_err("invalid configured proxy should fail once the env override is blank");
+
+        assert!(err.contains("upstream proxy"));
+        assert!(!err.contains("AIO_OAUTH_PROXY_URL"));
+        assert!(err.contains("[redacted]"));
+        assert!(!err.contains("super-secret"));
+    }
+
+    #[test]
+    fn resolve_app_configured_proxy_url_reflects_settings() {
+        let _lock = crate::test_support::test_env_lock();
+        let home = tempfile::tempdir().expect("tempdir");
+        let home_dir = home.path().as_os_str().to_os_string();
+        // Drop guards, so a failed assertion cannot leak these into the rest of
+        // the (single-threaded) test binary and break every later settings read.
+        let _home_restore = EnvVarRestore::set("AIO_CODING_HUB_HOME_DIR", home_dir);
+        let dotdir = ".aio-coding-hub-oauth-proxy-test";
+        let _dotdir_restore = EnvVarRestore::set("AIO_CODING_HUB_DOTDIR_NAME", dotdir);
+        crate::test_support::clear_settings_cache();
+
+        let app = tauri::test::mock_app();
+        let handle = app.handle().clone();
+
+        assert_eq!(resolve_app_configured_proxy_url(&handle), None);
+
+        let mut settings = crate::settings::read(&handle).expect("read default settings");
+        settings.upstream_proxy_enabled = true;
+        settings.upstream_proxy_url = "socks5://ssh-proxy:1080".to_string();
+        crate::settings::write(&handle, &settings).expect("persist settings");
+        crate::test_support::clear_settings_cache();
+
+        let resolved = resolve_app_configured_proxy_url(&handle).expect("proxy should resolve");
+        let parsed = reqwest::Url::parse(&resolved).expect("resolved proxy url should parse");
+        assert_eq!(parsed.scheme(), "socks5");
+        assert_eq!(parsed.host_str(), Some("ssh-proxy"));
+        assert_eq!(parsed.port(), Some(1080));
+    }
+
+    #[test]
+    fn resolve_app_configured_proxy_url_rejects_gateway_self_loop() {
+        let _lock = crate::test_support::test_env_lock();
+        let home = tempfile::tempdir().expect("tempdir");
+        let home_dir = home.path().as_os_str().to_os_string();
+        let _home_restore = EnvVarRestore::set("AIO_CODING_HUB_HOME_DIR", home_dir);
+        let dotdir = ".aio-coding-hub-oauth-self-loop-test";
+        let _dotdir_restore = EnvVarRestore::set("AIO_CODING_HUB_DOTDIR_NAME", dotdir);
+        crate::test_support::clear_settings_cache();
+
+        let app = tauri::test::mock_app();
+        let handle = app.handle().clone();
+
+        let mut settings = crate::settings::read(&handle).expect("read default settings");
+        let gateway_proxy_url = format!("http://127.0.0.1:{}", settings.preferred_port);
+        settings.upstream_proxy_enabled = true;
+        settings.upstream_proxy_url = gateway_proxy_url;
+        crate::settings::write(&handle, &settings).expect("persist settings");
+        crate::test_support::clear_settings_cache();
+
+        // A hand-edited settings.json pointing at the gateway must not be used
+        // for OAuth traffic either — the gateway rejects it for the same reason.
+        assert_eq!(resolve_app_configured_proxy_url(&handle), None);
     }
 
     #[test]

--- a/src-tauri/src/gateway/oauth/mod.rs
+++ b/src-tauri/src/gateway/oauth/mod.rs
@@ -109,43 +109,24 @@ pub(crate) fn build_default_oauth_http_client<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
 ) -> Result<reqwest::Client, String> {
     build_oauth_http_client(
+        app,
         DEFAULT_OAUTH_USER_AGENT,
         DEFAULT_OAUTH_TIMEOUT_SECS,
         DEFAULT_OAUTH_CONNECT_TIMEOUT_SECS,
-        resolve_app_configured_proxy_url(app).as_deref(),
     )
 }
 
-/// Resolve the app's configured upstream proxy URL (Settings → 上游代理) for use
-/// by OAuth HTTP clients. Returns `None` (after logging) if settings can't be
-/// read or the configured proxy is invalid, so a local settings hiccup never
-/// hard-fails a login/refresh attempt — it just falls back to no explicit proxy.
-pub(crate) fn resolve_app_configured_proxy_url<R: tauri::Runtime>(
+fn resolve_app_configured_proxy_url<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
-) -> Option<String> {
-    let settings = match crate::settings::read(app) {
-        Ok(settings) => settings,
-        Err(err) => {
-            tracing::warn!("oauth: failed to read app settings for proxy resolution: {err}");
-            return None;
-        }
-    };
+) -> Result<Option<String>, String> {
+    let settings = crate::settings::read(app)
+        .map_err(|err| format!("oauth upstream proxy settings unavailable: {err}"))?;
 
-    // Run the same validation the gateway applies when it installs the proxy
-    // (scheme/format plus the self-loop guard), so a hand-edited settings.json
-    // can never point OAuth traffic back at the gateway itself.
-    if let Err(err) = super::http_client::validate_proxy_for_settings(&settings) {
-        tracing::warn!("oauth: ignoring invalid configured upstream proxy: {err}");
-        return None;
-    }
+    super::http_client::validate_proxy_for_settings(&settings)
+        .map_err(|err| format!("invalid app upstream proxy settings: {err}"))?;
 
-    match super::http_client::effective_proxy_url(&settings) {
-        Ok(url) => url,
-        Err(err) => {
-            tracing::warn!("oauth: ignoring invalid configured upstream proxy: {err}");
-            None
-        }
-    }
+    super::http_client::effective_proxy_url(&settings)
+        .map_err(|err| format!("invalid app upstream proxy settings: {err}"))
 }
 
 fn mask_oauth_proxy_env_value(value: &str) -> String {
@@ -165,18 +146,17 @@ fn mask_oauth_proxy_env_value(value: &str) -> String {
 /// 1. `AIO_OAUTH_PROXY_URL` env var — explicit override for advanced/dev setups.
 ///    An empty/whitespace value counts as unset so it cannot silently shadow the
 ///    app-configured proxy.
-/// 2. `configured_proxy_url` — the app's Settings → 上游代理 (Upstream Proxy),
-///    resolved via [`resolve_app_configured_proxy_url`]. This is the same proxy
+/// 2. The app's Settings → 上游代理 (Upstream Proxy). This is the same proxy
 ///    the gateway uses for upstream API calls (supports `http(s)://` and
 ///    `socks5(h)://`), so enabling it also routes OAuth login/refresh/reset
 ///    traffic — no separate proxy setup is needed to log in from behind a firewall.
 /// 3. Standard proxy env vars (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`), picked
 ///    up automatically via reqwest defaults.
-pub(crate) fn build_oauth_http_client(
+pub(crate) fn build_oauth_http_client<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     user_agent: &str,
     timeout_secs: u64,
     connect_timeout_secs: u64,
-    configured_proxy_url: Option<&str>,
 ) -> Result<reqwest::Client, String> {
     let mut builder = reqwest::Client::builder()
         .user_agent(user_agent)
@@ -201,38 +181,20 @@ pub(crate) fn build_oauth_http_client(
             .map_err(|e| format!("invalid AIO_OAUTH_PROXY_URL={masked}: {e}"))?;
         builder = super::http_client::apply_socks5_local_dns_workaround(builder, proxy_url);
         builder = builder.proxy(proxy);
-    } else if let Some(proxy_url) = configured_proxy_url
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
-        let masked = mask_oauth_proxy_env_value(proxy_url);
-        tracing::info!(
-            proxy_url = %masked,
-            "oauth: using app-configured upstream proxy"
-        );
-        let proxy = reqwest::Proxy::all(proxy_url)
-            .map_err(|e| format!("invalid upstream proxy '{masked}': {e}"))?;
-        builder = super::http_client::apply_socks5_local_dns_workaround(builder, proxy_url);
-        builder = builder.proxy(proxy);
     } else {
-        // Log which standard proxy env vars are active for diagnostics.
-        for var in [
-            "HTTPS_PROXY",
-            "HTTP_PROXY",
-            "ALL_PROXY",
-            "https_proxy",
-            "http_proxy",
-            "all_proxy",
-        ] {
-            if let Ok(val) = std::env::var(var) {
-                if !val.is_empty() {
-                    tracing::debug!(
-                        env_var = var,
-                        value = %mask_oauth_proxy_env_value(&val),
-                        "oauth: detected proxy env var"
-                    );
-                }
-            }
+        let configured_proxy_url = resolve_app_configured_proxy_url(app)?;
+        if let Some(proxy_url) = configured_proxy_url.as_deref() {
+            let masked = mask_oauth_proxy_env_value(proxy_url);
+            tracing::info!(
+                proxy_url = %masked,
+                "oauth: using app-configured upstream proxy"
+            );
+            let proxy = reqwest::Proxy::all(proxy_url)
+                .map_err(|e| format!("invalid upstream proxy '{masked}': {e}"))?;
+            builder = super::http_client::apply_socks5_local_dns_workaround(builder, proxy_url);
+            builder = builder.proxy(proxy);
+        } else {
+            builder = super::http_client::apply_system_proxy_self_loop_guard(builder);
         }
     }
 
@@ -245,7 +207,11 @@ pub(crate) fn build_oauth_http_client(
 mod tests {
     use super::*;
     use std::ffi::OsString;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{mpsc, Mutex, MutexGuard, OnceLock};
+    use std::thread;
+    use std::time::Duration;
 
     struct EnvVarRestore {
         key: &'static str,
@@ -273,6 +239,65 @@ mod tests {
                 None => std::env::remove_var(self.key),
             }
         }
+    }
+
+    struct OAuthProxyTestGuard<'a> {
+        _guard: MutexGuard<'a, ()>,
+    }
+
+    fn oauth_proxy_test_lock() -> OAuthProxyTestGuard<'static> {
+        OAuthProxyTestGuard {
+            _guard: crate::test_support::test_env_lock(),
+        }
+    }
+
+    fn isolate_settings_env(
+        home: &tempfile::TempDir,
+        dotdir: &'static str,
+    ) -> (EnvVarRestore, EnvVarRestore) {
+        crate::test_support::clear_settings_cache();
+        (
+            EnvVarRestore::set(
+                "AIO_CODING_HUB_HOME_DIR",
+                home.path().as_os_str().to_os_string(),
+            ),
+            EnvVarRestore::set("AIO_CODING_HUB_DOTDIR_NAME", dotdir),
+        )
+    }
+
+    fn unset_standard_proxy_env() -> Vec<EnvVarRestore> {
+        [
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ]
+        .into_iter()
+        .map(EnvVarRestore::unset)
+        .collect()
+    }
+
+    fn spawn_recording_http_proxy() -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind proxy listener");
+        let addr = listener.local_addr().expect("proxy listener addr");
+        let (tx, rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept proxy request");
+            let mut buf = [0_u8; 4096];
+            let size = stream.read(&mut buf).expect("read proxy request");
+            tx.send(String::from_utf8_lossy(&buf[..size]).to_string())
+                .expect("record proxy request");
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .expect("write proxy response");
+        });
+
+        (format!("http://127.0.0.1:{}", addr.port()), rx)
     }
 
     fn oauth_flow_test_lock() -> MutexGuard<'static, ()> {
@@ -308,8 +333,9 @@ mod tests {
     fn explicit_oauth_proxy_error_masks_env_value() {
         let _env_lock = crate::test_support::test_env_lock();
         let _restore = EnvVarRestore::set("AIO_OAUTH_PROXY_URL", "http://user:super-secret@");
+        let app = tauri::test::mock_app();
 
-        let err = build_oauth_http_client("test-agent", 1, 1, None)
+        let err = build_oauth_http_client(app.handle(), "test-agent", 1, 1)
             .expect_err("invalid explicit proxy should fail")
             .to_string();
 
@@ -318,43 +344,140 @@ mod tests {
         assert!(!err.contains("user:"));
     }
 
-    #[test]
-    fn configured_proxy_url_is_applied_when_no_env_override() {
-        let _env_lock = crate::test_support::test_env_lock();
-        let _restore = EnvVarRestore::unset("AIO_OAUTH_PROXY_URL");
+    #[tokio::test(flavor = "current_thread")]
+    async fn blank_env_uses_app_proxy_for_real_request() {
+        let _env_lock = oauth_proxy_test_lock();
+        let home = tempfile::tempdir().expect("tempdir");
+        let (_home_restore, _dotdir_restore) =
+            isolate_settings_env(&home, ".aio-coding-hub-oauth-real-proxy-test");
+        let _oauth_proxy_restore = EnvVarRestore::set("AIO_OAUTH_PROXY_URL", "   ");
+        let _system_proxy_restores = unset_standard_proxy_env();
+        let (proxy_url, request_rx) = spawn_recording_http_proxy();
+        let app = tauri::test::mock_app();
 
-        let result = build_oauth_http_client("test-agent", 1, 1, Some("socks5://127.0.0.1:1080"));
+        let mut settings = crate::settings::read(app.handle()).expect("read default settings");
+        settings.upstream_proxy_enabled = true;
+        settings.upstream_proxy_url = proxy_url;
+        crate::settings::write(app.handle(), &settings).expect("persist settings");
 
-        assert!(
-            result.is_ok(),
-            "configured socks5 proxy should build a client"
-        );
+        let client = build_oauth_http_client(app.handle(), "test-agent", 3, 1)
+            .expect("configured proxy should build client");
+        let response = client
+            .get("http://oauth.example.test/token")
+            .send()
+            .await
+            .expect("OAuth request should use configured proxy");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let request = request_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("configured proxy should receive OAuth request");
+        assert!(request.starts_with("GET http://oauth.example.test/token HTTP/1.1"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn env_override_bypasses_unreadable_app_settings() {
+        let _env_lock = oauth_proxy_test_lock();
+        let home = tempfile::tempdir().expect("tempdir");
+        let (_home_restore, _dotdir_restore) =
+            isolate_settings_env(&home, ".aio-coding-hub-oauth-env-priority-test");
+        let _system_proxy_restores = unset_standard_proxy_env();
+        let (proxy_url, request_rx) = spawn_recording_http_proxy();
+        let _oauth_proxy_restore = EnvVarRestore::set("AIO_OAUTH_PROXY_URL", proxy_url.as_str());
+        let app = tauri::test::mock_app();
+        let settings_path = crate::app_paths::app_data_dir(app.handle())
+            .expect("resolve app data dir")
+            .join("settings.json");
+        std::fs::write(settings_path, b"{invalid-json").expect("write invalid settings");
+        crate::test_support::clear_settings_cache();
+
+        let client = build_oauth_http_client(app.handle(), "test-agent", 3, 1)
+            .expect("env override should avoid reading app settings");
+        let response = client
+            .get("http://oauth.example.test/device")
+            .send()
+            .await
+            .expect("OAuth request should use env proxy");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let request = request_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("env proxy should receive OAuth request");
+        assert!(request.starts_with("GET http://oauth.example.test/device HTTP/1.1"));
     }
 
     #[test]
-    fn env_override_takes_priority_over_configured_proxy_url() {
+    fn unreadable_app_settings_fail_closed_without_env_override() {
         let _env_lock = crate::test_support::test_env_lock();
-        let _restore = EnvVarRestore::set("AIO_OAUTH_PROXY_URL", "http://user:super-secret@");
+        let home = tempfile::tempdir().expect("tempdir");
+        let (_home_restore, _dotdir_restore) =
+            isolate_settings_env(&home, ".aio-coding-hub-oauth-settings-error-test");
+        let _oauth_proxy_restore = EnvVarRestore::unset("AIO_OAUTH_PROXY_URL");
+        let app = tauri::test::mock_app();
+        let settings_path = crate::app_paths::app_data_dir(app.handle())
+            .expect("resolve app data dir")
+            .join("settings.json");
+        std::fs::write(settings_path, b"{invalid-json").expect("write invalid settings");
+        crate::test_support::clear_settings_cache();
 
-        // Even though a valid configured proxy is supplied, the (invalid) env
-        // override must still win so `AIO_OAUTH_PROXY_URL` stays authoritative.
-        let err = build_oauth_http_client("test-agent", 1, 1, Some("socks5://127.0.0.1:1080"))
-            .expect_err("invalid env override should fail even with a valid configured proxy");
+        let err = build_oauth_http_client(app.handle(), "test-agent", 1, 1)
+            .expect_err("unreadable settings must not silently fall back")
+            .to_string();
 
-        assert!(err.contains("AIO_OAUTH_PROXY_URL"));
+        assert!(err.contains("oauth upstream proxy settings unavailable"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn automatic_system_proxy_self_loop_is_bypassed() {
+        let _env_lock = oauth_proxy_test_lock();
+        let home = tempfile::tempdir().expect("tempdir");
+        let (_home_restore, _dotdir_restore) =
+            isolate_settings_env(&home, ".aio-coding-hub-oauth-system-self-loop-test");
+        let _oauth_proxy_restore = EnvVarRestore::unset("AIO_OAUTH_PROXY_URL");
+        let _system_proxy_restores = unset_standard_proxy_env();
+        let (server_url, request_rx) = spawn_recording_http_proxy();
+        let port = reqwest::Url::parse(&server_url)
+            .expect("parse server URL")
+            .port()
+            .expect("server URL port");
+        let _http_proxy_restore = EnvVarRestore::set("HTTP_PROXY", server_url.as_str());
+        super::super::http_client::sync_runtime_context(port, "127.0.0.1", "127.0.0.1");
+        let app = tauri::test::mock_app();
+
+        let client = build_oauth_http_client(app.handle(), "test-agent", 3, 1)
+            .expect("system self-loop guard should build client");
+        let response = client
+            .get(format!("{server_url}/token"))
+            .send()
+            .await
+            .expect("self-loop proxy should be bypassed");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let request = request_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("origin should receive direct request");
+        assert!(request.starts_with("GET /token HTTP/1.1"));
     }
 
     #[test]
-    fn empty_env_override_falls_through_to_configured_proxy() {
+    fn enabled_invalid_app_proxy_fails_closed_without_leaking_credentials() {
         let _env_lock = crate::test_support::test_env_lock();
-        let _restore = EnvVarRestore::set("AIO_OAUTH_PROXY_URL", "   ");
+        let home = tempfile::tempdir().expect("tempdir");
+        let (_home_restore, _dotdir_restore) =
+            isolate_settings_env(&home, ".aio-coding-hub-oauth-fail-closed-test");
+        let _oauth_proxy_restore = EnvVarRestore::unset("AIO_OAUTH_PROXY_URL");
+        let app = tauri::test::mock_app();
 
-        // The configured proxy is invalid, so surfacing *its* error proves the
-        // blank env override did not shadow it into a silent direct connection.
-        let err = build_oauth_http_client("test-agent", 1, 1, Some("http://user:super-secret@"))
-            .expect_err("invalid configured proxy should fail once the env override is blank");
+        let mut settings = crate::settings::read(app.handle()).expect("read default settings");
+        settings.upstream_proxy_enabled = true;
+        settings.upstream_proxy_url = "http://user:super-secret@".to_string();
+        crate::settings::write(app.handle(), &settings).expect("persist settings");
 
-        assert!(err.contains("upstream proxy"));
+        let err = build_oauth_http_client(app.handle(), "test-agent", 1, 1)
+            .expect_err("invalid enabled proxy must not fall back")
+            .to_string();
+
+        assert!(err.contains("invalid app upstream proxy settings"));
         assert!(!err.contains("AIO_OAUTH_PROXY_URL"));
         assert!(err.contains("[redacted]"));
         assert!(!err.contains("super-secret"));
@@ -364,18 +487,16 @@ mod tests {
     fn resolve_app_configured_proxy_url_reflects_settings() {
         let _lock = crate::test_support::test_env_lock();
         let home = tempfile::tempdir().expect("tempdir");
-        let home_dir = home.path().as_os_str().to_os_string();
-        // Drop guards, so a failed assertion cannot leak these into the rest of
-        // the (single-threaded) test binary and break every later settings read.
-        let _home_restore = EnvVarRestore::set("AIO_CODING_HUB_HOME_DIR", home_dir);
-        let dotdir = ".aio-coding-hub-oauth-proxy-test";
-        let _dotdir_restore = EnvVarRestore::set("AIO_CODING_HUB_DOTDIR_NAME", dotdir);
-        crate::test_support::clear_settings_cache();
+        let (_home_restore, _dotdir_restore) =
+            isolate_settings_env(&home, ".aio-coding-hub-oauth-proxy-test");
 
         let app = tauri::test::mock_app();
         let handle = app.handle().clone();
 
-        assert_eq!(resolve_app_configured_proxy_url(&handle), None);
+        assert_eq!(
+            resolve_app_configured_proxy_url(&handle).expect("default settings should resolve"),
+            None
+        );
 
         let mut settings = crate::settings::read(&handle).expect("read default settings");
         settings.upstream_proxy_enabled = true;
@@ -383,7 +504,9 @@ mod tests {
         crate::settings::write(&handle, &settings).expect("persist settings");
         crate::test_support::clear_settings_cache();
 
-        let resolved = resolve_app_configured_proxy_url(&handle).expect("proxy should resolve");
+        let resolved = resolve_app_configured_proxy_url(&handle)
+            .expect("settings should be valid")
+            .expect("proxy should resolve");
         let parsed = reqwest::Url::parse(&resolved).expect("resolved proxy url should parse");
         assert_eq!(parsed.scheme(), "socks5");
         assert_eq!(parsed.host_str(), Some("ssh-proxy"));
@@ -394,11 +517,8 @@ mod tests {
     fn resolve_app_configured_proxy_url_rejects_gateway_self_loop() {
         let _lock = crate::test_support::test_env_lock();
         let home = tempfile::tempdir().expect("tempdir");
-        let home_dir = home.path().as_os_str().to_os_string();
-        let _home_restore = EnvVarRestore::set("AIO_CODING_HUB_HOME_DIR", home_dir);
-        let dotdir = ".aio-coding-hub-oauth-self-loop-test";
-        let _dotdir_restore = EnvVarRestore::set("AIO_CODING_HUB_DOTDIR_NAME", dotdir);
-        crate::test_support::clear_settings_cache();
+        let (_home_restore, _dotdir_restore) =
+            isolate_settings_env(&home, ".aio-coding-hub-oauth-self-loop-test");
 
         let app = tauri::test::mock_app();
         let handle = app.handle().clone();
@@ -410,9 +530,9 @@ mod tests {
         crate::settings::write(&handle, &settings).expect("persist settings");
         crate::test_support::clear_settings_cache();
 
-        // A hand-edited settings.json pointing at the gateway must not be used
-        // for OAuth traffic either — the gateway rejects it for the same reason.
-        assert_eq!(resolve_app_configured_proxy_url(&handle), None);
+        let err = resolve_app_configured_proxy_url(&handle)
+            .expect_err("gateway self-loop must fail closed");
+        assert!(err.contains("self-loop"));
     }
 
     #[test]

--- a/src-tauri/src/gateway/oauth/refresh_loop.rs
+++ b/src-tauri/src/gateway/oauth/refresh_loop.rs
@@ -22,25 +22,27 @@ enum RefreshLoopStep<T> {
 ///
 /// The loop runs until `shutdown_rx` receives a signal (the gateway stop path
 /// should send it). Returns a `JoinHandle` that can be used to await termination.
-pub(crate) fn spawn(
+pub(crate) fn spawn<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
     db: crate::db::Db,
     shutdown_rx: watch::Receiver<bool>,
 ) -> tauri::async_runtime::JoinHandle<()> {
     tauri::async_runtime::spawn(async move {
-        run_loop(db, shutdown_rx).await;
+        run_loop(app, db, shutdown_rx).await;
     })
 }
 
-async fn run_loop(db: crate::db::Db, mut shutdown_rx: watch::Receiver<bool>) {
-    let client = match super::build_default_oauth_http_client() {
-        Ok(client) => client,
-        Err(err) => {
-            tracing::error!("oauth_refresh_loop: failed to build http client: {err}");
-            return;
-        }
-    };
-
+async fn run_loop<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    db: crate::db::Db,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
     tracing::info!("oauth_refresh_loop: started (poll_interval={POLL_INTERVAL_SECS}s)");
+
+    // Kept across polls and rebuilt only when the configured upstream proxy
+    // changes, so a proxy toggled in Settings takes effect on the next refresh
+    // while the steady state still reuses pooled connections.
+    let mut cached_client: Option<(Option<String>, reqwest::Client)> = None;
 
     loop {
         match wait_for_next_poll_or_shutdown(
@@ -85,6 +87,34 @@ async fn run_loop(db: crate::db::Db, mut shutdown_rx: watch::Receiver<bool>) {
             "oauth_refresh_loop: {} provider(s) need token refresh",
             providers_to_refresh.len()
         );
+
+        let configured_proxy = super::resolve_app_configured_proxy_url(&app);
+        if cached_client
+            .as_ref()
+            .is_none_or(|(proxy, _)| *proxy != configured_proxy)
+        {
+            // Bound to a local first so the `configured_proxy` borrow ends here
+            // and the value can be moved into the cache below.
+            let built = super::build_oauth_http_client(
+                super::DEFAULT_OAUTH_USER_AGENT,
+                super::DEFAULT_OAUTH_TIMEOUT_SECS,
+                super::DEFAULT_OAUTH_CONNECT_TIMEOUT_SECS,
+                configured_proxy.as_deref(),
+            );
+            match built {
+                Ok(client) => cached_client = Some((configured_proxy, client)),
+                Err(err) => {
+                    tracing::error!("oauth_refresh_loop: failed to build http client: {err}");
+                    cached_client = None;
+                    continue;
+                }
+            }
+        }
+
+        let client = match cached_client.as_ref() {
+            Some((_, client)) => client.clone(),
+            None => continue,
+        };
 
         for details in providers_to_refresh {
             // Check for shutdown between each provider to avoid blocking exit.

--- a/src-tauri/src/gateway/oauth/refresh_loop.rs
+++ b/src-tauri/src/gateway/oauth/refresh_loop.rs
@@ -18,6 +18,37 @@ enum RefreshLoopStep<T> {
     Shutdown,
 }
 
+async fn persist_client_build_error(
+    db: &crate::db::Db,
+    provider_ids: &[i64],
+    error: &str,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> RefreshLoopStep<()> {
+    for &provider_id in provider_ids {
+        let db_for_error = db.clone();
+        let err_msg = error.to_string();
+        match await_with_shutdown(
+            shutdown_rx,
+            crate::blocking::run("oauth_refresh_loop_set_client_error", move || {
+                providers::set_oauth_last_error(&db_for_error, provider_id, &err_msg)
+            }),
+        )
+        .await
+        {
+            RefreshLoopStep::Completed(Ok(())) => {}
+            RefreshLoopStep::Completed(Err(persist_err)) => {
+                tracing::warn!(
+                    provider_id,
+                    "oauth_refresh_loop: failed to persist client error: {persist_err}"
+                );
+            }
+            RefreshLoopStep::Shutdown => return RefreshLoopStep::Shutdown,
+        }
+    }
+
+    RefreshLoopStep::Completed(())
+}
+
 /// Spawns the background OAuth refresh loop.
 ///
 /// The loop runs until `shutdown_rx` receives a signal (the gateway stop path
@@ -38,11 +69,6 @@ async fn run_loop<R: tauri::Runtime>(
     mut shutdown_rx: watch::Receiver<bool>,
 ) {
     tracing::info!("oauth_refresh_loop: started (poll_interval={POLL_INTERVAL_SECS}s)");
-
-    // Kept across polls and rebuilt only when the configured upstream proxy
-    // changes, so a proxy toggled in Settings takes effect on the next refresh
-    // while the steady state still reuses pooled connections.
-    let mut cached_client: Option<(Option<String>, reqwest::Client)> = None;
 
     loop {
         match wait_for_next_poll_or_shutdown(
@@ -88,32 +114,24 @@ async fn run_loop<R: tauri::Runtime>(
             providers_to_refresh.len()
         );
 
-        let configured_proxy = super::resolve_app_configured_proxy_url(&app);
-        if cached_client
-            .as_ref()
-            .is_none_or(|(proxy, _)| *proxy != configured_proxy)
-        {
-            // Bound to a local first so the `configured_proxy` borrow ends here
-            // and the value can be moved into the cache below.
-            let built = super::build_oauth_http_client(
-                super::DEFAULT_OAUTH_USER_AGENT,
-                super::DEFAULT_OAUTH_TIMEOUT_SECS,
-                super::DEFAULT_OAUTH_CONNECT_TIMEOUT_SECS,
-                configured_proxy.as_deref(),
-            );
-            match built {
-                Ok(client) => cached_client = Some((configured_proxy, client)),
-                Err(err) => {
-                    tracing::error!("oauth_refresh_loop: failed to build http client: {err}");
-                    cached_client = None;
-                    continue;
+        let client = match super::build_default_oauth_http_client(&app) {
+            Ok(client) => client,
+            Err(err) => {
+                tracing::error!("oauth_refresh_loop: failed to build http client: {err}");
+                let provider_ids = providers_to_refresh
+                    .iter()
+                    .map(|details| details.id)
+                    .collect::<Vec<_>>();
+                if let RefreshLoopStep::Shutdown =
+                    persist_client_build_error(&db, &provider_ids, &err, &mut shutdown_rx).await
+                {
+                    tracing::info!(
+                        "oauth_refresh_loop: shutdown while persisting client error, exiting"
+                    );
+                    return;
                 }
+                continue;
             }
-        }
-
-        let client = match cached_client.as_ref() {
-            Some((_, client)) => client.clone(),
-            None => continue,
         };
 
         for details in providers_to_refresh {
@@ -423,6 +441,49 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn client_build_error_is_persisted_for_each_provider() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = crate::db::init_for_tests(&dir.path().join("oauth-refresh-client-error.db"))
+            .expect("init db");
+        let provider_ids = {
+            let conn = db.open_connection().expect("open db");
+            for (id, name) in [(41_i64, "oauth-a"), (42_i64, "oauth-b")] {
+                conn.execute(
+                    "INSERT INTO providers(id, cli_key, name, base_url, api_key_plaintext, created_at, updated_at) VALUES (?1, 'codex', ?2, '', '', 1, 1)",
+                    rusqlite::params![id, name],
+                )
+                .expect("insert provider");
+            }
+            vec![41, 42]
+        };
+        let (_shutdown_tx, mut shutdown_rx) = watch::channel(false);
+
+        let result = persist_client_build_error(
+            &db,
+            &provider_ids,
+            "invalid app upstream proxy settings: [redacted]",
+            &mut shutdown_rx,
+        )
+        .await;
+
+        assert!(matches!(result, RefreshLoopStep::Completed(())));
+        let conn = db.open_connection().expect("reopen db");
+        for provider_id in provider_ids {
+            let error: Option<String> = conn
+                .query_row(
+                    "SELECT oauth_last_error FROM providers WHERE id = ?1",
+                    [provider_id],
+                    |row| row.get(0),
+                )
+                .expect("read oauth error");
+            assert_eq!(
+                error.as_deref(),
+                Some("invalid app upstream proxy settings: [redacted]")
+            );
+        }
+    }
 
     #[tokio::test]
     async fn wait_for_next_poll_or_shutdown_completes_after_interval() {

--- a/src-tauri/src/infra/cli_manager.rs
+++ b/src-tauri/src/infra/cli_manager.rs
@@ -774,35 +774,8 @@ pub(crate) fn codex_bundled_model_catalog_json(
     launch: &CodexLaunchSpec,
     codex_home: &Path,
 ) -> crate::shared::error::AppResult<Vec<u8>> {
-    #[cfg(windows)]
-    let mut command = {
-        let is_script = launch
-            .executable
-            .extension()
-            .and_then(|value| value.to_str())
-            .map(|value| value.eq_ignore_ascii_case("cmd") || value.eq_ignore_ascii_case("bat"))
-            .unwrap_or(false);
-        if is_script {
-            let mut command = Command::new("cmd.exe");
-            command.args(["/D", "/S", "/C"]);
-            command.arg(format!(
-                "\"{}\" debug models --bundled",
-                launch.executable.to_string_lossy().replace('"', "\\\"")
-            ));
-            command
-        } else {
-            let mut command = Command::new(&launch.executable);
-            command.args(["debug", "models", "--bundled"]);
-            command
-        }
-    };
-
-    #[cfg(not(windows))]
-    let mut command = {
-        let mut command = Command::new(&launch.executable);
-        command.args(["debug", "models", "--bundled"]);
-        command
-    };
+    let mut command = Command::new(&launch.executable);
+    command.args(["debug", "models", "--bundled"]);
 
     command
         .env("CODEX_HOME", codex_home)

--- a/src-tauri/src/infra/codex_model_catalog/protocol.rs
+++ b/src-tauri/src/infra/codex_model_catalog/protocol.rs
@@ -429,25 +429,6 @@ impl Drop for ManagedChild {
 }
 
 fn build_command(launch: &CodexLaunchSpec) -> Command {
-    #[cfg(windows)]
-    {
-        let is_script = launch
-            .executable
-            .extension()
-            .and_then(|value| value.to_str())
-            .map(|value| value.eq_ignore_ascii_case("cmd") || value.eq_ignore_ascii_case("bat"))
-            .unwrap_or(false);
-        if is_script {
-            let mut command = Command::new("cmd.exe");
-            command.args(["/D", "/S", "/C"]);
-            command.arg(format!(
-                "\"{}\" app-server --stdio",
-                launch.executable.to_string_lossy().replace('"', "\\\"")
-            ));
-            return command;
-        }
-    }
-
     let mut command = Command::new(&launch.executable);
     command.args(["app-server", "--stdio"]);
     command
@@ -637,22 +618,19 @@ impl Drop for WindowsJob {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        fetch_model_catalog, parse_model, parse_next_cursor, read_bounded_line,
-        run_protocol_with_timeout, StdoutBudget,
-    };
+    use super::{build_command, parse_model, parse_next_cursor, read_bounded_line, StdoutBudget};
+    #[cfg(unix)]
+    use super::{fetch_model_catalog, run_protocol_with_timeout};
     use crate::cli_manager::CodexLaunchSpec;
     use serde_json::json;
+    use std::ffi::{OsStr, OsString};
     use std::io::{BufReader, Cursor};
+    use std::path::PathBuf;
 
-    #[cfg(unix)]
-    use std::ffi::OsString;
     #[cfg(unix)]
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
-    #[cfg(unix)]
-    use std::path::PathBuf;
     #[cfg(unix)]
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -680,6 +658,23 @@ mod tests {
             version: Some("fixture".to_string()),
         };
         (root, home, launch)
+    }
+
+    #[test]
+    fn app_server_command_keeps_executable_and_arguments_separate() {
+        let launch = CodexLaunchSpec {
+            executable: PathBuf::from(r"C:\Program Files\Codex\codex.cmd"),
+            runtime_path: OsString::new(),
+            version: None,
+        };
+
+        let command = build_command(&launch);
+
+        assert_eq!(command.get_program(), launch.executable.as_os_str());
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            [OsStr::new("app-server"), OsStr::new("--stdio")]
+        );
     }
 
     #[test]

--- a/src/components/cli-manager/tabs/GeneralTab.tsx
+++ b/src/components/cli-manager/tabs/GeneralTab.tsx
@@ -1177,14 +1177,14 @@ function UpstreamProxySettingsForm({
         上游代理
       </h3>
       <p className="text-xs text-muted-foreground mb-3">
-        网关向上游 AI 服务（Claude/Codex/Gemini/Grok）发起请求时使用的代理，同时也会用于这些服务商的
-        OAuth 登录、令牌刷新与额度查询。支持 http/https/socks5/socks5h 协议 —— 例如本机的
-        socks5://127.0.0.1:1080。
+        网关向上游 AI 服务（Claude/Codex/Gemini/Grok）发起请求时使用的代理，也用于 app 发起的 OAuth
+        令牌交换、设备码轮询、令牌刷新与额度查询；系统浏览器中的授权页面不受此设置控制。支持
+        http/https/socks5/socks5h 协议，例如本机的 socks5://127.0.0.1:1080。
       </p>
       <div className="divide-y divide-border">
         <SettingsRow
           label="启用上游代理"
-          subtitle="启用后，所有上游请求（含 OAuth 登录/刷新）将通过指定代理发送。"
+          subtitle="启用后，网关请求与 app 发起的 OAuth 服务端请求将通过指定代理发送。"
         >
           <Switch
             checked={settings.upstream_proxy_enabled}

--- a/src/components/cli-manager/tabs/GeneralTab.tsx
+++ b/src/components/cli-manager/tabs/GeneralTab.tsx
@@ -1177,11 +1177,15 @@ function UpstreamProxySettingsForm({
         上游代理
       </h3>
       <p className="text-xs text-muted-foreground mb-3">
-        网关向上游 AI 服务（Claude/Codex/Gemini）发起请求时使用的代理。支持
-        http/https/socks5/socks5h 协议。
+        网关向上游 AI 服务（Claude/Codex/Gemini/Grok）发起请求时使用的代理，同时也会用于这些服务商的
+        OAuth 登录、令牌刷新与额度查询。支持 http/https/socks5/socks5h 协议 —— 例如本机的
+        socks5://127.0.0.1:1080。
       </p>
       <div className="divide-y divide-border">
-        <SettingsRow label="启用上游代理" subtitle="启用后，所有上游请求将通过指定代理发送。">
+        <SettingsRow
+          label="启用上游代理"
+          subtitle="启用后，所有上游请求（含 OAuth 登录/刷新）将通过指定代理发送。"
+        >
           <Switch
             checked={settings.upstream_proxy_enabled}
             onCheckedChange={handleProxyEnabledChange}

--- a/src/components/cli-manager/tabs/__tests__/GeneralTab.test.tsx
+++ b/src/components/cli-manager/tabs/__tests__/GeneralTab.test.tsx
@@ -356,6 +356,7 @@ describe("cli-manager/GeneralTab", () => {
     renderTab(<CliManagerGeneralTab {...createDefaultTabProps()} />);
 
     expect(screen.getByText("上游代理")).toBeInTheDocument();
+    expect(screen.getByText(/系统浏览器中的授权页面不受此设置控制/)).toBeInTheDocument();
 
     const proxyUrlInput = screen.getByPlaceholderText("http://127.0.0.1:7890");
     expect(proxyUrlInput).toBeInTheDocument();


### PR DESCRIPTION
## Summary

「设置 -> 上游代理」此前只覆盖 Gateway 登录后的上游 API 请求。OAuth 登录、设备码、令牌刷新、额度查询与 Codex 额度重置各自构建 HTTP client，只识别 `AIO_OAUTH_PROXY_URL` 或系统代理，因此用户即使在 app 中配置了代理，登录阶段仍可能失败。

本 PR 让这些 app 发起的 OAuth 服务端请求复用同一份上游代理配置，同时保留专用环境变量覆盖和系统代理兼容行为。

## Final behavior

代理优先级统一为：

1. 非空 `AIO_OAUTH_PROXY_URL`
2. app 的「上游代理」设置
3. reqwest 自动读取的系统代理或直连

- 空白 `AIO_OAUTH_PROXY_URL` 视为未设置，不会遮蔽 app 配置。
- app 代理已启用但设置无法读取、URL/凭据无效或指向当前 Gateway 时，OAuth client 构建失败，不会静默回退到系统代理或直连。
- 未启用 app 代理时保持原有系统代理/直连行为；系统代理指回 Gateway 时复用现有 `no_proxy()` 自环保护。
- 显式 `AIO_OAUTH_PROXY_URL` 继续作为高级覆盖，不改变其既有语义。
- HTTP/HTTPS/SOCKS5/SOCKS5H、独立凭据拼装与 SOCKS5 本地 DNS IPv4-first 行为复用 Gateway 现有 helper。
- 登录、设备码请求/轮询、手动刷新、额度查询、Codex 额度重置和后台刷新统一走 app-aware OAuth client builder。
- 后台刷新仅在本轮存在待刷新 provider 时构建一个 client，并在本轮复用；不保留跨轮询 cache。构建失败会为本轮 provider 写入脱敏的 `oauth_last_error`，下一轮继续重试。

## Scope

- 无 IPC、schema、generated bindings、依赖或数据迁移变化。
- 不影响系统浏览器中的授权页面；该页面仍遵循系统浏览器自身的网络设置。
- 不扩展到插件下载、更新检查、模型价格同步或其他非 OAuth 出站流量。
- 前端仅校正上游代理的范围说明，不新增状态或交互。

## Tests

- [x] 真实本地 HTTP recording proxy 验证 OAuth 请求确实经过 app 配置的代理
- [x] 覆盖 env/app/system 优先级、blank env、fail-closed、自环保护与凭据脱敏
- [x] 覆盖后台 client 构建失败后的 provider 错误持久化和下轮重试能力
- [x] OAuth tests: 39 passed
- [x] HTTP client tests: 28 passed
- [x] provider command tests: 25 passed
- [x] `settings_crud`: 20 passed
- [x] Frontend unit tests: 292 files / 2465 tests
- [x] Frontend coverage gate: 91.16% statements / 93.54% lines
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] Rust fmt
- [x] Rust clippy
- [x] Full Rust tests: 2053 passed / 0 failed / 3 ignored, plus integration tests
- [ ] GitHub Actions final result: `codex-catalog-platform (windows, windows-latest, 1)` is blocked by `0xc0000139 (STATUS_ENTRYPOINT_NOT_FOUND)` before the test harness starts. The failed job was retried once with the same result; current `main` (`d0f85364`) fails the same newly added job with the same loader error.

## Acceptance

- App 代理启用时，所有 app 发起的 OAuth 服务端请求必须使用该代理，除非非空 `AIO_OAUTH_PROXY_URL` 显式覆盖。
- App 代理配置错误必须可见且 fail-closed，错误不得包含用户名、密码或带凭据的完整 URL。
- App 代理未启用时，OAuth 的系统代理/直连兼容行为不变，且不得因系统代理指回 Gateway 形成递归。
- 后台刷新配置错误不得终止 refresh loop；修复配置后下一轮可以恢复。
- PR 与最新 `main` 可合并，所有必需 CI 检查通过。

Current CI note: GitHub reports the PR as mergeable. Frontend, Rust, macOS catalog, and all support-contract jobs pass; the Windows catalog job remains red because of the inherited `main` runner/loader failure described above, not an OAuth assertion or source compilation failure.
