### PR TITLE
fix: 修复Windows生图预览被CSP拦截(UI误报文件缺失)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost data: blob:; font-src 'self' data:; media-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* https://github.com https://api.github.com https://objects.githubusercontent.com; frame-src 'none'",
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost https://asset.localhost data: blob:; font-src 'self' data:; media-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* https://github.com https://api.github.com https://objects.githubusercontent.com; frame-src 'none'",
       "assetProtocol": {
         "enable": true
       }

--- a/src/services/desktop/__tests__/assetUrl.test.ts
+++ b/src/services/desktop/__tests__/assetUrl.test.ts
@@ -11,12 +11,16 @@ function cspDirectiveSources(csp: string, name: string): string[] {
   return directive.split(/\s+/).slice(1);
 }
 
-describe("services/desktop/assetUrl", () => {
-  it("allows Tauri asset protocol origins in the image CSP", () => {
+describe("Tauri asset URL CSP contract", () => {
+  it("allows every asset origin emitted by convertFileSrc", () => {
     const sources = cspDirectiveSources(tauriConfig.app.security.csp, "img-src");
+    const windowsAssetOrigins = tauriConfig.app.windows.map((window) => {
+      const scheme =
+        "useHttpsScheme" in window && window.useHttpsScheme === true ? "https" : "http";
+      return `${scheme}://asset.localhost`;
+    });
 
     expect(sources).toContain("asset:");
-    // Tauri maps custom protocols to http://<scheme>.localhost on Windows by default.
-    expect(sources).toContain("http://asset.localhost");
+    expect(sources).toEqual(expect.arrayContaining(windowsAssetOrigins));
   });
 });

--- a/src/services/desktop/__tests__/assetUrl.test.ts
+++ b/src/services/desktop/__tests__/assetUrl.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import tauriConfig from "../../../../src-tauri/tauri.conf.json";
+
+function cspDirectiveSources(csp: string, name: string): string[] {
+  const directive = csp
+    .split(";")
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith(`${name} `));
+
+  if (!directive) throw new Error(`CSP should define ${name}`);
+  return directive.split(/\s+/).slice(1);
+}
+
+describe("services/desktop/assetUrl", () => {
+  it("allows Tauri asset protocol origins in the image CSP", () => {
+    const sources = cspDirectiveSources(tauriConfig.app.security.csp, "img-src");
+
+    expect(sources).toContain("asset:");
+    // Tauri maps custom protocols to http://<scheme>.localhost on Windows by default.
+    expect(sources).toContain("http://asset.localhost");
+  });
+});


### PR DESCRIPTION
## 问题与根因

Tauri 2 的 convertFileSrc 在 Windows 默认使用 http://asset.localhost，而 macOS 与 Linux 使用 asset://localhost。原 CSP 只允许 asset: 和 https://asset.localhost，因此 Windows WebView2 会拦截已落盘图片，界面随后误报图片缺失。

本 PR 仅补齐 Windows 默认 asset origin，并用配置契约测试约束窗口协议配置与 CSP 必须同步。

## 需求边界

- 保留现有 convertFileSrc 调用链，不在 image-gen 业务代码中拼接平台 URL。
- 不新增 OS 条件分支，不改变任务持久化、IPC 或渲染状态机。
- 不扩大 connect-src。
- 不扩大 Rust asset filesystem scope；磁盘路径授权仍由 runtime asset scope 管理。
- 测试是 tauri.conf.json 的静态配置契约，不宣称覆盖真实 WebView2 运行时。

## 三端兼容

| 平台 | convertFileSrc origin | CSP 要求 |
| --- | --- | --- |
| macOS | asset://localhost | img-src 包含 asset: |
| Linux | asset://localhost | img-src 包含 asset: |
| Windows，useHttpsScheme 缺省或 false | http://asset.localhost | img-src 包含 http://asset.localhost |
| Windows，useHttpsScheme 为 true | https://asset.localhost | img-src 包含 https://asset.localhost |

测试会遍历每个窗口，并从 useHttpsScheme 推导 Windows 所需 origin，避免未来新增窗口或切换 scheme 时产生静默配置分叉。

## 验收

- [x] Windows 默认 asset origin 已加入 img-src。
- [x] macOS 与 Linux 的 asset: source 继续受测试保护。
- [x] useHttpsScheme 与 CSP 不同步时契约测试失败。
- [x] 未新增生产代码平台分支，未扩大 connect-src 或 filesystem scope。
- [x] 精确契约测试通过：1/1。
- [x] image-gen 回归通过：208/208。
- [x] 全量 Vitest 通过：293 files，2466/2466 tests；Statements 91.16%，Branches 85.23%。
- [x] pnpm lint、pnpm typecheck、pnpm build 通过。
- [x] pnpm check:prepush 全部 15 项通过，Rust lib 2044 passed / 0 failed / 3 ignored。
- [x] 当前提交的 GitHub CI 通过。

## Windows 手工证据

贡献者使用同一本地数据库完成修复前后对比。

修复前：

<img width="1988" height="1280" alt="Windows 修复前：图片被 CSP 拦截" src="https://github.com/user-attachments/assets/03b70f6c-deeb-4d40-8e88-ffb2852dc726" />

修复后：

<img width="2020" height="1349" alt="Windows 修复后：图片正常预览" src="https://github.com/user-attachments/assets/bed313a3-3eb4-4e32-b3ba-cf30ebeaa0e1" />